### PR TITLE
Fixed the issue #80 of install dependency while installing this app

### DIFF
--- a/frappe_theme/package.json
+++ b/frappe_theme/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "pinia": "^3.0.2",
     "vue": "^3.5.13",
+    "chart.js": "^4.1.1",
     "vue-chartjs": "^5.3.2",
     "vue-router": "^4.5.0"
   }


### PR DESCRIPTION
# ✅ Fix: Add Missing `chart.js` Dependency Required by `vue-chartjs`

## Summary

This PR resolves a build failure caused by a missing `chart.js` dependency. The `vue-chartjs` package used in the app declares `chart.js` as a **peer dependency**, which is not automatically installed. This leads to build errors during `esbuild` when running `bench build`.

---

## 🛠️ Changes Made

- Added `chart.js@^4.1.1` to `dependencies` in `package.json`.
- Removed `package-lock.json` to prevent conflicts with Yarn.
- Updated `yarn.lock` after running `yarn install`.

---

## 🧪 How to Test

1. Clone the app using:

   ```bash
   bench get-app git@github.com:Suvaidyam/frappe_theme.git --branch development --resolve-deps
   ```

2. Run the build:

   ```bash
   bench build --app frappe_theme
   ```

3. The build should complete successfully without any missing module errors.

---

## 📌 Related Issue

This PR **resolves** the issue: _"Build fails due to missing chart.js dependency"_  
See PR: **#80**

---

## ✅ Checklist

- [x] Added required dependency
- [x] Confirmed `yarn install` succeeds
- [x] Confirmed `bench build` succeeds
- [x] No breaking changes introduced

---

Let me know if any additional testing, changes, or version locking is required.
