### PR TITLE
Implement embedded form feature

### DIFF
--- a/.claude/skills/embedded-form/SKILL.md
+++ b/.claude/skills/embedded-form/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: embedded-form
+description: Embedded DocType Form Renderer — renders a complete DocType form inline inside an HTML field of a parent form (not a modal dialog). Use when working on the embedded_form.bundle.js standalone API, the EmbeddedFormMixin, tab rendering, composite proxy, or set_only_once handling.
+---
+
+# Embedded DocType Form Renderer
+
+Renders a linked DocType's complete form inline inside a DOM wrapper instead of a modal dialog. Reuses all existing `dt_events` hooks with identical signatures — event handlers work in both rendering modes without changes.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `frappe_theme/public/js/datatable/mixins/embedded_form.js` | `EmbeddedFormMixin` — mixed into `SvaDataTable.prototype` |
+| `frappe_theme/public/js/embedded_form.bundle.js` | Standalone global API for use in Client Scripts |
+| `frappe_theme/public/js/datatable/mixins/form_dialog.js` | Parallel dialog path — changes here usually need mirroring |
+| `frappe_theme/hooks.py` | `embedded_form.bundle.js` registered in `app_include_js` |
+| `frappe_theme/dt_api.py` | `get_meta_fields(include_tabs=False)` — pass `include_tabs=True` to get Tab Breaks |
+| `frappe_theme/controllers/dt_conf.py` | `get_meta_fields` implementation — filters out `Tab Break` unless `include_tabs` is set |
+
+## Standalone API
+
+```javascript
+// In a Frappe Client Script
+await frappe_theme.embedded_form.render({
+    parent_frm: frm,
+    target_doctype: "Employee",
+    target_docname: frm.doc.employee,  // null for create mode
+    html_field: "details_html",        // HTML fieldname on the parent DocType
+    mode: "write",                     // "create" | "write" | "view"  (default: "write")
+});
+```
+
+### Storage on `parent_frm` (all keyed by DocType name)
+
+```javascript
+frm.sva_dt_frm["Employee"]        // comprehensive frm-compatible object (doc, meta, fields_dict, set_value, ScriptManager, …)
+frm.embedded_form["Employee"]     // dialog-compatible proxy (get_value, set_value, fields_dict, get_values)
+frm.embedded_frm["Employee"]      // alias → sva_dt_frm["Employee"]
+frm.embedded_controls["Employee"] // fg.fields_dict (direct field control access)
+```
+
+Multiple DocTypes can be embedded simultaneously in different HTML fields of the same parent form.
+
+### `frm.sva_dt_frm[doctype]` interface
+
+Comprehensive frm-compatible stub for Client Script lifecycle:
+
+```javascript
+{
+    doctype, docname, doc,
+    meta: frappe.get_meta(doctype),
+    perm: frappe.perm.get_perm(doctype),
+    fields_dict,         // from FieldGroup
+    fields_list,
+    set_value, get_value, get_field,
+    refresh_field, refresh_fields,
+    set_df_property,
+    toggle_display, toggle_enable, toggle_reqd,
+    is_new: () => !doc.name,
+    dirty: () => {},
+    events: {}, cscript: {},
+    page: { set_title, add_inner_button, set_primary_action, … },
+    toolbar: { current_status, refresh },
+    dashboard: { refresh, add_section, … },
+    layout: fg,          // FieldGroup extends Layout — fully compatible
+    call, has_perm, save,
+    trigger,             // fires dt_events then script_manager.trigger
+    script_manager,      // real frappe.ui.form.ScriptManager instance
+    add_custom_button, set_intro,
+}
+```
+
+## EmbeddedFormMixin Methods
+
+| Method | Signature | Notes |
+|--------|-----------|-------|
+| `showEmbeddedFormPanel` | `(doctype, name, mode)` | Opens/resets panel below the table. Wires close button + `onAfterSave → reloadTable()` |
+| `createEmbeddedForm` | `(doctype, name, wrapper_el, mode, onAfterSave)` | Core renderer. Returns dialog-compatible proxy (also sets `this.form_dialog`) |
+| `_openForm` | `(doctype, name, mode)` | Router: checks `use_embedded_form` flag, dispatches to panel or dialog |
+| `_prepareEmbeddedFieldsWriteMode` | `(doctype, name, doc, fields, mode, fg_holder)` | Mirrors `createFormDialog` field prep. Binds `onchange`/`click` from `dt_events`, handles Tables, Links, Attach, `set_only_once` |
+| `_prepareEmbeddedFieldsViewMode` | `(doctype, name, doc, fields, mode)` | All fields `read_only: 1` |
+| `_renderEmbeddedFormFooter` | `(wrapper_el, doctype, name, mode, form_proxy, fg, onAfterSave)` | Renders Save / Cancel buttons |
+| `_saveEmbeddedForm` | `(doctype, name, mode, form_proxy, fg, onAfterSave)` | `validate` → insert/set_value → after_insert/after_update/after_save |
+| `_splitFieldsByTabs` | `(fields)` | Splits field list into `{ tabGroups, hasTabs }` at Tab Break boundaries |
+| `_renderEmbeddedTabs` | `(wrapper_el, tabGroups, allFgs, allFieldsDict)` | Bootstrap tab nav + per-tab FieldGroups. Active tab = first non-empty group (`renderedCount === 0`, not `i === 0`) |
+| `_buildCompositeProxy` | `(allFgs, allFieldsDict, wrapper_el)` | Aggregates `fields_dict`, `get_value`, `set_value`, `get_values`, `fields_list` across all tab FieldGroups |
+
+## Tab Rendering
+
+Fields are fetched with `include_tabs: 1` so Tab Break fields come back from the backend. `_splitFieldsByTabs` groups fields into `{ label, fields }` buckets at each Tab Break boundary.
+
+**Critical detail:** Frappe DocTypes often start with a Tab Break, creating an empty placeholder group at index 0. The active tab is tracked with `renderedCount` (number of groups actually rendered), not array index `i`. First rendered group → `renderedCount === 0` → active.
+
+## `set_only_once` — Two-Part Fix (applies to both dialog and embedded paths)
+
+1. **UI layer** — in `_prepareEmbeddedFieldsWriteMode`, when `mode === "write"`:
+   ```javascript
+   if (f.set_only_once) {
+       if (mode === "write") {
+           f.read_only = 1;          // locked unconditionally in edit mode
+       } else if (doc[f.fieldname]) {
+           f.default = doc[f.fieldname];
+           f.read_only = 1;
+       } else {
+           f.reqd = 0; f.hidden = 1;
+       }
+   }
+   ```
+
+2. **Save payload** — in `_saveEmbeddedForm`, exclude from `fields_to_update`:
+   ```javascript
+   fg.fields_list.filter(f =>
+       !["Section Break", "Column Break", "HTML", "Button", "Tab Break"].includes(f.df.fieldtype)
+       && !f.df.set_only_once    // ← must be present
+   )
+   ```
+   Missing this causes Frappe to throw _"Value cannot be changed for \<field label\>"_.
+
+## `dt_events` Compatibility
+
+All hooks fire with identical signatures in both rendering paths:
+
+| Hook | Signature |
+|------|-----------|
+| `customize_form_fields` | `(dt, fields, mode, has_additional_action, name)` |
+| `[fieldname]` (onchange) | `(dt, mode, field, name)` |
+| `after_render` | `(dt, mode, has_additional_action, name)` — `dt.form_dialog` is composite proxy |
+| `validate` | `(dt, mode, values, has_additional_action)` |
+| `after_insert` | `(dt, response_doc)` |
+| `after_update` | `(dt, response_doc)` |
+| `after_save` | `(dt, mode, values)` |
+
+## `fg_holder` Pattern
+
+Link field `get_query` closures need to call `fg.get_value(sibling_field)`, but the FieldGroup doesn't exist yet when the closure is defined. Solution: a mutable reference object set after construction.
+
+```javascript
+const fg_holder = { instance: null };
+// ... passed into field prep, closures capture fg_holder ...
+// After FieldGroup is created:
+fg_holder.instance = form_proxy;  // composite proxy, so cross-tab sibling lookups work
+```
+
+## Activation (SvaDataTable)
+
+Set `use_embedded_form: true` on the connection or options:
+
+```javascript
+// In SVADatatable Configuration connection settings
+{ use_embedded_form: true }
+
+// Or in SvaDataTable constructor options
+new SvaDataTable({ ..., options: { use_embedded_form: true } });
+```
+
+This routes all three action types — Create (Add Row), Edit, and View — through `_openForm` → `showEmbeddedFormPanel`.
+
+## Parallel Paths Rule
+
+`form_dialog.js` and `embedded_form.js` are parallel. **Always edit both** when changing:
+- Field preparation logic (e.g., new field type handling, `set_only_once`)
+- Save payload filtering
+- `dt_events` hook execution order or arguments

--- a/.claude/skills/sva-datatable/SKILL.md
+++ b/.claude/skills/sva-datatable/SKILL.md
@@ -17,6 +17,7 @@ frappe_theme/public/js/datatable/
 │   ├── fields.js                    ← Cell rendering: getCellStyle, createEditableField, createNonEditableField, bindColumnEvents, percentageCell
 │   ├── action_column.js             ← Row actions: createActionColumn, checkCondition
 │   ├── form_dialog.js               ← CRUD dialogs: createFormDialog, deleteRecord, childTableDialog
+│   ├── embedded_form.js             ← Inline form rendering (alternative to modal): showEmbeddedFormPanel, createEmbeddedForm, _openForm, _prepareEmbeddedFieldsWriteMode, _prepareEmbeddedFieldsViewMode, _renderEmbeddedFormFooter, _saveEmbeddedForm, _splitFieldsByTabs, _renderEmbeddedTabs, _buildCompositeProxy
 │   ├── workflow.js                  ← Workflow transitions: wf_action
 │   ├── pagination.js                ← Page controls: setupPagination, updatePageButtons
 │   ├── ui_setup.js                  ← Chrome: setupHeader, setupFooter, setupWrapper, setupTableWrapper, setupListviewSettings, createSettingsButton, add_custom_button
