### PR TITLE
Add folder Rename and file Move-to-Folder actions in Gallery component

### DIFF
--- a/frappe_theme/api.py
+++ b/frappe_theme/api.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 from typing import Optional, Union
 
@@ -1617,6 +1618,36 @@ def upload_file_to_folder(
 
 	file_doc.save(ignore_permissions=False)
 	return file_doc.as_dict()
+
+
+UNSAFE_FOLDER_NAME_CHARS = re.compile(r'[~/\\%&#?<>"`*+]')
+
+
+@frappe.whitelist()
+def rename_folder(old_name: str, new_name: str):
+	"""Rename a gallery folder (a `File` doc with is_folder=1), keeping its docname
+	(and hence its children's `folder` links) in sync with the folder's display label.
+	"""
+	file_doc = frappe.get_doc("File", old_name)
+	if not file_doc.is_folder:
+		frappe.throw(_("{0} is not a folder").format(old_name))
+
+	new_display_name = (new_name or "").strip()
+	if not new_display_name:
+		frappe.throw(_("Folder name cannot be empty"))
+	if UNSAFE_FOLDER_NAME_CHARS.search(new_display_name):
+		frappe.throw(_("Folder name contains invalid characters"))
+
+	new_file_name_value = f"{file_doc.attached_to_name}~{new_display_name}"
+	new_docname = os.path.join(file_doc.folder, new_file_name_value)
+
+	if new_docname == old_name:
+		return {"name": old_name}
+
+	frappe.rename_doc("File", old_name, new_docname, force=True)
+	frappe.db.set_value("File", new_docname, "file_name", new_file_name_value)
+
+	return {"name": new_docname}
 
 
 @frappe.whitelist()

--- a/frappe_theme/api.py
+++ b/frappe_theme/api.py
@@ -1853,8 +1853,6 @@ def export_fixtures_runtime():
 	return frappe.as_json(export_data)
 
 
-import os
-
 from frappe.core.doctype.data_import.data_import import import_doc
 
 

--- a/frappe_theme/overrides/workflow.py
+++ b/frappe_theme/overrides/workflow.py
@@ -412,7 +412,7 @@ def _validate_dialog_fields(required_fields, doc):
 		missing = [f for f in required_fields if not wf_dialog_fields.get(f["fieldname"])]
 		if missing:
 			field_list = "".join(f"<li>{f['label']}</li>" for f in missing)
-			frappe.throw("Required workflow data is missing or incomplete." f"<br><ul>{field_list}</ul>")
+			frappe.throw(f"Required workflow data is missing or incomplete.<br><ul>{field_list}</ul>")
 
 	return wf_dialog_fields
 

--- a/frappe_theme/public/js/custom_components/gallery/gallery.bundle.js
+++ b/frappe_theme/public/js/custom_components/gallery/gallery.bundle.js
@@ -506,6 +506,80 @@ class SVAGalleryComponent {
 		return false;
 	}
 
+	_moveFileToFolder(fileId, currentFolder) {
+		const self = this;
+		let selectedFolder = currentFolder || "Home";
+
+		const moveDialog = new frappe.ui.Dialog({
+			title: __("Move to Folder"),
+			fields: [
+				{
+					fieldname: "folder_tree_wrapper",
+					fieldtype: "HTML",
+				},
+			],
+			primary_action_label: __("Move"),
+			async primary_action() {
+				if (selectedFolder === currentFolder) {
+					moveDialog.hide();
+					return;
+				}
+				try {
+					await frappe.db.set_value("File", fileId, "folder", selectedFolder);
+					moveDialog.hide();
+					frappe.show_alert({ message: __("File moved"), indicator: "green" });
+					await self.fetchFolders();
+					await self.fetchGalleryFiles();
+					self.render();
+				} catch (error) {
+					console.error("Error moving file:", error);
+				}
+			},
+		});
+
+		const renderTree = () => {
+			const folderTree = self._buildFolderTree(self.folders);
+			const $wrapper = moveDialog.fields_dict.folder_tree_wrapper.$wrapper;
+			$wrapper.html(`
+				<div class="folder-tree-container" style="max-height: 320px; overflow-y: auto; border: 1px solid var(--border-color); border-radius: 8px; padding: 8px 6px;">
+					${self._renderFolderTreeHTML(folderTree, selectedFolder)}
+				</div>
+			`);
+
+			$wrapper
+				.find(".folder-tree-item")
+				.off("click")
+				.on("click", function (e) {
+					if ($(e.target).hasClass("folder-toggle-arrow")) return;
+					selectedFolder = $(this).data("folder");
+					renderTree();
+				});
+
+			$wrapper
+				.find(".folder-toggle-arrow")
+				.off("click")
+				.on("click", function (e) {
+					e.stopPropagation();
+					const $item = $(this).closest(".folder-tree-item");
+					const folderPath = $item.data("folder");
+					const $children = $item.next(".folder-tree-children");
+					if (!self._expandedFolders) self._expandedFolders = new Set();
+					if ($children.is(":visible")) {
+						$children.slideUp(150);
+						$(this).removeClass("fa-chevron-down").addClass("fa-chevron-right");
+						self._expandedFolders.delete(folderPath);
+					} else {
+						$children.slideDown(150);
+						$(this).removeClass("fa-chevron-right").addClass("fa-chevron-down");
+						self._expandedFolders.add(folderPath);
+					}
+				});
+		};
+
+		moveDialog.show();
+		renderTree();
+	}
+
 	async _createNewFolder(parentFolder, uploadDialog) {
 		const self = this;
 		const newFolderDialog = new frappe.ui.Dialog({
@@ -1861,6 +1935,9 @@ class SVAGalleryComponent {
 					items.push(
 						`<div class="sva-popup-item sva-popup-edit" data-id="${fileId}" style="padding:8px 16px;cursor:pointer;display:flex;align-items:center;gap:8px;font-size:13px;color:var(--text-color);"><i class="fa fa-pencil text-muted"></i> Edit</div>`
 					);
+					items.push(
+						`<div class="sva-popup-item sva-popup-move" data-id="${fileId}" style="padding:8px 16px;cursor:pointer;display:flex;align-items:center;gap:8px;font-size:13px;color:var(--text-color);"><i class="fa fa-folder-o text-muted"></i> Move</div>`
+					);
 				}
 				if (canDelete) {
 					items.push(
@@ -1890,6 +1967,13 @@ class SVAGalleryComponent {
 					$popup.remove();
 					$container.removeClass("menu-active");
 					await self.renderForm("edit", $(this).data("id"));
+				});
+				$popup.find(".sva-popup-move").on("click", function () {
+					$popup.remove();
+					$container.removeClass("menu-active");
+					const fId = $(this).data("id");
+					const fileData = self.gallery_files.find((f) => f.name === fId);
+					self._moveFileToFolder(fId, fileData ? fileData.folder : "Home");
 				});
 				$popup.find(".sva-popup-delete").on("click", function () {
 					$popup.remove();

--- a/frappe_theme/public/js/custom_components/gallery/gallery_directory_view.js
+++ b/frappe_theme/public/js/custom_components/gallery/gallery_directory_view.js
@@ -365,6 +365,7 @@ export function applyDirectoryViewMixin(GalleryClass) {
 
 	GalleryClass.prototype._attachDirectoryEventListeners = function () {
 		const self = this;
+		const canWrite = this.permissions.includes("write");
 		const canDelete = this.permissions.includes("delete");
 
 		// Attach drag and drop handlers for folder cases
@@ -402,6 +403,11 @@ export function applyDirectoryViewMixin(GalleryClass) {
 
 				const rect = this.getBoundingClientRect();
 				const menuItems = [];
+				if (canWrite) {
+					menuItems.push(
+						`<div class="dir-popup-item dir-popup-rename" style="padding:8px 16px;cursor:pointer;display:flex;align-items:center;gap:8px;font-size:13px;color:var(--text-color);"><i class="fa fa-pencil"></i> Rename</div>`
+					);
+				}
 				if (canDelete) {
 					menuItems.push(
 						`<div class="dir-popup-item dir-popup-delete" style="padding:8px 16px;cursor:pointer;display:flex;align-items:center;gap:8px;font-size:13px;color:var(--red-500, #e74c3c);"><i class="fa fa-trash"></i> Delete</div>`
@@ -426,6 +432,11 @@ export function applyDirectoryViewMixin(GalleryClass) {
 				const $btn = $(this);
 				$btn.addClass("menu-active");
 
+				$popup.find(".dir-popup-rename").on("click", function () {
+					$popup.remove();
+					$btn.removeClass("menu-active");
+					self._renameFolder(folderDoc, displayName);
+				});
 				$popup.find(".dir-popup-delete").on("click", function () {
 					$popup.remove();
 					$btn.removeClass("menu-active");
@@ -603,6 +614,48 @@ export function applyDirectoryViewMixin(GalleryClass) {
 		} else {
 			frappe.msgprint(__("Failed to upload files"));
 		}
+	};
+
+	GalleryClass.prototype._renameFolder = function (folderDocName, displayName) {
+		const self = this;
+		const renameDialog = new frappe.ui.Dialog({
+			title: __("Rename Folder"),
+			fields: [
+				{
+					label: "Folder Name",
+					fieldname: "folder_name",
+					fieldtype: "Data",
+					reqd: 1,
+					default: displayName,
+				},
+			],
+			primary_action_label: __("Rename"),
+			async primary_action(values) {
+				try {
+					const newName = values.folder_name.trim();
+					if (!newName) {
+						frappe.msgprint(__("Please enter a folder name"));
+						return;
+					}
+					if (newName === displayName) {
+						renameDialog.hide();
+						return;
+					}
+					await frappe.call({
+						method: "frappe_theme.api.rename_folder",
+						args: { old_name: folderDocName, new_name: newName },
+					});
+					renameDialog.hide();
+					frappe.show_alert({ message: __("Folder renamed"), indicator: "green" });
+					await self.fetchFolders();
+					await self.fetchGalleryFiles();
+					self.render();
+				} catch (error) {
+					console.error("Error renaming folder:", error);
+				}
+			},
+		});
+		renameDialog.show();
 	};
 
 	GalleryClass.prototype._deleteFolder = function (folderDocName, displayName) {

--- a/frappe_theme/utils/test_sql_builder.py
+++ b/frappe_theme/utils/test_sql_builder.py
@@ -945,7 +945,7 @@ class TestSQLBuilderUserPermissions(unittest.TestCase):
 			},
 		)
 
-		sql = "SELECT * FROM `tabGrant` " "WHERE workflow_state IN %(states)s " "AND year = %(year)s"
+		sql = "SELECT * FROM `tabGrant` WHERE workflow_state IN %(states)s AND year = %(year)s"
 
 		with patch.dict(sys.modules, {"frappe": mock_frappe}):
 			result = SQLBuilder.apply(


### PR DESCRIPTION
## Summary
- Adds a "Rename" option to the folder 3-dot menu in the Gallery Directory View, alongside the existing "Delete" (renames the underlying File doc via `frappe.rename_doc(force=True)` since File doesn't have `allow_rename` set, and keeps `file_name` in sync).
- Adds a "Move" option to each file's 3-dot menu (alongside Edit/Delete) that opens a folder-tree picker (reusing the existing `_buildFolderTree`/`_renderFolderTreeHTML` helpers) and updates the file's `folder` field.

## Test plan
- [x] `bench build --app frappe_theme` and hard-refresh
- [ ] Rename a folder in a document's Files tab; confirm nested subfolders remain reachable afterward
- [ ] Move a file between folders via the new "Move" option; confirm file counts update on both folders
- [ ] Confirm both actions are hidden for a user without write permission on File