### PR TITLE
feat: Conditional freezing of Workflow in datatable

### DIFF
--- a/frappe_theme/frappe_theme/doctype/svadatatable_child_conf/svadatatable_child_conf.json
+++ b/frappe_theme/frappe_theme/doctype/svadatatable_child_conf/svadatatable_child_conf.json
@@ -20,6 +20,7 @@
   "disable_add_depends_on",
   "disable_edit_depends_on",
   "disable_delete_depends_on",
+  "disable_workflow_depends_on",
   "redirect_to_main_form",
   "keep_workflow_enabled_form_submission",
   "full_screen_dialog",
@@ -144,13 +145,20 @@
    "label": "Disable Add Depends On (JS)",
    "max_height": "3rem",
    "options": "JS"
+  },
+  {
+   "fieldname": "disable_workflow_depends_on",
+   "fieldtype": "Code",
+   "label": "Disable Workflow Depends On (JS)",
+   "max_height": "3rem",
+   "options": "JS"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-24 10:57:39.138268",
+ "modified": "2025-10-29 12:16:06.719796",
  "modified_by": "Administrator",
  "module": "Frappe Theme",
  "name": "SVADatatable Child Conf",

--- a/frappe_theme/frappe_theme/doctype/svadatatable_configuration_child/svadatatable_configuration_child.json
+++ b/frappe_theme/frappe_theme/doctype/svadatatable_configuration_child/svadatatable_configuration_child.json
@@ -47,6 +47,7 @@
   "disable_edit_depends_on",
   "column_break_zjxl",
   "disable_delete_depends_on",
+  "disable_workflow_depends_on",
   "section_break_gyve",
   "redirect_to_main_form",
   "keep_workflow_enabled_form_submission",
@@ -387,13 +388,21 @@
    "label": "Disable Add Depends On (JS)",
    "max_height": "3rem",
    "options": "JS"
+  },
+  {
+   "depends_on": "eval:![\"Report\"].includes(doc.connection_type)",
+   "fieldname": "disable_workflow_depends_on",
+   "fieldtype": "Code",
+   "label": "Disable Workflow Depends On (JS)",
+   "max_height": "3rem",
+   "options": "JS"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-24 10:56:14.232508",
+ "modified": "2025-10-29 12:15:40.732908",
  "modified_by": "Administrator",
  "module": "Frappe Theme",
  "name": "SVADatatable Configuration Child",

--- a/frappe_theme/public/js/datatable/sva_datatable.bundle.js
+++ b/frappe_theme/public/js/datatable/sva_datatable.bundle.js
@@ -2359,7 +2359,7 @@ class SvaDataTable {
 								method: "frappe.model.workflow.get_transitions",
 								doc: { ...row, doctype: this.doctype },
 							});
-							el.disabled = el.disabled || transitions.length === 0;
+							el.disabled = el.disabled || transitions.length === 0 || (this.connection?.disable_workflow_depends_on ? frappe.utils.custom_eval(this.connection?.disable_workflow_depends_on, row) : false);
 							// const titleText = transitions
 							// 	.map((e) => `&#x2022; ${e.action} by ${e.allowed}`)
 							// 	.join("<br>");


### PR DESCRIPTION
This pull request adds a new field to both the `SVADatatable Child Conf` and `SVADatatable Configuration Child` doctypes to allow for workflow-specific dependency logic using JavaScript. The main changes are the introduction of the `disable_workflow_depends_on` field and its configuration.

**New workflow dependency logic:**

* Added the `disable_workflow_depends_on` field to the `fields` array in both `svadatatable_child_conf.json` and `svadatatable_configuration_child.json`, allowing custom JS logic to control workflow-related behaviors. [[1]](diffhunk://#diff-f2664bc40391f7db8ea3e107587271b54f157b8fb893bc736117f3c07ea9d724R23) [[2]](diffhunk://#diff-cac91179f541fabf9449e98719fb61a1af8d9ba9db717c77d93676e5f3f9e775R50)
* Configured the new field as a `Code` field type with JS options and a label in both doctypes, enabling developers to specify JavaScript for workflow dependency checks. [[1]](diffhunk://#diff-f2664bc40391f7db8ea3e107587271b54f157b8fb893bc736117f3c07ea9d724R148-R161) [[2]](diffhunk://#diff-cac91179f541fabf9449e98719fb61a1af8d9ba9db717c77d93676e5f3f9e775R391-R405)
* In `svadatatable_configuration_child.json`, added a `depends_on` condition to the new field so it only appears when `connection_type` is not "Report".