@@ -27,6 +28,84 @@ frappe_theme/public/js/datatable/
 ├── list_settings.bundle.js          (standalone)
 └── filters/                         (standalone)
 ```
+
+There is also a **standalone embedded form bundle** for use outside of SvaDataTable:
+
+```
+frappe_theme/public/js/embedded_form.bundle.js
+→ exposes frappe_theme.embedded_form.render({ parent_frm, target_doctype, target_docname, html_field, mode })
+```
+
+## Dual Form Rendering Paths
+
+SvaDataTable has two parallel paths for Create / Edit / View forms. They share identical `dt_events` hook signatures — handlers work in both without changes.
+
+| Path | Entry point | When used |
+|------|-------------|-----------|
+| Modal dialog | `createFormDialog(doctype, name, mode)` | Default |
+| Inline panel | `showEmbeddedFormPanel(doctype, name, mode)` | `use_embedded_form: true` |
+
+### Routing via `_openForm`
+
+All four action triggers (Add Row, View, Edit × 2 workflow branches) go through a single router:
+
+```javascript
+_openForm(doctype, name, mode) {
+    if (this.connection?.use_embedded_form || this.options?.use_embedded_form) {
+        return this.showEmbeddedFormPanel(doctype, name, mode);
+    }
+    return this.createFormDialog(doctype, name, mode);
+}
+```
+
+**Never call `createFormDialog` directly** from `action_column.js` or `ui_setup.js` — always call `_openForm` so the flag is respected.
+
+### Enabling embedded mode
+
+Set `use_embedded_form: true` on the connection config in SVADatatable Configuration, or pass it via the `options` object:
+
+```javascript
+new SvaDataTable({ ..., options: { use_embedded_form: true } });
+```
+
+### Embedded form — key methods
+
+| Method | Purpose |
+|--------|---------|
+| `showEmbeddedFormPanel(doctype, name, mode)` | Creates/resets the panel below the table, wires up close button and `onAfterSave → reloadTable()` |
+| `createEmbeddedForm(doctype, name, wrapper_el, mode, onAfterSave)` | Fetches fields with `include_tabs:1`, runs dt_events hooks, prepares fields, splits at Tab Break boundaries, renders Bootstrap tabs + per-tab FieldGroups, builds composite proxy |
+| `_openForm(doctype, name, mode)` | Router: checks flag, dispatches to panel or dialog |
+| `_buildCompositeProxy(allFgs, allFieldsDict, wrapper_el)` | Aggregates `fields_dict`, `get_value`, `set_value`, `get_values`, `fields_list` across all tab FieldGroups. Stored as `this.form_dialog` so `dt_events.after_render` hooks can call `dt.form_dialog.set_value()` |
+| `_saveEmbeddedForm(doctype, name, mode, form_proxy, fg, onAfterSave)` | Fires `validate` → `frappe.client.insert` or `frappe.client.set_value` → `after_insert/after_update/after_save` |
+
+### Tab rendering
+
+`get_meta_fields` is called with `include_tabs: 1` so Tab Break fields are returned. `_splitFieldsByTabs` groups fields into `{ label, fields }` buckets at Tab Break boundaries. Empty groups (Tab Break with no following fields) are skipped — active tab is determined by `renderedCount === 0`, **not** array index `i === 0`.
+
+### `include_tabs` backend parameter
+
+`frappe_theme.dt_api.get_meta_fields` accepts `include_tabs=True` (default `False`). Normally Tab Break fields are stripped; passing this flag returns them for embedded form tab rendering.
+
+### `set_only_once` fields — two-part fix
+
+Both rendering paths must apply this consistently:
+
+1. **UI (field prep)**: In `mode === "write"`, set `f.read_only = 1` unconditionally (whether or not the field currently has a value).
+2. **Save payload**: Exclude `set_only_once` fields when building the update dict before `frappe.client.set_value`. Missing this causes Frappe to throw _"Value cannot be changed for \<field\>"_.
+
+```javascript
+// form_dialog.js — value_fields filter
+fields.filter(f => !["Section Break", ...].includes(f.fieldtype) && !f.set_only_once)
+
+// embedded_form.js — fields_to_update filter
+fg.fields_list.filter(f => !["Section Break", ...].includes(f.df.fieldtype) && !f.df.set_only_once)
+```
+
+### Changes always apply to BOTH paths
+
+`form_dialog.js` and `embedded_form.js` are parallel. Field preparation logic, save payload filtering, and dt_events hook execution must be kept in sync across both files.
+
+---
 
 ## Pattern: Prototype Mixin via Object.assign
 
@@ -215,6 +294,14 @@ Then manually verify in the browser:
 - Percent columns show progress bar (thin bar + value label)
 - Percent progress bar uses `color` from list view settings (default blue `#3182ce`)
 - Currency formatting in total row matches data rows (`formatCurrency` from `utils.js`)
+
+**When `use_embedded_form: true`:**
+- Add Row opens inline panel (not modal), first tab active by default
+- Edit opens inline panel with existing values populated, `set_only_once` fields are read-only
+- View opens inline panel with all fields read-only
+- Saving does not include `set_only_once` fields in the update payload (no backend error)
+- After save, panel collapses and table reloads
+- Close (✕) button dismisses panel without saving
 
 ## Related Documentation
 

--- a/frappe_theme/controllers/dt_conf.py
+++ b/frappe_theme/controllers/dt_conf.py
@@ -112,7 +112,7 @@ class DTConf:
 		settings["charts"] = updated_charts
 		return settings
 
-	def get_meta_fields(doctype, _type, meta_attached=False):
+	def get_meta_fields(doctype, _type, meta_attached=False, include_tabs=False):
 		if _type == "Report":
 			report = frappe.get_doc("Report", doctype)
 			if report.report_type != "Query Report":
@@ -135,7 +135,8 @@ class DTConf:
 			# 	ignore_permissions=True,
 			# )
 			# # Convert meta_fields into mutable dictionaries if necessary
-			fields_dict = [f.as_dict() for f in meta_fields if f.fieldtype not in ["Tab Break"]]
+			excluded = [] if frappe.utils.cint(include_tabs) else ["Tab Break"]
+			fields_dict = [f.as_dict() for f in meta_fields if f.fieldtype not in excluded]
 			# # Apply property setter values to the meta fields
 			# for field in fields_dict:
 			# 	for ps in property_setters:

--- a/frappe_theme/dt_api.py
+++ b/frappe_theme/dt_api.py
@@ -97,8 +97,8 @@ def check_list_permissions(doctype: str, _type: str = "Direct"):
 
 
 @frappe.whitelist()
-def get_meta_fields(doctype, _type="Direct", meta_attached=False):
-	return DTConf.get_meta_fields(doctype, _type, meta_attached)
+def get_meta_fields(doctype, _type="Direct", meta_attached=False, include_tabs=False):
+	return DTConf.get_meta_fields(doctype, _type, meta_attached, include_tabs)
 
 
 @frappe.whitelist()

--- a/frappe_theme/frappe_theme/doctype/custom_property_setter/custom_property_setter.json
+++ b/frappe_theme/frappe_theme/doctype/custom_property_setter/custom_property_setter.json
@@ -48,6 +48,7 @@
   "connection_type",
   "column_break_qdop",
   "hide_table",
+  "use_embedded_form",
   "section_break_qivk",
   "template",
   "link_report",
@@ -846,13 +847,19 @@
    "fieldname": "redirect_to_list",
    "fieldtype": "Check",
    "label": "Redirect to List"
+  },
+  {
+   "default": "0",
+   "fieldname": "use_embedded_form",
+   "fieldtype": "Check",
+   "label": "Use Embedded Form"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_virtual": 1,
  "links": [],
- "modified": "2026-05-20 15:22:29.171326",
+ "modified": "2026-06-11 17:50:04.851872",
  "modified_by": "Administrator",
  "module": "Frappe Theme",
  "name": "Custom Property Setter",

--- a/frappe_theme/hooks.py
+++ b/frappe_theme/hooks.py
@@ -33,6 +33,7 @@ app_include_js = [
 	"override_autocomplete.bundle.js",
 	"override_data.bundle.js",
 	f"/assets/frappe_theme/js/svadb.js?ver={time.time()}",
+	"embedded_form.bundle.js",
 	f"/assets/frappe_theme/js/fields_comment.js?ver={time.time()}",
 	f"/assets/frappe_theme/js/extended_chart.js?ver={time.time()}",
 	f"/assets/frappe_theme/js/list_column_width.js?ver={time.time()}",

--- a/frappe_theme/public/js/datatable/mixins/action_column.js
+++ b/frappe_theme/public/js/datatable/mixins/action_column.js
@@ -56,7 +56,7 @@ const ActionColumnMixin = {
 						});
 					});
 				} else {
-					await this.createFormDialog(this.doctype, primaryKey, "view");
+					await this._openForm(this.doctype, primaryKey, "view");
 				}
 			});
 		}
@@ -100,7 +100,7 @@ const ActionColumnMixin = {
 										cur_frm["sva_dt_prev_route"] = route;
 									});
 								} else {
-									await this.createFormDialog(this.doctype, primaryKey, "write");
+									await this._openForm(this.doctype, primaryKey, "write");
 								}
 							}
 						);
@@ -115,7 +115,7 @@ const ActionColumnMixin = {
 									cur_frm["sva_dt_prev_route"] = route;
 								});
 							} else {
-								await this.createFormDialog(this.doctype, primaryKey, "write");
+								await this._openForm(this.doctype, primaryKey, "write");
 							}
 						}
 					);

