### PR TITLE
Fix ui issue

### DIFF
--- a/frappe_theme/public/css/frappe_theme.css
+++ b/frappe_theme/public/css/frappe_theme.css
@@ -163,3 +163,16 @@
 .list-view .awesomplete > ul {
     z-index: 1000 !important;
 }
+
+/* page-head and its action dropdowns must sit above sticky table/list headers */
+.page-head {
+    /* position: relative; */
+    z-index: 20;
+}
+
+.page-head .dropdown-menu,
+.page-actions .dropdown-menu,
+.standard-actions .dropdown-menu,
+.page-head .dropdown-menu.show {
+    z-index: 1050 !important;
+}

--- a/frappe_theme/public/js/fields_overwrite/override_date_field.bundle.js
+++ b/frappe_theme/public/js/fields_overwrite/override_date_field.bundle.js
@@ -260,10 +260,14 @@ frappe.ui.form.ControlDate = class extends frappe.ui.form.ControlDate {
 				const dates = this.datepicker.selectedDates;
 				if (dates.length === 2) {
 					this._show_add_range_button();
-				} else {
+					this.$input.trigger("change");
+				} else if (dates.length === 0 && !this._adding_range) {
 					this._hide_add_range_button();
+					this.$input.trigger("change");
 				}
-				this.$input.trigger("change");
+				// dates.length === 1: user picked start date, end date not yet chosen —
+				// do not trigger change here; doing so calls set_value(null) → clears
+				// the input → aiDatepicker detects the empty input and auto-closes.
 			},
 		};
 		this.$input.datepicker(datepicker_options);


### PR DESCRIPTION
This pull request makes improvements to the z-index stacking order for page headers and dropdown menus in the `frappe_theme` CSS to ensure that dropdowns appear above sticky table or list headers.

**UI layering and dropdown fixes:**

* Increased the `z-index` of `.page-head` to 20 so that it sits above sticky table/list headers.
* Set the `z-index` of dropdown menus inside `.page-head`, `.page-actions`, and `.standard-actions` to 1050 to ensure dropdowns always appear above other UI elements.

---------