### PR TITLE
Apply a link filter for the Group Title in sva task planner

### DIFF
--- a/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.js
+++ b/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.js
@@ -1,14 +1,22 @@
 // Copyright (c) 2025, Suvaidyam and contributors
 // For license information, please see license.txt
-monthly_dates = [
-    "",
-    "Start of the month",
-    "End of the month",
-    1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-    11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-    21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
-]
-Quarterly_dates = ["", "Start of the month", "End of the month"]
+function setDayOptions(frm) {
+    monthly_dates = [
+        "",
+        "Start of the month",
+        "End of the month",
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+    ]
+    Quarterly_dates = ["", "Start of the month", "End of the month"]
+
+    if (frm.doc.frequency === "Quarterly") {
+        frm.set_df_property("day", "options", Quarterly_dates);
+    } else {
+        frm.set_df_property("day", "options", monthly_dates);
+    }
+}
 
 frappe.ui.form.on("SVA Task Planner", {
     refresh(frm) {
@@ -19,10 +27,3 @@ frappe.ui.form.on("SVA Task Planner", {
     }
 });
 
-function setDayOptions(frm) {
-    if (frm.doc.frequency === "Quarterly") {
-        frm.set_df_property("day", "options", Quarterly_dates);
-    } else {
-        frm.set_df_property("day", "options", monthly_dates);
-    }
-}

--- a/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.js
+++ b/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.js
@@ -16,10 +16,10 @@ function setDayOptions(frm) {
         11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
         21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
     ]
-    Quarterly_dates = ["", "Start of the month", "End of the month"]
+    quarterly_dates = ["", "Start of the month", "End of the month"]
 
     if (frm.doc.frequency === "Quarterly") {
-        frm.set_df_property("day", "options", Quarterly_dates);
+        frm.set_df_property("day", "options", quarterly_dates);
     } else {
         frm.set_df_property("day", "options", monthly_dates);
     }

--- a/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.js
+++ b/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.js
@@ -1,6 +1,13 @@
 // Copyright (c) 2025, Suvaidyam and contributors
 // For license information, please see license.txt
 function setDayOptions(frm) {
+    frm.set_query("parent_task_name", function () {
+        return {
+            filters: {
+                "is_group": 1
+            }
+        };
+    });
     monthly_dates = [
         "",
         "Start of the month",

--- a/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.json
+++ b/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.json
@@ -35,7 +35,7 @@
    "fieldname": "parent_task_name",
    "fieldtype": "Link",
    "label": "Parent Task Name",
-   "link_filters": "[[\"SVA Task Planner\",\"is_group\",\"=\",1]]",
+   "link_filters": "[]",
    "mandatory_depends_on": "eval:!doc.is_group",
    "options": "SVA Task Planner"
   },
@@ -82,7 +82,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-28 13:01:44.804698",
+ "modified": "2025-07-28 18:51:16.219034",
  "modified_by": "Administrator",
  "module": "Frappe Theme",
  "name": "SVA Task Planner",

--- a/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.json
+++ b/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.json
@@ -32,6 +32,7 @@
    "fieldname": "parent_task_name",
    "fieldtype": "Link",
    "label": "Parent Task Name",
+   "link_filters": "[[\"SVA Task Planner\",\"is_group\",\"=\",1]]",
    "mandatory_depends_on": "eval:!doc.is_group",
    "options": "SVA Task Planner"
   },
@@ -60,7 +61,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-28 10:20:22.194493",
+ "modified": "2025-07-28 11:32:36.632170",
  "modified_by": "Administrator",
  "module": "Frappe Theme",
  "name": "SVA Task Planner",

--- a/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.json
+++ b/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.json
@@ -11,7 +11,9 @@
   "parent_task_name",
   "frequency",
   "month",
-  "day"
+  "day",
+  "reference_doctype",
+  "reference_doc"
  ],
  "fields": [
   {
@@ -57,11 +59,25 @@
    "label": "Month",
    "mandatory_depends_on": "eval:[\"Annually\",\"Biannually\"].includes(doc.frequency)",
    "options": "\nJanuary\nFebruary\nMarch\nApril\nMay\nJune\nJuly\nAugust\nSeptember\nOctober\nNovember\nDecember"
+  },
+  {
+   "fieldname": "reference_doctype",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "reference_doctype",
+   "options": "DocType"
+  },
+  {
+   "fieldname": "reference_doc",
+   "fieldtype": "Dynamic Link",
+   "hidden": 1,
+   "label": "reference_doc",
+   "options": "reference_doctype"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-28 11:32:36.632170",
+ "modified": "2025-07-28 12:46:53.007483",
  "modified_by": "Administrator",
  "module": "Frappe Theme",
  "name": "SVA Task Planner",

--- a/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.json
+++ b/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.json
@@ -9,10 +9,11 @@
   "task_name",
   "is_group",
   "parent_task_name",
+  "reference_doctype",
+  "column_break_pfce",
   "frequency",
   "month",
   "day",
-  "reference_doctype",
   "reference_doc"
  ],
  "fields": [
@@ -73,11 +74,15 @@
    "hidden": 1,
    "label": "reference_doc",
    "options": "reference_doctype"
+  },
+  {
+   "fieldname": "column_break_pfce",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-28 12:46:53.007483",
+ "modified": "2025-07-28 13:01:44.804698",
  "modified_by": "Administrator",
  "module": "Frappe Theme",
  "name": "SVA Task Planner",


### PR DESCRIPTION
## 🔧 Enhance SVA Task Planner with Reference Fields and Default Filter

### Summary

- Adding support for filtering by task group (default filter applied).
- Introducing two new fields to support dynamic linkage to other doctypes for integration via **SVADatatable**.

---

### ✅ Features Added

#### 🆕 New Fields in **SVA Task Planner**:
- `reference_doctype` *(Link)*:  
  Used to specify the target Doctype where the `SVA Task Planner` will be applied through `SVADatatable`.

- `reference_doc` *(Dynamic Link)*:  
  Dynamically fetches and links the document name of the selected `reference_doctype`.

---

### 🔍 UI Improvements

- **Default Filter Applied**:
  - The list view of `SVA Task Planner` now shows only **Group Tasks** (`is_group = 1`) by default.
  - Helps users focus on task categories and avoid clutter from individual leaf tasks.

---

### 🧩 Use Case

This enhancement supports modular and dynamic configuration of `SVA Task Planner` across various doctypes such as **GAF**, **Grant**, and more. It enables:
- Linking tasks to specific programmatic or organizational contexts.
- More contextual and reusable task planning using `SVADatatable`.

---

### 📸 Screenshot

![Default Group Filter in List View](https://github.com/user-attachments/assets/7fd0a4f3-174c-4403-9df1-d273c3b08163)

---

Let me know if you'd like to include technical field definitions or field permission info as well.