--- a/frappe_theme/public/js/datatable/mixins/embedded_form.js
+++ b/frappe_theme/public/js/datatable/mixins/embedded_form.js
@@ -1,0 +1,906 @@
+/**
+ * EmbeddedFormMixin — renders a linked DocType's complete form inline inside
+ * an HTML field wrapper (instead of a modal dialog).
+ *
+ * All dt_events hooks fire with the same signature as FormDialogMixin so that
+ * existing event handlers work in both rendering modes without changes.
+ *
+ * this.form_dialog is set to a frappe.ui.Dialog-compatible proxy so that
+ * after_render hooks can call dt.form_dialog.set_value(), get_value(), etc.
+ */
+const EmbeddedFormMixin = {
+	/**
+	 * Opens an inline form panel below the datatable (instead of a modal dialog).
+	 * Triggered by the "Add row" or "Edit" buttons when use_embedded_form is enabled.
+	 *
+	 * Configuration (either location works):
+	 *   connection.use_embedded_form = true
+	 *   options.use_embedded_form    = true
+	 *
+	 * @param {string}      doctype - Target DocType to render
+	 * @param {string|null} name    - Document name (null = create mode)
+	 * @param {string}      mode    - "create" | "write" | "view"
+	 */
+	async showEmbeddedFormPanel(doctype, name = null, mode = "create") {
+		// Find or create the panel container below the datatable wrapper
+		let panel = this.wrapper.querySelector(".sva-embedded-form-panel");
+		if (!panel) {
+			panel = document.createElement("div");
+			panel.className = "sva-embedded-form-panel card p-3 mt-2";
+			this.wrapper.appendChild(panel);
+		}
+
+		// Reset panel content
+		panel.innerHTML = "";
+		panel.style.display = "block";
+
+		// Header with title and collapse button
+		const header = document.createElement("div");
+		header.className = "d-flex justify-content-between align-items-center mb-3";
+		header.innerHTML = `
+			<strong>${__(name ? "Edit" : "Add")} ${__(doctype)}</strong>
+			<button class="btn btn-xs btn-default sva-panel-close" style="padding:2px 8px">✕</button>
+		`;
+		header.querySelector(".sva-panel-close").addEventListener("click", () => {
+			panel.style.display = "none";
+			panel.innerHTML = "";
+		});
+		panel.appendChild(header);
+
+		// Content wrapper for FieldGroup
+		const content = document.createElement("div");
+		content.className = "sva-embedded-form-content";
+		panel.appendChild(content);
+
+		// After save: reload table data and collapse panel
+		const onAfterSave = async () => {
+			panel.style.display = "none";
+			panel.innerHTML = "";
+			await this.reloadTable();
+		};
+
+		await this.createEmbeddedForm(doctype, name, content, mode, onAfterSave);
+
+		// Scroll panel into view
+		panel.scrollIntoView({ behavior: "smooth", block: "nearest" });
+	},
+
+	/**
+	 * Main entry point. Renders the DocType form inline into `wrapper_el`.
+	 *
+	 * @param {string}      doctype       - Target DocType to render
+	 * @param {string|null} name          - Document name (null for create mode)
+	 * @param {HTMLElement} wrapper_el    - DOM element to render into
+	 * @param {string}      mode          - "create" | "write" | "view"
+	 * @param {Function}    onAfterSave   - Optional callback fired after successful save
+	 * @returns {Object} dialog-compatible proxy (also stored as this.form_dialog)
+	 */
+	async createEmbeddedForm(doctype, name = null, wrapper_el, mode = "write", onAfterSave = null) {
+		if (!wrapper_el) {
+			console.warn("[embedded_form] wrapper_el is required");
+			return null;
+		}
+
+		// Fetch field metadata — include_tabs:1 so Tab Breaks come back and we
+		// convert them to Section Breaks (FieldGroup doesn't support native tabs)
+		let res = await this.sva_db.call({
+			method: "frappe_theme.dt_api.get_meta_fields",
+			doctype: doctype,
+			include_tabs: 1,
+		});
+		let fields = res?.message;
+		if (!fields || !fields.length) {
+			console.warn(`[embedded_form] No fields returned for doctype: ${doctype}`);
+			return null;
+		}
+
+		// Tab Breaks are kept as-is; they are used as boundaries when splitting
+		// fields into per-tab FieldGroup instances below.
+
+		// SVADialog early-exit hook (same as FormDialogMixin)
+		if (window?.SVADialog?.[doctype]) {
+			window?.SVADialog?.[doctype](mode, fields);
+			return null;
+		}
+
+		// SVAHandleParentFieldProps hook
+		if (window?.SVAHandleParentFieldProps) {
+			let f = window?.SVAHandleParentFieldProps(fields, doctype, name, mode);
+			if (f) fields = [...f];
+		}
+
+		// dt_events: customize_form_fields
+		if (this.frm?.["dt_events"]?.[doctype]?.["customize_form_fields"]) {
+			let customize = this.frm["dt_events"][doctype]["customize_form_fields"];
+			let customized = this.isAsync(customize)
+				? await customize(this, fields, mode, false, name)
+				: customize(this, fields, mode, false, name);
+			if (customized) fields = customized;
+		}
+		if (this.frm?.["dt_global_events"]?.["customize_form_fields"]) {
+			let customize = this.frm["dt_global_events"]["customize_form_fields"];
+			let customized = this.isAsync(customize)
+				? await customize(this, fields, mode, false, name)
+				: customize(this, fields, mode, false, name);
+			if (customized) fields = customized;
+		}
+
+		// Fetch document for edit / view modes, store on instance for callers to reuse
+		let doc = {};
+		if (name && mode !== "create") {
+			try {
+				doc = await this.sva_db.get_doc(doctype, name);
+			} catch (e) {
+				console.warn(`[embedded_form] Could not fetch doc ${doctype}/${name}:`, e);
+			}
+		}
+		this._embedded_doc = doc;
+
+		// fg_holder allows get_query closures to reference the FieldGroup before it exists
+		const fg_holder = { instance: null };
+
+		// Field preparation — mirrors FormDialogMixin's create/write path exactly
+		if (mode === "create" || mode === "write") {
+			await this._prepareEmbeddedFieldsWriteMode(
+				doctype, name, doc, fields, mode, fg_holder
+			);
+		} else {
+			// view mode — all fields read_only
+			await this._prepareEmbeddedFieldsViewMode(
+				doctype, name, doc, fields, mode
+			);
+		}
+
+		// Split fields into tab groups at Tab Break boundaries
+		const { tabGroups, hasTabs } = this._splitFieldsByTabs(fields);
+
+		// Clear wrapper
+		wrapper_el.innerHTML = "";
+
+		const allFgs = [];
+		const allFieldsDict = {};
+
+		if (hasTabs) {
+			// Render Bootstrap tab nav header
+			this._renderEmbeddedTabs(wrapper_el, tabGroups, allFgs, allFieldsDict);
+		} else {
+			// No tabs — single FieldGroup (original behavior)
+			const fg0 = new frappe.ui.FieldGroup({ fields: tabGroups[0].fields, body: wrapper_el });
+			fg0.make();
+			allFgs.push(fg0);
+			Object.assign(allFieldsDict, fg0.fields_dict);
+		}
+
+		// Refresh grids (same pattern as FormDialogMixin line 735-739)
+		for (const fg0 of allFgs) {
+			Object.values(fg0.fields_dict).forEach((field) => {
+				if (field?.grid) field.grid.refresh();
+			});
+		}
+
+		// Composite proxy — works across all tab FieldGroups so dt.form_dialog
+		// calls like set_value / get_value / fields_dict work regardless of tab count
+		const form_proxy = this._buildCompositeProxy(allFgs, allFieldsDict, wrapper_el);
+		this.form_dialog = form_proxy;
+
+		// Point fg_holder at the composite so link-filter get_query closures resolve correctly
+		fg_holder.instance = form_proxy;
+
+		// Save / Cancel footer (same UX pattern as FormDialogMixin)
+		// form_proxy is passed as the fg argument — composite exposes get_values() / fields_list
+		if (["create", "write"].includes(mode)) {
+			this._renderEmbeddedFormFooter(wrapper_el, doctype, name, mode, form_proxy, form_proxy, onAfterSave);
+		}
+
+		// after_render dt_events (same args as FormDialogMixin lines 765-782)
+		if (this.frm?.["dt_events"]?.[doctype]?.["after_render"]) {
+			let change = this.frm["dt_events"][doctype]["after_render"];
+			if (this.isAsync(change)) {
+				await change(this, mode, false, name);
+			} else {
+				change(this, mode, false, name);
+			}
+		}
+		if (this.frm?.["dt_global_events"]?.["after_render"]) {
+			let change = this.frm["dt_global_events"]["after_render"];
+			if (this.isAsync(change)) {
+				await change(this, mode, false, name);
+			} else {
+				change(this, mode, false, name);
+			}
+		}
+
+		return form_proxy;
+	},
+
+	/**
+	 * Field preparation for create / write modes.
+	 * Mirrors FormDialogMixin lines 45-413 exactly.
+	 */
+	async _prepareEmbeddedFieldsWriteMode(doctype, name, doc, fields, mode, fg_holder) {
+		const has_doc = name && doc && Object.keys(doc).length;
+
+		if (has_doc) {
+			// Edit existing document — same as FormDialogMixin lines 46-413
+			for (const f of fields) {
+				f.default = "";
+				if (f.hidden === "0") f.hidden = 0;
+				f.onchange = this.onFieldValueChange?.bind(this);
+
+				if (this.frm?.["dt_events"]?.[doctype]?.[f.fieldname]) {
+					let change = this.frm["dt_events"][doctype][f.fieldname];
+					if (f.fieldtype === "Button") {
+						f.click = change.bind(this, this, mode, f, name);
+					} else {
+						f.onchange = change.bind(this, this, mode, f, name);
+					}
+				}
+				if (this.frm?.["dt_global_events"]?.[f.fieldname]) {
+					let change = this.frm["dt_global_events"][f.fieldname];
+					if (f.fieldtype === "Button") {
+						f.click = change.bind(this, this, mode, f, name);
+					} else {
+						f.onchange = change.bind(this, this, mode, f, name);
+					}
+				}
+
+				if (f.set_only_once) {
+					if (mode === "write") {
+						// Editing an existing record — field is locked unconditionally
+						f.read_only = 1;
+					} else if (doc[f.fieldname]) {
+						f.default = doc[f.fieldname];
+						f.read_only = 1;
+					} else {
+						f.reqd = 0;
+						f.hidden = 1;
+					}
+				}
+
+				if (["Table", "Table MultiSelect"].includes(f.fieldtype)) {
+					let tableRes = await this.sva_db.call({
+						method: "frappe_theme.dt_api.get_meta_fields",
+						doctype: f.options,
+					});
+					let tableFields = tableRes?.message || [];
+
+					if (this.frm?.["dt_events"]?.[f.options]?.["customize_form_fields"]) {
+						let customize = this.frm["dt_events"][f.options]["customize_form_fields"];
+						let customized = this.isAsync(customize)
+							? await customize(this, tableFields, mode, false, name)
+							: customize(this, tableFields, mode, false, name);
+						if (customized) tableFields = customized;
+					}
+					if (this.frm?.["dt_global_events"]?.["customize_form_fields"]) {
+						let customize = this.frm["dt_global_events"]["customize_form_fields"];
+						let customized = this.isAsync(customize)
+							? await customize(this, tableFields, mode, false, name)
+							: customize(this, tableFields, mode, false, name);
+						if (customized) tableFields = customized;
+					}
+
+					for (let tf of tableFields) {
+						if (tf.fieldtype === "Link") {
+							tf.get_query = () => {
+								const filters = [];
+								if (this.frm?.["dt_filters"]?.[f.options]?.[tf.fieldname]) {
+									filters.push(...this.frm["dt_filters"][f.options][tf.fieldname]);
+								}
+								if (tf.link_filter) {
+									const [parentfield, filter_key] = tf.link_filter.split("->");
+									filters.push([
+										tf.options,
+										filter_key,
+										"=",
+										fg_holder.instance?.get_value(parentfield) ||
+											`Please select ${parentfield}`,
+									]);
+								}
+								return { filters };
+							};
+						}
+						if (this.frm?.["dt_events"]?.[f.options]?.[tf.fieldname]) {
+							let change = this.frm["dt_events"][f.options][tf.fieldname];
+							tf.onchange = this.isAsync(change)
+								? await change.bind(this, this, mode, tf, name)
+								: change.bind(this, this, mode, tf, name);
+						}
+						if (this.frm?.["dt_global_events"]?.[tf.fieldname]) {
+							let change = this.frm["dt_global_events"][tf.fieldname];
+							tf.onchange = this.isAsync(change)
+								? await change.bind(this, this, mode, tf, name)
+								: change.bind(this, this, mode, tf, name);
+						}
+					}
+
+					f.fields = tableFields;
+					if (doc[f.fieldname]?.length) {
+						f.data = doc[f.fieldname]?.map((row) => {
+							let old_name = row.name;
+							delete row.name;
+							return { ...row, old_name };
+						});
+					}
+					continue;
+				}
+
+				if (["Attach", "Attach Image"].includes(f.fieldtype)) {
+					if (f.read_only) {
+						if (doc[f.fieldname]) {
+							f.fieldtype = "HTML";
+							f.options = `
+								<div class="form-group horizontal">
+									<div class="clearfix">
+										<label class="control-label" style="padding-right: 0px;">${f.label}</label>
+										<span class="help"></span>
+									</div>
+									<div class="control-input-wrapper">
+										<div class="control-input" style="display: none;"></div>
+										<div class="control-value like-disabled-input ellipsis">
+											<svg class="es-icon es-line icon-sm" aria-hidden="true">
+												<use href="#es-line-link"></use>
+											</svg>
+											<a href="${doc[f.fieldname]}" target="_blank">${doc[f.fieldname]}</a>
+										</div>
+										<div class="help-box small text-extra-muted hide"></div>
+									</div>
+								</div>`;
+						} else {
+							f.default = "";
+							f.hidden = 1;
+						}
+					} else if (f.hidden) {
+						f.fieldtype = "Data";
+					} else if (doc[f.fieldname]) {
+						f.default = doc[f.fieldname];
+					}
+					continue;
+				}
+
+				if (doc[f.fieldname]) {
+					f.default = doc[f.fieldname];
+				}
+
+				if (f.fieldtype === "Link") {
+					f.get_query = () => {
+						const filters = [];
+						if (this.frm?.["dt_filters"]?.[doctype]?.[f.fieldname]) {
+							filters.push(...this.frm["dt_filters"][doctype][f.fieldname]);
+						}
+						if (f.link_filter) {
+							const [parentfield, filter_key] = f.link_filter.split("->");
+							filters.push([
+								f.options,
+								filter_key,
+								"=",
+								fg_holder.instance?.get_value(parentfield) ||
+									`Please select ${parentfield}`,
+							]);
+						}
+						return { filters };
+					};
+				}
+
+				if (
+					!["Check", "Button", "Table", "Table MultiSelect", "Currency"].includes(
+						f.fieldtype
+					) &&
+					f.read_only &&
+					!doc[f.fieldname]
+				) {
+					if (!f.depends_on) {
+						f.depends_on = `eval:(doc?.${f.fieldname} != null || doc?.${f.fieldname} != undefined)`;
+					} else {
+						f.hidden = 1;
+					}
+					continue;
+				}
+			}
+		} else {
+			// Create new document — same as FormDialogMixin create path
+			for (const f of fields) {
+				f.onchange = this.onFieldValueChange?.bind(this);
+				if (f.hidden === "0") f.hidden = 0;
+
+				if (["Attach", "Attach Image"].includes(f.fieldtype)) {
+					if (f.hidden) {
+						f.fieldtype = "Data";
+						f.hidden = 1;
+						continue;
+					}
+				}
+
+				if (this.frm?.["dt_events"]?.[doctype]?.[f.fieldname]) {
+					let change = this.frm["dt_events"][doctype][f.fieldname];
+					if (f.fieldtype === "Button") {
+						f.click = change.bind(this, this, mode, f, name);
+					} else {
+						f.onchange = change.bind(this, this, mode, f, name);
+					}
+				}
+				if (this.frm?.["dt_global_events"]?.[f.fieldname]) {
+					let change = this.frm["dt_global_events"][f.fieldname];
+					if (f.fieldtype === "Button") {
+						f.click = change.bind(this, this, mode, f, name);
+					} else {
+						f.onchange = change.bind(this, this, mode, f, name);
+					}
+				}
+
+				// Set parent doctype field as default + read_only for connection context
+				if (this.frm?.parentRow?.[f.fieldname]) {
+					if (f.fieldname !== "workflow_state") {
+						f.default = this.frm.parentRow[f.fieldname];
+						f.read_only = 1;
+					}
+				}
+				if (this.frm?.doctype === f.options) {
+					f.default = this.frm?.doc?.name;
+					f.read_only = 1;
+				}
+
+				if (["Table", "Table MultiSelect"].includes(f.fieldtype)) {
+					let tableRes = await this.sva_db.call({
+						method: "frappe_theme.dt_api.get_meta_fields",
+						doctype: f.options,
+					});
+					let tableFields = tableRes?.message || [];
+
+					if (this.frm?.["dt_events"]?.[f.options]?.["customize_form_fields"]) {
+						let customize = this.frm["dt_events"][f.options]["customize_form_fields"];
+						let customized = this.isAsync(customize)
+							? await customize(this, tableFields, mode, false, null)
+							: customize(this, tableFields, mode, false, null);
+						if (customized) tableFields = customized;
+					}
+					for (let tf of tableFields) {
+						if (this.frm?.["dt_events"]?.[f.options]?.[tf.fieldname]) {
+							let change = this.frm["dt_events"][f.options][tf.fieldname];
+							tf.onchange = change.bind(this, this, mode, tf, name);
+						}
+						if (this.frm?.["dt_global_events"]?.[tf.fieldname]) {
+							let change = this.frm["dt_global_events"][tf.fieldname];
+							tf.onchange = change.bind(this, this, mode, tf, name);
+						}
+					}
+					f.fields = tableFields;
+					continue;
+				}
+
+				if (f.fieldtype === "Link") {
+					f.get_query = () => {
+						const filters = [];
+						if (this.frm?.["dt_filters"]?.[doctype]?.[f.fieldname]) {
+							filters.push(...this.frm["dt_filters"][doctype][f.fieldname]);
+						}
+						if (f.link_filter) {
+							const [parentfield, filter_key] = f.link_filter.split("->");
+							filters.push([
+								f.options,
+								filter_key,
+								"=",
+								fg_holder.instance?.get_value(parentfield) ||
+									`Please select ${parentfield}`,
+							]);
+						}
+						return { filters };
+					};
+				}
+			}
+		}
+	},
+
+	/**
+	 * Field preparation for view mode.
+	 * Mirrors FormDialogMixin lines 415-533 exactly.
+	 */
+	async _prepareEmbeddedFieldsViewMode(doctype, name, doc, fields, mode) {
+		for (const f of fields) {
+			if (f.hidden === "0") f.hidden = 0;
+
+			if (["Table", "Table MultiSelect"].includes(f.fieldtype)) {
+				let tableRes = await this.sva_db.call({
+					method: "frappe_theme.dt_api.get_meta_fields",
+					doctype: f.options,
+				});
+				let tableFields = tableRes?.message || [];
+
+				if (this.frm?.["dt_events"]?.[f.options]?.["customize_form_fields"]) {
+					let customize = this.frm["dt_events"][f.options]["customize_form_fields"];
+					let customized = this.isAsync(customize)
+						? await customize(this, tableFields, mode, false, name)
+						: customize(this, tableFields, mode, false, name);
+					if (customized) tableFields = customized;
+				}
+				if (this.frm?.["dt_global_events"]?.["customize_form_fields"]) {
+					let customize = this.frm["dt_global_events"]["customize_form_fields"];
+					let customized = this.isAsync(customize)
+						? await customize(this, tableFields, mode, false, name)
+						: customize(this, tableFields, mode, false, name);
+					if (customized) tableFields = customized;
+				}
+
+				f.fields = tableFields.map((tf) => ({ ...tf, read_only: 1 }));
+				f.cannot_add_rows = 1;
+				f.cannot_delete_rows = 1;
+				f.read_only = 1;
+
+				if (doc[f.fieldname]?.length) {
+					if (f.fieldtype === "Table MultiSelect") {
+						f.default = doc[f.fieldname];
+					} else {
+						f.data = doc[f.fieldname];
+					}
+				}
+				continue;
+			}
+
+			if (["Attach", "Attach Image"].includes(f.fieldtype)) {
+				if (doc[f.fieldname]) {
+					f.fieldtype = "HTML";
+					f.options = `
+						<div class="form-group horizontal">
+							<div class="clearfix">
+								<label class="control-label" style="padding-right: 0px;">${f.label}</label>
+								<span class="help"></span>
+							</div>
+							<div class="control-input-wrapper">
+								<div class="control-input" style="display: none;"></div>
+								<div class="control-value like-disabled-input ellipsis">
+									<svg class="es-icon es-line icon-sm" aria-hidden="true">
+										<use href="#es-line-link"></use>
+									</svg>
+									<a href="${doc[f.fieldname]}" target="_blank">${doc[f.fieldname]}</a>
+								</div>
+								<div class="help-box small text-extra-muted hide"></div>
+							</div>
+						</div>`;
+				} else {
+					f.hidden = 1;
+				}
+				continue;
+			}
+
+			if (f.fieldtype === "Button") {
+				if (this.frm?.["dt_events"]?.[doctype]?.[f.fieldname]) {
+					let change = this.frm["dt_events"][doctype][f.fieldname];
+					f.click = change.bind(this, this, mode, f, name);
+				}
+				if (this.frm?.["dt_global_events"]?.[f.fieldname]) {
+					let change = this.frm["dt_global_events"][f.fieldname];
+					f.click = change.bind(this, this, mode, f, name);
+				}
+				continue;
+			}
+
+			if (
+				!["Check", "Button", "Table", "Table MultiSelect", "Currency"].includes(f.fieldtype) &&
+				f.read_only &&
+				!doc[f.fieldname]
+			) {
+				if (!f.depends_on) {
+					f.depends_on = `eval:(doc?.${f.fieldname} != null || doc?.${f.fieldname} != undefined)`;
+				} else {
+					f.hidden = 1;
+				}
+				continue;
+			}
+
+			if (doc[f.fieldname]) {
+				f.default = doc[f.fieldname];
+				f.read_only = 1;
+			} else {
+				f.default = "";
+				f.read_only = 1;
+			}
+		}
+	},
+
+	/**
+	 * Renders the Save footer below the embedded form.
+	 * onAfterSave is called after all dt_events hooks complete (e.g. to hide a panel).
+	 */
+	_renderEmbeddedFormFooter(wrapper_el, doctype, name, mode, form_proxy, fg, onAfterSave = null) {
+		const footer = document.createElement("div");
+		footer.className = "embedded-form-footer d-flex justify-content-end gap-2 mt-3 pb-2";
+
+		const saveBtn = document.createElement("button");
+		saveBtn.className = "btn btn-primary btn-sm";
+		saveBtn.textContent = name ? __("Update") : __("Create");
+
+		saveBtn.addEventListener("click", async () => {
+			try {
+				saveBtn.disabled = true;
+				saveBtn.innerHTML =
+					'<span class="spinner-border spinner-border-sm" style="width:.75rem;height:.75rem"></span> ' +
+					(name ? __("Updating") : __("Creating"));
+				await this._saveEmbeddedForm(doctype, name, mode, form_proxy, fg, onAfterSave);
+			} finally {
+				// only restore button state if onAfterSave didn't remove/hide the panel
+				if (saveBtn.isConnected) {
+					saveBtn.disabled = false;
+					saveBtn.textContent = name ? __("Update") : __("Create");
+				}
+			}
+		});
+
+		footer.appendChild(saveBtn);
+		wrapper_el.appendChild(footer);
+	},
+
+	/**
+	 * Save flow — mirrors FormDialogMixin primary_action exactly.
+	 * Fires: validate → insert/set_value → after_insert/after_update → after_save
+	 * onAfterSave is called last (e.g. to reload table and hide the inline panel).
+	 */
+	async _saveEmbeddedForm(doctype, name, mode, form_proxy, fg, onAfterSave = null) {
+		let values = fg.get_values();
+		if (!values) return;
+
+		// validate hook
+		if (this.frm?.["dt_events"]?.[doctype]?.["validate"]) {
+			let change = this.frm["dt_events"][doctype]["validate"];
+			if (this.isAsync(change)) {
+				await change(this, mode, values, false);
+			} else {
+				change(this, mode, values, false);
+			}
+			values = fg.get_values();
+		}
+		if (this.frm?.["dt_global_events"]?.["validate"]) {
+			let change = this.frm["dt_global_events"]["validate"];
+			if (this.isAsync(change)) {
+				await change(this, mode, values, false);
+			} else {
+				change(this, mode, values, false);
+			}
+			values = fg.get_values();
+		}
+
+		if (!name) {
+			// insert
+			let response = await frappe.xcall("frappe.client.insert", {
+				doc: { doctype, ...values },
+			});
+			if (response) {
+				frappe.show_alert({
+					message: __("Successfully created {0}", [__(doctype)]),
+					indicator: "success",
+				});
+				if (this.frm?.["dt_events"]?.[doctype]?.["after_insert"]) {
+					let change = this.frm["dt_events"][doctype]["after_insert"];
+					this.isAsync(change) ? await change(this, response) : change(this, response);
+				}
+				if (this.frm?.["dt_global_events"]?.["after_insert"]) {
+					let change = this.frm["dt_global_events"]["after_insert"];
+					this.isAsync(change) ? await change(this, response) : change(this, response);
+				}
+			}
+		} else {
+			// set_value (update)
+			let fields_to_update = fg.fields_list
+				.filter(
+					(f) =>
+						!["Section Break", "Column Break", "HTML", "Button", "Tab Break"].includes(
+							f.df.fieldtype
+						) && !f.df.set_only_once
+				)
+				.map((f) => f.df.fieldname);
+
+			let updated_values = {};
+			for (let key of fields_to_update) {
+				let val = values[key];
+				if (Array.isArray(val)) {
+					updated_values[key] = val.map((item) =>
+						item.old_name ? { ...item, name: item.old_name } : item
+					);
+				} else {
+					updated_values[key] = val ?? "";
+				}
+			}
+
+			let response = await frappe.xcall("frappe.client.set_value", {
+				doctype,
+				name,
+				fieldname: updated_values,
+			});
+			if (response) {
+				frappe.show_alert({
+					message: __("Successfully updated {0}", [__(doctype)]),
+					indicator: "success",
+				});
+				if (this.frm?.["dt_events"]?.[doctype]?.["after_update"]) {
+					let change = this.frm["dt_events"][doctype]["after_update"];
+					this.isAsync(change) ? await change(this, response) : change(this, response);
+				}
+				if (this.frm?.["dt_global_events"]?.["after_update"]) {
+					let change = this.frm["dt_global_events"]["after_update"];
+					this.isAsync(change) ? await change(this, response) : change(this, response);
+				}
+			}
+		}
+
+		// after_save hook
+		if (this.frm?.["dt_events"]?.[doctype]?.["after_save"]) {
+			let change = this.frm["dt_events"][doctype]["after_save"];
+			this.isAsync(change) ? await change(this, mode, values) : change(this, mode, values);
+		}
+		if (this.frm?.["dt_global_events"]?.["after_save"]) {
+			let change = this.frm["dt_global_events"]["after_save"];
+			this.isAsync(change) ? await change(this, mode, values) : change(this, mode, values);
+		}
+
+		// Panel / caller teardown (e.g. hide inline panel and reload table)
+		if (typeof onAfterSave === "function") {
+			await onAfterSave();
+		}
+	},
+
+	// ── Routing helper ───────────────────────────────────────────────────────────
+
+	/**
+	 * Routes Create / Edit / View to either the inline panel or the modal dialog
+	 * depending on the use_embedded_form flag on connection or options.
+	 *
+	 * Usage:
+	 *   this._openForm(doctype, name, "write")   // edit
+	 *   this._openForm(doctype, null, "create")  // add row
+	 *   this._openForm(doctype, name, "view")    // view
+	 */
+	_openForm(doctype, name, mode) {
+		if (this.connection?.use_embedded_form || this.options?.use_embedded_form) {
+			return this.showEmbeddedFormPanel(doctype, name, mode);
+		}
+		return this.createFormDialog(doctype, name, mode);
+	},
+
+	// ── Tab helpers ──────────────────────────────────────────────────────────────
+
+	/**
+	 * Splits a flat fields array into groups at each Tab Break boundary.
+	 * Returns { tabGroups: [{ label, fields }], hasTabs: bool }
+	 */
+	_splitFieldsByTabs(fields) {
+		const tabGroups = [];
+		let currentLabel = __("Details");
+		let currentFields = [];
+		let hasTabs = false;
+
+		for (const f of fields) {
+			if (f.fieldtype === "Tab Break") {
+				hasTabs = true;
+				tabGroups.push({ label: currentLabel, fields: currentFields });
+				currentLabel = f.label || `Tab ${tabGroups.length + 1}`;
+				currentFields = [];
+			} else {
+				currentFields.push(f);
+			}
+		}
+		tabGroups.push({ label: currentLabel, fields: currentFields });
+
+		return { tabGroups, hasTabs };
+	},
+
+	/**
+	 * Renders Bootstrap nav-tabs + per-tab FieldGroups.
+	 * Populates allFgs and allFieldsDict in-place.
+	 */
+	_renderEmbeddedTabs(wrapper_el, tabGroups, allFgs, allFieldsDict) {
+		// Nav tabs header
+		const nav = document.createElement("ul");
+		nav.className = "nav nav-tabs sva-ef-tabs";
+		nav.style.cssText =
+			"border-bottom:1px solid var(--border-color);flex-wrap:wrap;margin-bottom:0;";
+		wrapper_el.appendChild(nav);
+
+		// Content container
+		const contentWrap = document.createElement("div");
+		contentWrap.className = "sva-ef-tab-content";
+		contentWrap.style.cssText = "border:1px solid var(--border-color);border-top:none;padding:12px 8px 4px;";
+		wrapper_el.appendChild(contentWrap);
+
+		let renderedCount = 0;
+
+		tabGroups.forEach((group, i) => {
+			// Skip groups with no fields (the implicit empty group before the first Tab Break)
+			if (group.fields.length === 0) return;
+
+			const isFirst = renderedCount === 0;
+
+			// Nav item
+			const li = document.createElement("li");
+			li.className = "nav-item";
+
+			const a = document.createElement("a");
+			a.className = `nav-link sva-ef-tab-link${isFirst ? " active" : ""}`;
+			a.href = "#";
+			a.textContent = __(group.label);
+			a.style.cssText =
+				"font-size:12px;padding:6px 14px;color:var(--text-color);";
+			li.appendChild(a);
+			nav.appendChild(li);
+
+			// Tab panel
+			const panel = document.createElement("div");
+			panel.className = "sva-ef-tab-panel";
+			panel.setAttribute("data-tab", renderedCount);
+			if (!isFirst) panel.style.display = "none";
+			contentWrap.appendChild(panel);
+
+			renderedCount++;
+
+			// Tab switch handler
+			a.addEventListener("click", (e) => {
+				e.preventDefault();
+				nav.querySelectorAll(".sva-ef-tab-link").forEach((l) =>
+					l.classList.remove("active")
+				);
+				contentWrap.querySelectorAll(".sva-ef-tab-panel").forEach((p) => {
+					p.style.display = "none";
+				});
+				a.classList.add("active");
+				panel.style.display = "block";
+			});
+
+			// FieldGroup for this tab's fields
+			if (group.fields.length > 0) {
+				const tabFg = new frappe.ui.FieldGroup({
+					fields: group.fields,
+					body: panel,
+				});
+				tabFg.make();
+				allFgs.push(tabFg);
+				Object.assign(allFieldsDict, tabFg.fields_dict);
+			}
+		});
+	},
+
+	/**
+	 * Builds a frappe.ui.Dialog-compatible proxy that aggregates
+	 * across all tab FieldGroups so dt_events can call
+	 * dt.form_dialog.set_value(), get_value(), fields_dict etc.
+	 * Also exposes fields_list (used by _saveEmbeddedForm).
+	 */
+	_buildCompositeProxy(allFgs, allFieldsDict, wrapper_el) {
+		const getValueFromAny = (fn) => {
+			for (const fg of allFgs) {
+				const val = fg.get_value(fn);
+				if (val !== undefined && val !== null && val !== "") return val;
+				if (fn in (fg.fields_dict || {})) return fg.get_value(fn);
+			}
+			return undefined;
+		};
+
+		const setValueInAny = (fn, val) => {
+			for (const fg of allFgs) {
+				if (fn in (fg.fields_dict || {})) {
+					return fg.set_value(fn, val);
+				}
+			}
+		};
+
+		const getAllValues = () => {
+			let merged = {};
+			for (const fg of allFgs) {
+				Object.assign(merged, fg.get_values() || {});
+			}
+			return merged;
+		};
+
+		return {
+			fields_dict: allFieldsDict,
+			fields_list: allFgs.flatMap((fg) => fg.fields_list || []),
+			get_value: getValueFromAny,
+			set_value: setValueInAny,
+			get_values: getAllValues,
+			$wrapper: $(wrapper_el),
+			clear: () => allFgs.forEach((fg) => fg.set_values({})),
+			hide: () => {},
+			show: () => {},
+			_fg: allFgs[0] || null,
+			_fgs: allFgs,
+		};
+	},
+};
+
+export default EmbeddedFormMixin;

