### PR TITLE
Fix limit

### DIFF
--- a/frappe_theme/public/js/datatable/mixins/rendering.js
+++ b/frappe_theme/public/js/datatable/mixins/rendering.js
@@ -486,7 +486,7 @@ const RenderingMixin = {
 		const tbody = document.createElement("tbody");
 		this.tBody = tbody;
 		let rowIndex = 0;
-		const batchSize = this.options?.pageLimit || 30;
+		const batchSize = this.limit || this.options?.pageLimit || 30;
 		tbody.style.whiteSpace = "nowrap";
 
 		if (this.currentSort) {


### PR DESCRIPTION
This pull request makes a small improvement to the batching logic in the `RenderingMixin` by prioritizing the use of a local `limit` property when determining the batch size for rendering table rows.

- Improved batch size selection:
  * In `frappe_theme/public/js/datatable/mixins/rendering.js`, the batching logic now uses `this.limit` if available, falling back to `this.options?.pageLimit` or `30` as defaults.