### PR TITLE
Remove Month Field and Update Option to "Yearly" in Frequency Selection

### DIFF
--- a/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.js
+++ b/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.js
@@ -22,11 +22,7 @@ function set_day_options(frm) {
             "Start of the year", "End of the year"
         ],
         "Bi-Annually": [
-        "Yearly": [
-            "Start of the year", "End of the year"
-        ],
-        "Bi-Yearly": [
-            "Start of the Bi-Yearly Period", "End of the Bi-Yearly Period"
+            "Start of the Bi-Annually Period", "End of the Bi-Annually Period"
         ]
     };
 

--- a/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.js
+++ b/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.js
@@ -4,19 +4,25 @@
 function set_day_options(frm) {
     const day_options_by_frequency = {
         "Monthly": [
-            "", "Start of the month", "End of the month",
+            "Start of the month", "End of the month",
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
             11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
             21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
         ],
         "Quarterly": [
-            "", "Start of the month", "End of the month"
+            "Start of the month", "End of the month"
         ],
         "Weekly": [
-            "", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"
+            "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"
         ],
         "Fortnightly": [
-            "", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+        ],
+        "Annually": [
+            "Start of the year", "End of the year"
+        ],
+        "Bi-Annually": [
+            "Start of the Bi-Annually Period", "End of the Bi-Annually Period"
         ]
     };
 

--- a/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.js
+++ b/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.js
@@ -22,7 +22,11 @@ function set_day_options(frm) {
             "Start of the year", "End of the year"
         ],
         "Bi-Annually": [
-            "Start of the Bi-Annually Period", "End of the Bi-Annually Period"
+        "Yearly": [
+            "Start of the year", "End of the year"
+        ],
+        "Bi-Yearly": [
+            "Start of the Bi-Yearly Period", "End of the Bi-Yearly Period"
         ]
     };
 

--- a/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.json
+++ b/frappe_theme/frappe_theme/doctype/sva_task_planner/sva_task_planner.json
@@ -12,7 +12,6 @@
   "reference_doctype",
   "column_break_pfce",
   "frequency",
-  "month",
   "day",
   "reference_doc"
  ],
@@ -53,14 +52,6 @@
    "label": "Day"
   },
   {
-   "depends_on": "eval:[\"Annually\",\"Bi-Annually\"].includes(doc.frequency)",
-   "fieldname": "month",
-   "fieldtype": "Select",
-   "label": "Month",
-   "mandatory_depends_on": "eval:[\"Annually\",\"Biannually\"].includes(doc.frequency)",
-   "options": "\nJanuary\nFebruary\nMarch\nApril\nMay\nJune\nJuly\nAugust\nSeptember\nOctober\nNovember\nDecember"
-  },
-  {
    "fieldname": "reference_doctype",
    "fieldtype": "Link",
    "hidden": 1,
@@ -81,7 +72,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-31 10:12:43.477742",
+ "modified": "2025-08-01 12:08:52.280191",
  "modified_by": "Administrator",
  "module": "Frappe Theme",
  "name": "SVA Task Planner",


### PR DESCRIPTION
## 🔧 Fix: Update Frequency to Yearly & Remove Months Field

### Changes:
- Changed frequency option to **"Annually"**
- Removed unused `months` field from the form/model
- Fixed invalid f-string bug in `project_proposal.py`

### Impact:
- Simplifies form for Annually proposals
- Prevents syntax error during proposal regeneration

### Tested:
- ✅ Proposal regeneration with "Annually" frequency
- ✅ UI no longer shows `months` field