--- a/frappe_theme/public/js/datatable/mixins/embedded_form.js
+++ b/frappe_theme/public/js/datatable/mixins/embedded_form.js
@@ -75,7 +75,13 @@ const EmbeddedFormMixin = {
 	 * @param {Function}    onAfterSave   - Optional callback fired after successful save
 	 * @returns {Object} dialog-compatible proxy (also stored as this.form_dialog)
 	 */
-	async createEmbeddedForm(doctype, name = null, wrapper_el, mode = "write", onAfterSave = null) {
+	async createEmbeddedForm(
+		doctype,
+		name = null,
+		wrapper_el,
+		mode = "write",
+		onAfterSave = null
+	) {
 		if (!wrapper_el) {
 			console.warn("[embedded_form] wrapper_el is required");
 			return null;
@@ -142,13 +148,16 @@ const EmbeddedFormMixin = {
 		// Field preparation — mirrors FormDialogMixin's create/write path exactly
 		if (mode === "create" || mode === "write") {
 			await this._prepareEmbeddedFieldsWriteMode(
-				doctype, name, doc, fields, mode, fg_holder
+				doctype,
+				name,
+				doc,
+				fields,
+				mode,
+				fg_holder
 			);
 		} else {
 			// view mode — all fields read_only
-			await this._prepareEmbeddedFieldsViewMode(
-				doctype, name, doc, fields, mode
-			);
+			await this._prepareEmbeddedFieldsViewMode(doctype, name, doc, fields, mode);
 		}
 
 		// Split fields into tab groups at Tab Break boundaries
@@ -165,7 +174,10 @@ const EmbeddedFormMixin = {
 			this._renderEmbeddedTabs(wrapper_el, tabGroups, allFgs, allFieldsDict);
 		} else {
 			// No tabs — single FieldGroup (original behavior)
-			const fg0 = new frappe.ui.FieldGroup({ fields: tabGroups[0].fields, body: wrapper_el });
+			const fg0 = new frappe.ui.FieldGroup({
+				fields: tabGroups[0].fields,
+				body: wrapper_el,
+			});
 			fg0.make();
 			allFgs.push(fg0);
 			Object.assign(allFieldsDict, fg0.fields_dict);
@@ -189,7 +201,15 @@ const EmbeddedFormMixin = {
 		// Save / Cancel footer (same UX pattern as FormDialogMixin)
 		// form_proxy is passed as the fg argument — composite exposes get_values() / fields_list
 		if (["create", "write"].includes(mode)) {
-			this._renderEmbeddedFormFooter(wrapper_el, doctype, name, mode, form_proxy, form_proxy, onAfterSave);
+			this._renderEmbeddedFormFooter(
+				wrapper_el,
+				doctype,
+				name,
+				mode,
+				form_proxy,
+				form_proxy,
+				onAfterSave
+			);
 		}
 
 		// after_render dt_events (same args as FormDialogMixin lines 765-782)
@@ -284,7 +304,9 @@ const EmbeddedFormMixin = {
 							tf.get_query = () => {
 								const filters = [];
 								if (this.frm?.["dt_filters"]?.[f.options]?.[tf.fieldname]) {
-									filters.push(...this.frm["dt_filters"][f.options][tf.fieldname]);
+									filters.push(
+										...this.frm["dt_filters"][f.options][tf.fieldname]
+									);
 								}
 								if (tf.link_filter) {
 									const [parentfield, filter_key] = tf.link_filter.split("->");
@@ -574,7 +596,9 @@ const EmbeddedFormMixin = {
 			}
 
 			if (
-				!["Check", "Button", "Table", "Table MultiSelect", "Currency"].includes(f.fieldtype) &&
+				!["Check", "Button", "Table", "Table MultiSelect", "Currency"].includes(
+					f.fieldtype
+				) &&
 				f.read_only &&
 				!doc[f.fieldname]
 			) {
@@ -600,7 +624,15 @@ const EmbeddedFormMixin = {
 	 * Renders the Save footer below the embedded form.
 	 * onAfterSave is called after all dt_events hooks complete (e.g. to hide a panel).
 	 */
-	_renderEmbeddedFormFooter(wrapper_el, doctype, name, mode, form_proxy, fg, onAfterSave = null) {
+	_renderEmbeddedFormFooter(
+		wrapper_el,
+		doctype,
+		name,
+		mode,
+		form_proxy,
+		fg,
+		onAfterSave = null
+	) {
 		const footer = document.createElement("div");
 		footer.className = "embedded-form-footer d-flex justify-content-end gap-2 mt-3 pb-2";
 
@@ -796,7 +828,8 @@ const EmbeddedFormMixin = {
 		// Content container
 		const contentWrap = document.createElement("div");
 		contentWrap.className = "sva-ef-tab-content";
-		contentWrap.style.cssText = "border:1px solid var(--border-color);border-top:none;padding:12px 8px 4px;";
+		contentWrap.style.cssText =
+			"border:1px solid var(--border-color);border-top:none;padding:12px 8px 4px;";
 		wrapper_el.appendChild(contentWrap);
 
 		let renderedCount = 0;
@@ -815,8 +848,7 @@ const EmbeddedFormMixin = {
 			a.className = `nav-link sva-ef-tab-link${isFirst ? " active" : ""}`;
 			a.href = "#";
 			a.textContent = __(group.label);
-			a.style.cssText =
-				"font-size:12px;padding:6px 14px;color:var(--text-color);";
+			a.style.cssText = "font-size:12px;padding:6px 14px;color:var(--text-color);";
 			li.appendChild(a);
 			nav.appendChild(li);
 

--- a/frappe_theme/public/js/datatable/mixins/form_dialog.js
+++ b/frappe_theme/public/js/datatable/mixins/form_dialog.js
@@ -73,7 +73,10 @@ const FormDialogMixin = {
 						}
 					}
 					if (f.set_only_once) {
-						if (doc[f.fieldname]) {
+						if (mode === "write") {
+							// Editing an existing record — field is locked unconditionally
+							f.read_only = 1;
+						} else if (doc[f.fieldname]) {
 							f.default = doc[f.fieldname];
 							f.read_only = 1;
 						} else {
@@ -624,7 +627,7 @@ const FormDialogMixin = {
 											"HTML",
 											"Button",
 											"Tab Break",
-										].includes(f.fieldtype)
+										].includes(f.fieldtype) && !f.set_only_once
 								);
 								let updated_values = {};
 								for (let field of value_fields) {

--- a/frappe_theme/public/js/datatable/mixins/ui_setup.js
+++ b/frappe_theme/public/js/datatable/mixins/ui_setup.js
@@ -484,7 +484,7 @@ const UISetupMixin = {
 										cur_frm["sva_dt_prev_route"] = route;
 									});
 							} else {
-								await this.createFormDialog(this.doctype);
+								await this._openForm(this.doctype, null, "create");
 							}
 						};
 					}

--- a/frappe_theme/public/js/datatable/sva_datatable.bundle.js
+++ b/frappe_theme/public/js/datatable/sva_datatable.bundle.js
@@ -3,6 +3,7 @@ import RenderingMixin from "./mixins/rendering.js";
 import FieldsMixin from "./mixins/fields.js";
 import ActionColumnMixin from "./mixins/action_column.js";
 import FormDialogMixin from "./mixins/form_dialog.js";
+import EmbeddedFormMixin from "./mixins/embedded_form.js";
 import WorkflowMixin from "./mixins/workflow.js";
 import PaginationMixin from "./mixins/pagination.js";
 import UISetupMixin from "./mixins/ui_setup.js";
@@ -444,6 +445,7 @@ Object.assign(
 	FieldsMixin,
 	ActionColumnMixin,
 	FormDialogMixin,
+	EmbeddedFormMixin,
 	WorkflowMixin,
 	PaginationMixin,
 	UISetupMixin,

--- a/frappe_theme/public/js/embedded_form.bundle.js
+++ b/frappe_theme/public/js/embedded_form.bundle.js
@@ -1,0 +1,446 @@
+/**
+ * frappe_theme.embedded_form
+ *
+ * Renders a complete linked DocType form inline inside an HTML field of the
+ * parent DocType — callable from any Frappe Client Script without a SvaDataTable.
+ *
+ * Usage:
+ *   frappe.ui.form.on("Test New", {
+ *       async refresh(frm) {
+ *           if (frm.doc.employee) {
+ *               await frappe_theme.embedded_form.render({
+ *                   parent_frm: frm,
+ *                   target_doctype: "Employee",
+ *                   target_docname: frm.doc.employee,
+ *                   html_field: "test",
+ *               });
+ *           }
+ *       },
+ *       async employee(frm) {
+ *           await frappe_theme.embedded_form.render({
+ *               parent_frm: frm,
+ *               target_doctype: "Employee",
+ *               target_docname: frm.doc.employee,
+ *               html_field: "test",
+ *           });
+ *       },
+ *   });
+ *
+ * After render, references are stored on parent_frm keyed by DocType:
+ *   frm.sva_dt_frm["Employee"]       → full frm-compatible object (use for Client Scripts)
+ *   frm.embedded_form["Employee"]     → dialog-compatible proxy (same as dt.form_dialog)
+ *   frm.embedded_frm["Employee"]      → alias to sva_dt_frm["Employee"]
+ *   frm.embedded_controls["Employee"] → fg.fields_dict (direct field access)
+ *
+ * dt_events work identically to FormDialogMixin — same hook names, same signatures.
+ */
+
+import EmbeddedFormMixin from "./datatable/mixins/embedded_form.js";
+
+frappe.provide("frappe_theme.embedded_form");
+
+/**
+ * Main public API. All options are required except `mode` (defaults to "write").
+ *
+ * @param {Object}      options
+ * @param {Object}      options.parent_frm      - The Frappe form object (frm)
+ * @param {string}      options.target_doctype  - DocType to render inline
+ * @param {string|null} options.target_docname  - Document name (null for create mode)
+ * @param {string}      options.html_field      - Fieldname of the HTML field to render into
+ * @param {string}      [options.mode="write"]  - "create" | "write" | "view"
+ */
+frappe_theme.embedded_form.render = async function ({
+	parent_frm,
+	target_doctype,
+	target_docname,
+	html_field,
+	mode = "write",
+} = {}) {
+	if (!parent_frm || !target_doctype || !html_field) {
+		console.warn("[embedded_form] parent_frm, target_doctype, and html_field are required");
+		return;
+	}
+
+	// Resolve wrapper element from the HTML field control
+	const field_ctrl = parent_frm.fields_dict?.[html_field];
+	if (!field_ctrl) {
+		console.warn(
+			`[embedded_form] HTML field '${html_field}' not found on ${parent_frm.doctype}`
+		);
+		return;
+	}
+
+	// frappe.ui.HTMLControl places content in .html-field-value or directly in wrapper
+	const wrapper_el =
+		field_ctrl.$wrapper?.[0]?.querySelector(".html-field-value") ||
+		field_ctrl.wrapper?.querySelector(".html-field-value") ||
+		field_ctrl.$wrapper?.[0] ||
+		field_ctrl.wrapper;
+
+	if (!wrapper_el) {
+		console.warn(`[embedded_form] Cannot resolve wrapper for field '${html_field}'`);
+		return;
+	}
+
+	// Initialize per-doctype storage maps lazily
+	if (!parent_frm.sva_dt_frm)        parent_frm.sva_dt_frm       = {};
+	if (!parent_frm.embedded_form)      parent_frm.embedded_form     = {};
+	if (!parent_frm.embedded_frm)       parent_frm.embedded_frm      = {};
+	if (!parent_frm.embedded_controls)  parent_frm.embedded_controls  = {};
+
+	// Build a SvaDataTable-compatible dt_proxy so EmbeddedFormMixin methods work
+	// and dt_events callbacks receive a proper `dt` as first argument.
+	const dt_proxy = {
+		frm: parent_frm,
+		doctype: target_doctype,
+		sva_db: new SVAHTTP(),
+		isAsync: (fn) => fn?.constructor?.name === "AsyncFunction",
+		rows: [],
+		connection: null,
+		form_dialog: null,
+		updateTableBody: () => {},
+		onFieldValueChange: () => {},
+	};
+	Object.assign(dt_proxy, EmbeddedFormMixin);
+
+	// Render the embedded form — sets dt_proxy.form_dialog
+	const form_proxy = await dt_proxy.createEmbeddedForm(
+		target_doctype,
+		target_docname || null,
+		wrapper_el,
+		mode
+	);
+	if (!form_proxy) return;
+
+	const fg = form_proxy._fg;
+
+	// Reuse the doc already fetched by createEmbeddedForm — avoids a second API call
+	const embedded_doc = dt_proxy._embedded_doc || {};
+
+	// Build the comprehensive frm-compatible object for this embedded DocType.
+	// Keys mirror what frappe.ui.form.Form exposes so Client Scripts written for
+	// the target DocType can call set_value, refresh_field, add_custom_button etc.
+	const embedded_frm_obj = _buildEmbeddedFrm({
+		doctype: target_doctype,
+		docname: target_docname || "",
+		doc: embedded_doc,
+		fg,
+		parent_frm,
+		dt_proxy,
+		form_proxy,
+		wrapper_el,
+		html_field,
+	});
+
+	// Store all references keyed by DocType so multiple embeds coexist
+	parent_frm.sva_dt_frm[target_doctype]       = embedded_frm_obj;
+	parent_frm.embedded_form[target_doctype]     = form_proxy;
+	parent_frm.embedded_frm[target_doctype]      = embedded_frm_obj;
+	parent_frm.embedded_controls[target_doctype] = fg?.fields_dict || {};
+
+	// Attach ScriptManager and run lifecycle events for the embedded DocType.
+	// This allows existing Client Scripts registered via frappe.ui.form.on("Employee", ...)
+	// to run with the embedded frm context.
+	if (frappe.ui.form.ScriptManager) {
+		try {
+			embedded_frm_obj.script_manager = new frappe.ui.form.ScriptManager({
+				frm: embedded_frm_obj,
+			});
+			// Lifecycle order mirrors Frappe Form: setup → onload → refresh
+			await _safeScriptTrigger(embedded_frm_obj.script_manager, "setup");
+			await _safeScriptTrigger(embedded_frm_obj.script_manager, "onload");
+			await _safeScriptTrigger(embedded_frm_obj.script_manager, "refresh");
+		} catch (e) {
+			console.warn("[embedded_form] ScriptManager init failed:", e);
+		}
+	}
+
+	return embedded_frm_obj;
+};
+
+/**
+ * Builds the comprehensive frm-compatible object for the embedded DocType.
+ * All properties and methods that common Client Scripts and ScriptManager need
+ * are implemented. UI-only stubs (page, toolbar, dashboard) are no-op objects.
+ */
+function _buildEmbeddedFrm({
+	doctype,
+	docname,
+	doc,
+	fg,
+	parent_frm,
+	dt_proxy,
+	form_proxy,
+	wrapper_el,
+	html_field,
+}) {
+	// Place embedded doc in frappe.model.locals so field dependencies resolve correctly
+	if (docname && doc) {
+		if (!frappe.model.locals[doctype]) {
+			frappe.model.locals[doctype] = {};
+		}
+		frappe.model.locals[doctype][docname] = doc;
+	}
+
+	const embedded_frm = {
+		// ── Identity ─────────────────────────────────────────────────────────────
+		doctype,
+		docname,
+		doc,
+		meta: frappe.get_meta(doctype),
+		perm: frappe.perm.get_perm(doctype),
+
+		// ── Field access (FieldGroup is Layout — fields_dict is fully compatible) ─
+		fields_dict: fg?.fields_dict || {},
+		fields: fg?.fields_list || [],
+		layout: fg,
+
+		// ── Value methods ─────────────────────────────────────────────────────────
+		set_value(fieldname, value) {
+			if (typeof fieldname === "object") {
+				// Support: frm.set_value({ field1: val1, field2: val2 })
+				return fg?.set_values(fieldname);
+			}
+			if (doc) doc[fieldname] = value;
+			return fg?.set_value(fieldname, value);
+		},
+		get_value(fieldname) {
+			return fg?.get_value(fieldname);
+		},
+		get_field(fieldname) {
+			return fg?.fields_dict?.[fieldname];
+		},
+		refresh_field(fieldname) {
+			fg?.fields_dict?.[fieldname]?.refresh();
+		},
+		refresh_fields() {
+			Object.values(fg?.fields_dict || {}).forEach((f) => f?.refresh?.());
+		},
+		get_values(ignore_errors, check_invalid) {
+			return fg?.get_values();
+		},
+		set_df_property(fieldname, property, value) {
+			fg?.set_df_property?.(fieldname, property, value);
+		},
+		toggle_display(fieldnames, show) {
+			const fns = Array.isArray(fieldnames) ? fieldnames : [fieldnames];
+			fns.forEach((fn) => {
+				const f = fg?.fields_dict?.[fn];
+				if (f) f.df.hidden = show ? 0 : 1, f.refresh?.();
+			});
+		},
+		toggle_enable(fieldnames, enable) {
+			const fns = Array.isArray(fieldnames) ? fieldnames : [fieldnames];
+			fns.forEach((fn) => {
+				const f = fg?.fields_dict?.[fn];
+				if (f) f.df.read_only = enable ? 0 : 1, f.refresh?.();
+			});
+		},
+		toggle_reqd(fieldnames, reqd) {
+			const fns = Array.isArray(fieldnames) ? fieldnames : [fieldnames];
+			fns.forEach((fn) => {
+				const f = fg?.fields_dict?.[fn];
+				if (f) f.df.reqd = reqd ? 1 : 0, f.refresh?.();
+			});
+		},
+		set_query(fieldname, opt_or_query, query) {
+			// Support both: frm.set_query(fn, query) and frm.set_query(fn, parent, query)
+			const qfn = typeof opt_or_query === "function" ? opt_or_query : query;
+			const f = fg?.fields_dict?.[fieldname];
+			if (f) f.get_query = qfn;
+		},
+		add_fetch(link_field, source_field, target_field) {
+			// add_fetch is wired per-field in frappe.model; register via fg if possible
+			fg?.add_fetch?.(link_field, source_field, target_field);
+		},
+		get_formatted(fieldname) {
+			const f = fg?.fields_dict?.[fieldname];
+			return f ? frappe.format(f.get_value(), f.df, { only_value: true }, doc) : "";
+		},
+
+		// ── State ─────────────────────────────────────────────────────────────────
+		is_new: () => !docname,
+		is_dirty: () => false,
+		dirty: () => {},
+		read_only: false,
+		save_disabled: false,
+
+		// ── Script hooks (populated by ScriptManager) ─────────────────────────────
+		events: {},
+		cscript: {},
+
+		// ── Server communication ──────────────────────────────────────────────────
+		call(opts, args, callback) {
+			if (typeof opts === "string") {
+				return frappe.call({ method: opts, args: args || {}, callback });
+			}
+			return frappe.call(opts);
+		},
+		has_perm(ptype) {
+			return frappe.perm.has_perm(doctype, 0, ptype);
+		},
+		get_perm(permlevel, access_type) {
+			return frappe.perm.get_perm(doctype, permlevel, access_type);
+		},
+
+		// ── Custom buttons ────────────────────────────────────────────────────────
+		custom_buttons: {},
+		add_custom_button(label, fn, group) {
+			// Render button in the embedded form footer area
+			const btn_area = wrapper_el?.querySelector(".embedded-form-footer");
+			if (!btn_area) return $("<button>");
+			const btn = document.createElement("button");
+			btn.className = "btn btn-default btn-sm";
+			btn.textContent = __(label);
+			btn.addEventListener("click", fn);
+			btn_area.prepend(btn);
+			this.custom_buttons[label] = $(btn);
+			return $(btn);
+		},
+		remove_custom_button(label, group) {
+			this.custom_buttons[label]?.remove();
+			delete this.custom_buttons[label];
+		},
+		clear_custom_buttons() {
+			Object.values(this.custom_buttons).forEach((btn) => btn?.remove());
+			this.custom_buttons = {};
+		},
+		set_intro(text, color) {
+			// Render intro text above the embedded form
+			let intro_el = wrapper_el?.querySelector(".embedded-form-intro");
+			if (!intro_el) {
+				intro_el = document.createElement("div");
+				intro_el.className = "embedded-form-intro alert";
+				wrapper_el?.prepend(intro_el);
+			}
+			intro_el.className = `embedded-form-intro alert alert-${color || "info"}`;
+			intro_el.textContent = text || "";
+		},
+
+		// ── Save ─────────────────────────────────────────────────────────────────
+		async save() {
+			const form_proxy_ref = parent_frm.embedded_form?.[doctype];
+			const fg_ref = form_proxy_ref?._fg;
+			if (fg_ref) {
+				await dt_proxy._saveEmbeddedForm(
+					doctype,
+					docname || null,
+					"write",
+					form_proxy_ref,
+					fg_ref
+				);
+			}
+		},
+
+		// ── Trigger ───────────────────────────────────────────────────────────────
+		async trigger(event, dt, dn) {
+			// Fire dt_events for this doctype then ScriptManager handlers
+			if (parent_frm?.["dt_events"]?.[doctype]?.[event]) {
+				const change = parent_frm["dt_events"][doctype][event];
+				dt_proxy.isAsync(change)
+					? await change(dt_proxy, "write", null, docname)
+					: change(dt_proxy, "write", null, docname);
+			}
+			if (this.script_manager) {
+				await _safeScriptTrigger(this.script_manager, event, dt, dn);
+			}
+		},
+
+		// ── Refresh ───────────────────────────────────────────────────────────────
+		async refresh() {
+			await frappe_theme.embedded_form.render({
+				parent_frm,
+				target_doctype: doctype,
+				target_docname: docname,
+				html_field: html_field || _resolveHtmlField(parent_frm, wrapper_el),
+				mode: "write",
+			});
+		},
+
+		// ── UI stubs — enough for common Client Script patterns ───────────────────
+		page: {
+			set_title: () => {},
+			set_title_sub: () => {},
+			set_indicator: () => {},
+			add_inner_button: (label, fn) => {
+				// Delegate to add_custom_button so buttons appear in embedded footer
+				return embedded_frm.add_custom_button(label, fn);
+			},
+			remove_inner_button: (label) => embedded_frm.remove_custom_button(label),
+			clear_inner_toolbar: () => embedded_frm.clear_custom_buttons(),
+			clear_primary_action: () => {},
+			set_primary_action: () => {},
+			show_menu: () => {},
+			hide_menu: () => {},
+			add_action_icon: () => {},
+			change_inner_button_type: () => {},
+			btn_primary: $("<button>"),
+			btn_secondary: $("<button>"),
+			main: $(wrapper_el),
+			wrapper: $(wrapper_el),
+		},
+		toolbar: {
+			current_status: null,
+			refresh: () => {},
+			set_primary_action: () => {},
+		},
+		dashboard: {
+			refresh: () => {},
+			add_section: () => {},
+			reset: () => {},
+			show: () => {},
+			set_headline: () => {},
+			set_headline_alert: () => {},
+			clear_headline: () => {},
+			add_comment: () => {},
+			add_transactions: () => {},
+			show_progress: () => {},
+			hide_progress: () => {},
+			after_refresh: () => {},
+		},
+		timeline: null,
+		sidebar: null,
+		footer: null,
+		attachments: { max_attachments: 0, get_attachments: () => [] },
+
+		// ── ScriptManager — set after construction ─────────────────────────────────
+		script_manager: null,
+
+		// ── Internal — not part of public API ────────────────────────────────────
+		_dt_proxy: dt_proxy,
+		_fg: fg,
+		_form_proxy: form_proxy,
+	};
+
+	return embedded_frm;
+}
+
+/**
+ * Resolves the html_field name from the parent_frm given a wrapper element.
+ * Used by embedded_frm.refresh() to re-render in the same slot.
+ */
+function _resolveHtmlField(parent_frm, wrapper_el) {
+	for (const [fn, ctrl] of Object.entries(parent_frm.fields_dict || {})) {
+		const ctrl_wrapper =
+			ctrl.$wrapper?.[0]?.querySelector(".html-field-value") ||
+			ctrl.wrapper?.querySelector(".html-field-value") ||
+			ctrl.$wrapper?.[0] ||
+			ctrl.wrapper;
+		if (ctrl_wrapper === wrapper_el) return fn;
+	}
+	return null;
+}
+
+/**
+ * Triggers a ScriptManager event safely, catching any errors that stem from
+ * the fake frm not fully implementing the Frappe Form interface.
+ */
+async function _safeScriptTrigger(script_manager, event, doctype, docname) {
+	try {
+		await script_manager.trigger(event, doctype, docname);
+	} catch (e) {
+		// ScriptManager may access frm properties (status, toolbar, etc.) that
+		// are stubs; log but do not rethrow so rendering continues.
+		console.warn(`[embedded_form] ScriptManager.trigger("${event}") error:`, e);
+	}
+}

--- a/frappe_theme/public/js/embedded_form.bundle.js
+++ b/frappe_theme/public/js/embedded_form.bundle.js
@@ -83,10 +83,10 @@ frappe_theme.embedded_form.render = async function ({
 	}
 
 	// Initialize per-doctype storage maps lazily
-	if (!parent_frm.sva_dt_frm)        parent_frm.sva_dt_frm       = {};
-	if (!parent_frm.embedded_form)      parent_frm.embedded_form     = {};
-	if (!parent_frm.embedded_frm)       parent_frm.embedded_frm      = {};
-	if (!parent_frm.embedded_controls)  parent_frm.embedded_controls  = {};
+	if (!parent_frm.sva_dt_frm) parent_frm.sva_dt_frm = {};
+	if (!parent_frm.embedded_form) parent_frm.embedded_form = {};
+	if (!parent_frm.embedded_frm) parent_frm.embedded_frm = {};
+	if (!parent_frm.embedded_controls) parent_frm.embedded_controls = {};
 
 	// Build a SvaDataTable-compatible dt_proxy so EmbeddedFormMixin methods work
 	// and dt_events callbacks receive a proper `dt` as first argument.
@@ -133,9 +133,9 @@ frappe_theme.embedded_form.render = async function ({
 	});
 
 	// Store all references keyed by DocType so multiple embeds coexist
-	parent_frm.sva_dt_frm[target_doctype]       = embedded_frm_obj;
-	parent_frm.embedded_form[target_doctype]     = form_proxy;
-	parent_frm.embedded_frm[target_doctype]      = embedded_frm_obj;
+	parent_frm.sva_dt_frm[target_doctype] = embedded_frm_obj;
+	parent_frm.embedded_form[target_doctype] = form_proxy;
+	parent_frm.embedded_frm[target_doctype] = embedded_frm_obj;
 	parent_frm.embedded_controls[target_doctype] = fg?.fields_dict || {};
 
 	// Attach ScriptManager and run lifecycle events for the embedded DocType.
@@ -226,21 +226,21 @@ function _buildEmbeddedFrm({
 			const fns = Array.isArray(fieldnames) ? fieldnames : [fieldnames];
 			fns.forEach((fn) => {
 				const f = fg?.fields_dict?.[fn];
-				if (f) f.df.hidden = show ? 0 : 1, f.refresh?.();
+				if (f) (f.df.hidden = show ? 0 : 1), f.refresh?.();
 			});
 		},
 		toggle_enable(fieldnames, enable) {
 			const fns = Array.isArray(fieldnames) ? fieldnames : [fieldnames];
 			fns.forEach((fn) => {
 				const f = fg?.fields_dict?.[fn];
-				if (f) f.df.read_only = enable ? 0 : 1, f.refresh?.();
+				if (f) (f.df.read_only = enable ? 0 : 1), f.refresh?.();
 			});
 		},
 		toggle_reqd(fieldnames, reqd) {
 			const fns = Array.isArray(fieldnames) ? fieldnames : [fieldnames];
 			fns.forEach((fn) => {
 				const f = fg?.fields_dict?.[fn];
-				if (f) f.df.reqd = reqd ? 1 : 0, f.refresh?.();
+				if (f) (f.df.reqd = reqd ? 1 : 0), f.refresh?.();
 			});
 		},
 		set_query(fieldname, opt_or_query, query) {

--- a/frappe_theme/public/js/overwrite_form.bundle.js
+++ b/frappe_theme/public/js/overwrite_form.bundle.js
@@ -1269,8 +1269,8 @@ frappe.ui.form.Form = class CustomForm extends frappe.ui.form.Form {
 					field?.connection_type === "Is Custom Design"
 						? field?.template
 						: ["Direct", "Unfiltered", "Indirect"].includes(field.connection_type)
-						? field.link_doctype
-						: field.referenced_link_doctype
+							? field.link_doctype
+							: field.referenced_link_doctype
 				)} items`
 			);
 			element.innerHTML = `

--- a/frappe_theme/public/js/overwrite_form.bundle.js
+++ b/frappe_theme/public/js/overwrite_form.bundle.js
@@ -1269,8 +1269,8 @@ frappe.ui.form.Form = class CustomForm extends frappe.ui.form.Form {
 					field?.connection_type === "Is Custom Design"
 						? field?.template
 						: ["Direct", "Unfiltered", "Indirect"].includes(field.connection_type)
-							? field.link_doctype
-							: field.referenced_link_doctype
+						? field.link_doctype
+						: field.referenced_link_doctype
 				)} items`
 			);
 			element.innerHTML = `


### PR DESCRIPTION
This pull request introduces support for an "Embedded Form" feature, refines field handling in dialogs, and improves API flexibility for retrieving meta fields. The changes affect both backend Python and frontend JavaScript code, as well as configuration files. The main themes are feature enablement, API enhancements, and UI/UX improvements.

**Feature Enablement:**

* Added a new `use_embedded_form` property to the `Custom Property Setter` DocType, including it in the JSON schema and property list, enabling toggling of embedded form functionality. [[1]](diffhunk://#diff-e515cdb5e51990bd4ff98c8d8e5ac1ec7739d32970fb53445c18da9acd75fcb1R51) [[2]](diffhunk://#diff-e515cdb5e51990bd4ff98c8d8e5ac1ec7739d32970fb53445c18da9acd75fcb1R850-R862)
* Registered a new `embedded_form.bundle.js` asset in `hooks.py` to support the embedded form feature on the frontend.

**API and Backend Enhancements:**

* Updated the `get_meta_fields` method and its API wrapper to accept an `include_tabs` parameter, allowing callers to specify whether "Tab Break" fields should be included in the returned metadata. [[1]](diffhunk://#diff-05c23e93b34430dd75078fc1f96623cfabf7aa7e049c21f0fcaa52a7968910c3L115-R115) [[2]](diffhunk://#diff-05c23e93b34430dd75078fc1f96623cfabf7aa7e049c21f0fcaa52a7968910c3L138-R139) [[3]](diffhunk://#diff-6313081d8ddd4c84f231dabcb4c6e188bf0024d9886d0e0f3fbce57369ad8613L100-R101)

**Frontend/UI Improvements:**

* Changed all calls from `createFormDialog` to the new `_openForm` method in the datatable mixins, standardizing form opening logic for different modes (view, write, create). [[1]](diffhunk://#diff-2c45a52b03c34cc8d0096eb10064f594477f14276c0dcff28a43110cddfd4998L59-R59) [[2]](diffhunk://#diff-2c45a52b03c34cc8d0096eb10064f594477f14276c0dcff28a43110cddfd4998L103-R103) [[3]](diffhunk://#diff-2c45a52b03c34cc8d0096eb10064f594477f14276c0dcff28a43110cddfd4998L118-R118) [[4]](diffhunk://#diff-85e1136996a2eb89e90ee0a36f1b4120c00d4e05d4b8cd9a1327bd3d53f9e87cL487-R487)
* Improved field locking logic in form dialogs: fields with `set_only_once` are now always read-only in "write" (edit) mode, regardless of their value.
* Refined the value extraction logic in form dialogs to exclude fields with `set_only_once` from being considered as value fields, preventing unintended updates.

**Create**
<img width="1429" height="1084" alt="image" src="https://github.com/user-attachments/assets/29c0f0ad-fe08-45b2-a679-c176167a7d7f" />

**Edit**
<img width="1429" height="1084" alt="image" src="https://github.com/user-attachments/assets/408e9da2-a785-40d6-a5a6-99e7f5247dc4" />

**View (ReadOnly)**
<img width="1429" height="1084" alt="image" src="https://github.com/user-attachments/assets/631ae779-d7a0-4b3d-8a50-f24245a1bb52" />
