### PR TITLE
SVAVerticalDocRenderer + VDR table work, plus cached doc fetch fix

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(docker exec devcontainer_frappe_1 *)"
+    ]
+  }
+}

--- a/frappe_theme/apis/add_more_batch.py
+++ b/frappe_theme/apis/add_more_batch.py
@@ -5,7 +5,7 @@ from frappe import _
 
 
 @frappe.whitelist()
-def add_more_batch(doctype, filters, grouping_field, link_field=None):
+def add_more_batch(doctype, filters, grouping_field, link_field=None, copy_fields_only=None):
 	"""
 	Generic "Add More" batch duplication for SVAVerticalDocRenderer.
 
@@ -101,12 +101,28 @@ def add_more_batch(doctype, filters, grouping_field, link_field=None):
 	if not latest_batch:
 		return {"created": 0, "next_batch": next_batch, "names": []}
 
+	# When copy_fields_only is provided, only those fields are carried over.
+	# Otherwise all data fields are copied (original behaviour).
+	if isinstance(copy_fields_only, str):
+		import json as _json
+
+		try:
+			copy_fields_only = _json.loads(copy_fields_only)
+		except Exception:
+			copy_fields_only = None
+
+	allowed_copy = set(copy_fields_only) if copy_fields_only else None
+
 	# ── Duplicate each record in the latest batch ────────────────────────────
 	created_names = []
 	for record in latest_batch:
 		new_doc = frappe.new_doc(doctype)
 		for field in data_fieldnames:
-			if field != grouping_field and field in record:
+			if field == grouping_field:
+				continue
+			if allowed_copy is not None and field not in allowed_copy:
+				continue
+			if field in record:
 				new_doc.set(field, record[field])
 		new_doc.set(grouping_field, next_batch)
 		new_doc.insert(ignore_permissions=False)

--- a/frappe_theme/apis/add_more_batch.py
+++ b/frappe_theme/apis/add_more_batch.py
@@ -1,0 +1,157 @@
+import json
+
+import frappe
+from frappe import _
+
+
+@frappe.whitelist()
+def add_more_batch(doctype, filters, grouping_field, link_field=None):
+	"""
+	Generic "Add More" batch duplication for SVAVerticalDocRenderer.
+
+	Finds the latest batch (max grouping_field value) from existing records
+	that match `filters`, then duplicates every record in that batch with
+	grouping_field = max + 1.  All other field values are carried over as-is
+	so the new batch starts as an exact copy ready for editing.
+
+	Args:
+	    doctype (str):        Child DocType to duplicate records in.
+	    filters (str|list):   JSON-encoded frappe filter array.
+	    grouping_field (str): Field that identifies the batch (e.g. "batch_no").
+	    link_field (str|None): Field that links to the item/plot — used for
+	                           reference only, not required for duplication.
+
+	Returns:
+	    dict: {
+	        created   (int):      Number of new records inserted.
+	        next_batch (int):     Batch number assigned to the new records.
+	        names     (list[str]): Names of the newly created documents.
+	    }
+	"""
+	frappe.has_permission(doctype, "write", throw=True)
+
+	if isinstance(filters, str):
+		filters = json.loads(filters)
+
+	# ── Discover data fields from meta ──────────────────────────────────────
+	meta = frappe.get_meta(doctype)
+
+	SKIP_TYPES = {
+		"Section Break",
+		"Column Break",
+		"Tab Break",
+		"HTML",
+		"Button",
+		"Fold",
+		"Heading",
+		"Image",
+		"Signature",
+		"Barcode",
+	}
+	SYSTEM_FIELDS = {
+		"name",
+		"creation",
+		"modified",
+		"modified_by",
+		"owner",
+		"docstatus",
+		"idx",
+		"doctype",
+		"parent",
+		"parentfield",
+		"parenttype",
+		"amended_from",
+	}
+
+	data_fieldnames = [
+		df.fieldname
+		for df in meta.fields
+		if df.fieldtype not in SKIP_TYPES and df.fieldname not in SYSTEM_FIELDS
+	]
+
+	if not data_fieldnames:
+		frappe.throw(_("No data fields found for {0}").format(doctype))
+
+	fetch_fields = list({"name", grouping_field} | set(data_fieldnames))
+
+	# ── Fetch all records matching parent filters ────────────────────────────
+	records = frappe.db.get_all(
+		doctype,
+		filters=filters,
+		fields=fetch_fields,
+		limit=0,
+	)
+
+	if not records:
+		return {"created": 0, "next_batch": 1, "names": []}
+
+	# ── Find max batch value (supports integer batch numbers) ────────────────
+	def safe_int(v):
+		try:
+			return int(v or 0)
+		except (ValueError, TypeError):
+			return 0
+
+	max_batch = max(safe_int(r.get(grouping_field)) for r in records)
+	next_batch = max_batch + 1
+
+	latest_batch = [r for r in records if safe_int(r.get(grouping_field)) == max_batch]
+
+	if not latest_batch:
+		return {"created": 0, "next_batch": next_batch, "names": []}
+
+	# ── Duplicate each record in the latest batch ────────────────────────────
+	created_names = []
+	for record in latest_batch:
+		new_doc = frappe.new_doc(doctype)
+		for field in data_fieldnames:
+			if field != grouping_field and field in record:
+				new_doc.set(field, record[field])
+		new_doc.set(grouping_field, next_batch)
+		new_doc.insert(ignore_permissions=False)
+		created_names.append(new_doc.name)
+
+	frappe.db.commit()
+
+	return {
+		"created": len(created_names),
+		"next_batch": next_batch,
+		"names": created_names,
+	}
+
+
+@frappe.whitelist()
+def delete_batch_records(doctype, filters, grouping_field, batch_value):
+	"""
+	Delete all records belonging to a specific batch.
+
+	Args:
+	    doctype (str):         DocType to delete records from.
+	    filters (str|list):    JSON-encoded frappe filter array (parent filters).
+	    grouping_field (str):  Field that identifies the batch (e.g. "batch_no").
+	    batch_value:           Value of the batch to delete (e.g. 2).
+
+	Returns:
+	    dict: { deleted (int): number of records deleted }
+	"""
+	frappe.has_permission(doctype, "delete", throw=True)
+
+	if isinstance(filters, str):
+		filters = json.loads(filters)
+
+	# Coerce batch_value to int when it looks numeric
+	try:
+		batch_value = int(batch_value)
+	except (ValueError, TypeError):
+		pass
+
+	batch_filters = list(filters) + [[grouping_field, "=", batch_value]]
+	names = frappe.db.get_all(doctype, filters=batch_filters, pluck="name")
+
+	deleted = 0
+	for name in names:
+		frappe.delete_doc(doctype, name, ignore_permissions=False)
+		deleted += 1
+
+	frappe.db.commit()
+	return {"deleted": deleted}

--- a/frappe_theme/apis/add_more_batch.py
+++ b/frappe_theme/apis/add_more_batch.py
@@ -41,6 +41,7 @@ def add_more_batch(doctype, filters, grouping_field, link_field=None):
 		"Column Break",
 		"Tab Break",
 		"HTML",
+		"Table",
 		"Button",
 		"Fold",
 		"Heading",

--- a/frappe_theme/frappe_theme/doctype/custom_property_setter/custom_property_setter.json
+++ b/frappe_theme/frappe_theme/doctype/custom_property_setter/custom_property_setter.json
@@ -21,6 +21,19 @@
   "label",
   "info",
   "show_full_number",
+  "section_break_vdr",
+  "vdr_doctype",
+  "vdr_docs",
+  "vdr_column_configs",
+  "column_break_vdr",
+  "vdr_title",
+  "vdr_fields_to_show",
+  "vdr_fields_to_hide",
+  "vdr_show_sections",
+  "vdr_show_unit",
+  "vdr_hide_empty_rows",
+  "vdr_show_legend",
+  "vdr_legend_items",
   "column_break_fwyn",
   "section_break_ylfd",
   "sdg_report",
@@ -162,7 +175,7 @@
    "fieldname": "property_type",
    "fieldtype": "Select",
    "label": "Property Type",
-   "options": "\nCarousel\nDocType (Direct)\nDocType (Indirect)\nDocType (Referenced)\nDocType (Unfiltered)\nReport\nIs Custom Design\nHeatmap (India Map)\nSDG Wheel\nDocField\nNumber Card\nDashboard Chart\nCustom HTML Block"
+   "options": "\nCarousel\nDocType (Direct)\nDocType (Indirect)\nDocType (Referenced)\nDocType (Unfiltered)\nReport\nIs Custom Design\nHeatmap (India Map)\nSDG Wheel\nDocField\nNumber Card\nDashboard Chart\nCustom HTML Block\nVertical Doc Renderer"
   },
   {
    "depends_on": "eval:doc.property_type=='Dashboard Chart'",
@@ -838,6 +851,94 @@
    "fieldname": "show_full_number",
    "fieldtype": "Check",
    "label": "Show Full Number"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "fieldname": "section_break_vdr",
+   "fieldtype": "Section Break",
+   "hide_border": 1,
+   "label": "Vertical Doc Renderer"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "fieldname": "vdr_doctype",
+   "fieldtype": "Link",
+   "label": "Source DocType",
+   "mandatory_depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "options": "DocType"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "JSON array of document names, e.g. [\"DOC-001\", \"DOC-002\"]",
+   "fieldname": "vdr_docs",
+   "fieldtype": "Code",
+   "label": "Document Names"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "JSON array of {label, bg_color, text_color} — index-aligned to Document Names",
+   "fieldname": "vdr_column_configs",
+   "fieldtype": "Code",
+   "label": "Column Configs"
+  },
+  {
+   "fieldname": "column_break_vdr",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "fieldname": "vdr_title",
+   "fieldtype": "Data",
+   "label": "Title"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "JSON array of fieldnames to display. Leave empty to show all fields.",
+   "fieldname": "vdr_fields_to_show",
+   "fieldtype": "Code",
+   "label": "Fields to Show"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "JSON array of fieldnames to exclude",
+   "fieldname": "vdr_fields_to_hide",
+   "fieldtype": "Code",
+   "label": "Fields to Hide"
+  },
+  {
+   "default": "1",
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "fieldname": "vdr_show_sections",
+   "fieldtype": "Check",
+   "label": "Show Section Headers"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "fieldname": "vdr_show_unit",
+   "fieldtype": "Check",
+   "label": "Show Unit Column"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "fieldname": "vdr_hide_empty_rows",
+   "fieldtype": "Check",
+   "label": "Hide Empty Rows"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "fieldname": "vdr_show_legend",
+   "fieldtype": "Check",
+   "label": "Show Legend"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\" && doc.vdr_show_legend",
+   "description": "JSON array of {label, bg_color, text_color, description}",
+   "fieldname": "vdr_legend_items",
+   "fieldtype": "Code",
+   "label": "Legend Items"
   }
  ],
  "grid_page_length": 50,

--- a/frappe_theme/frappe_theme/doctype/custom_property_setter/custom_property_setter.json
+++ b/frappe_theme/frappe_theme/doctype/custom_property_setter/custom_property_setter.json
@@ -298,12 +298,12 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "eval:[\"DocType (Direct)\",\"DocType (Indirect)\",\"DocType (Unfiltered)\",\"DocType (Referenced)\",\"Report\", \"Is Custom Design\"].includes(doc.property_type) || doc.is_report === 1",
+   "depends_on": "eval:[\"DocType (Direct)\",\"DocType (Indirect)\",\"DocType (Unfiltered)\",\"DocType (Referenced)\",\"Report\", \"Is Custom Design\", \"Vertical Doc Renderer\"].includes(doc.property_type) || doc.is_report === 1",
    "fieldname": "section_break_qivk",
    "fieldtype": "Section Break"
   },
   {
-   "depends_on": "eval:doc.property_type != \"Is Custom Design\"",
+   "depends_on": "eval:doc.property_type != \"Is Custom Design\" && doc.property_type != \"Vertical Doc Renderer\"",
    "fieldname": "setup_list_settings",
    "fieldtype": "Button",
    "label": "Setup Listview Setting"

--- a/frappe_theme/frappe_theme/doctype/custom_property_setter/custom_property_setter.json
+++ b/frappe_theme/frappe_theme/doctype/custom_property_setter/custom_property_setter.json
@@ -25,19 +25,32 @@
   "vdr_doctype",
   "vdr_docs",
   "vdr_column_configs",
+  "setup_vdr_column_configs",
   "column_break_vdr",
   "vdr_title",
+  "vdr_column_label_field",
+  "vdr_column_bg_color",
+  "vdr_column_text_color",
   "vdr_fields_to_show",
   "vdr_fields_to_hide",
+  "vdr_link_title_fields",
   "vdr_show_sections",
+  "vdr_section_configs",
   "vdr_show_unit",
   "vdr_hide_empty_rows",
   "vdr_show_legend",
   "vdr_legend_items",
   "vdr_max_height",
+  "vdr_column_batch_size",
+  "vdr_column_width",
   "vdr_link_fieldname",
   "vdr_foreign_field",
+  "vdr_order_by",
+  "vdr_use_custom_script",
+  "vdr_custom_docs_script",
   "vdr_fields_config",
+  "setup_vdr_sub_tables",
+  "vdr_sub_tables",
   "column_break_fwyn",
   "section_break_ylfd",
   "sdg_report",
@@ -378,7 +391,7 @@
    "options": "Tasks\nEmail\nTimeline\nGallery\nNotes\nLinked Users\nApproval Request\nHTML View From API"
   },
   {
-   "depends_on": "eval:doc.property_type != \"Is Custom Design\"",
+   "depends_on": "eval:doc.property_type != \"Is Custom Design\" && doc.property_type != \"Vertical Doc Renderer\"",
    "fieldname": "listview_settings",
    "fieldtype": "Code",
    "label": "Listview Settings",
@@ -387,7 +400,7 @@
   },
   {
    "default": "[]",
-   "depends_on": "eval:doc.extend_condition == true",
+   "depends_on": "eval:doc.extend_condition == true && doc.property_type != \"Vertical Doc Renderer\"",
    "description": "Only Double Quote (\") is allowed in the conditions,\ne.g. [[\"dt\",\"fieldname\",\"operator\",\"value\"],[\"dt\",\"fieldname\",\"operator\",\"value\"]]",
    "fieldname": "extended_condition",
    "fieldtype": "Code",
@@ -396,7 +409,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:![\"Report\", \"Is Custom Design\"].includes(doc.property_type)",
+   "depends_on": "eval:![\"Report\", \"Is Custom Design\", \"Vertical Doc Renderer\"].includes(doc.property_type)",
    "fieldname": "extend_condition",
    "fieldtype": "Check",
    "label": "Extend Condition"
@@ -879,11 +892,17 @@
    "label": "Document Names"
   },
   {
-   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
-   "description": "JSON array of {label, bg_color, text_color} — index-aligned to Document Names",
+   "depends_on": "eval:false",
+   "description": "JSON array of {label, bg_color, text_color} — index-aligned to Document Names. Managed by Setup Column Configs button.",
    "fieldname": "vdr_column_configs",
    "fieldtype": "Code",
    "label": "Column Configs"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "fieldname": "setup_vdr_column_configs",
+   "fieldtype": "Button",
+   "label": "Setup Column Configs"
   },
   {
    "fieldname": "column_break_vdr",
@@ -894,6 +913,28 @@
    "fieldname": "vdr_title",
    "fieldtype": "Data",
    "label": "Title"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "Field from the source DocType whose value is used as each column header label (e.g. \"farmer_name\"). Leave empty to use the document name.",
+   "fieldname": "vdr_column_label_field",
+   "fieldtype": "Data",
+   "label": "Column Label Field",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "Default background color for all column headers (overridden per-column by Column Configs).",
+   "fieldname": "vdr_column_bg_color",
+   "fieldtype": "Color",
+   "label": "Column Background Color"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "Default text color for all column headers (overridden per-column by Column Configs).",
+   "fieldname": "vdr_column_text_color",
+   "fieldtype": "Color",
+   "label": "Column Text Color"
   },
   {
    "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
@@ -966,11 +1007,76 @@
    "label": "Foreign Field"
   },
   {
+   "default": "0",
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "fieldname": "vdr_use_custom_script",
+   "fieldtype": "Check",
+   "label": "Use Custom Script for Docs"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\" && doc.vdr_use_custom_script",
+   "description": "Async JS with access to `frm`. Must return `{ docs, column_configs }`. `docs` can be string[] (names), object[] (inline data), or null (auto-paginate). `column_configs` is [{label, bg_color, text_color}] index-aligned to docs.",
+   "fieldname": "vdr_custom_docs_script",
+   "fieldtype": "Code",
+   "label": "Custom Docs Script",
+   "options": "JS"
+  },
+  {
    "depends_on": "eval:false",
    "description": "JSON array of fieldnames in display order (managed by Setup Listview Setting button and in-table gear icon)",
    "fieldname": "vdr_fields_config",
    "fieldtype": "Code",
    "label": "Fields Config"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "fieldname": "setup_vdr_sub_tables",
+   "fieldtype": "Button",
+   "label": "Setup Sub-tables"
+  },
+  {
+   "depends_on": "eval:false",
+   "description": "JSON array of sub-table configs [{title, fields_config, collapsed}] (managed by Setup Sub-tables button)",
+   "fieldname": "vdr_sub_tables",
+   "fieldtype": "Code",
+   "label": "Sub-tables Config"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "JSON object keyed by Section Break fieldname or label. Values: {label, bg_color, text_color, collapsed, hidden}. e.g. {\"section_break_contact\": {\"label\": \"Contact Info\", \"collapsed\": true}}",
+   "fieldname": "vdr_section_configs",
+   "fieldtype": "Code",
+   "label": "Section Configs",
+   "max_height": "8rem"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "JSON object to override link field display names. Keys are linked DocType names, values are the field to use as display label. e.g. {\"District\": \"district_name\", \"Mandal\": \"mandal_name\"}",
+   "fieldname": "vdr_link_title_fields",
+   "fieldtype": "Code",
+   "label": "Link Title Fields",
+   "max_height": "6rem"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "Sort order when fetching documents from the server, e.g. \"creation desc\" or \"employee_name asc\". Used when no static doc list is set.",
+   "fieldname": "vdr_order_by",
+   "fieldtype": "Data",
+   "label": "Order By"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "Number of columns to render per scroll batch. 0 = auto-calculate from viewport width.",
+   "fieldname": "vdr_column_batch_size",
+   "fieldtype": "Int",
+   "label": "Column Batch Size"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "Column width in px used for auto batch size calculation. Default: 150.",
+   "fieldname": "vdr_column_width",
+   "fieldtype": "Int",
+   "label": "Column Width (px)"
   }
  ],
  "grid_page_length": 50,

--- a/frappe_theme/frappe_theme/doctype/custom_property_setter/custom_property_setter.json
+++ b/frappe_theme/frappe_theme/doctype/custom_property_setter/custom_property_setter.json
@@ -57,6 +57,8 @@
   "vdr_fields_config",
   "setup_vdr_batch_config",
   "vdr_batch_config",
+  "setup_vdr_child_add_row_labels",
+  "vdr_child_add_row_labels",
   "section_break_ylfd",
   "sdg_report",
   "sdg_name_column",
@@ -1041,6 +1043,17 @@
    "fieldname": "vdr_batch_config",
    "fieldtype": "Code",
    "label": "Batch Config"
+  },
+  {
+   "fieldname": "setup_vdr_child_add_row_labels",
+   "fieldtype": "Button",
+   "label": "Setup Child Table Labels"
+  },
+  {
+   "fieldname": "vdr_child_add_row_labels",
+   "fieldtype": "Code",
+   "hidden": 1,
+   "label": "Child Table Add Row Labels"
   },
   {
    "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",

--- a/frappe_theme/frappe_theme/doctype/custom_property_setter/custom_property_setter.json
+++ b/frappe_theme/frappe_theme/doctype/custom_property_setter/custom_property_setter.json
@@ -34,6 +34,10 @@
   "vdr_hide_empty_rows",
   "vdr_show_legend",
   "vdr_legend_items",
+  "vdr_max_height",
+  "vdr_link_fieldname",
+  "vdr_foreign_field",
+  "vdr_fields_config",
   "column_break_fwyn",
   "section_break_ylfd",
   "sdg_report",
@@ -303,7 +307,7 @@
    "fieldtype": "Section Break"
   },
   {
-   "depends_on": "eval:doc.property_type != \"Is Custom Design\" && doc.property_type != \"Vertical Doc Renderer\"",
+   "depends_on": "eval:doc.property_type != \"Is Custom Design\"",
    "fieldname": "setup_list_settings",
    "fieldtype": "Button",
    "label": "Setup Listview Setting"
@@ -868,7 +872,7 @@
    "options": "DocType"
   },
   {
-   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "depends_on": "eval:false",
    "description": "JSON array of document names, e.g. [\"DOC-001\", \"DOC-002\"]",
    "fieldname": "vdr_docs",
    "fieldtype": "Code",
@@ -939,6 +943,34 @@
    "fieldname": "vdr_legend_items",
    "fieldtype": "Code",
    "label": "Legend Items"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "Max height in px for the scrollable table area. 0 = no limit.",
+   "fieldname": "vdr_max_height",
+   "fieldtype": "Int",
+   "label": "Max Height (px)"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "Field on the parent form whose value is used to filter the source DocType (e.g. 'employee' → show only records where the foreign field matches frm.doc.employee)",
+   "fieldname": "vdr_link_fieldname",
+   "fieldtype": "Data",
+   "label": "Parent Link Field"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\" && doc.vdr_link_fieldname",
+   "description": "Field on the source DocType to match against the parent link field value. Defaults to 'name' if empty.",
+   "fieldname": "vdr_foreign_field",
+   "fieldtype": "Data",
+   "label": "Foreign Field"
+  },
+  {
+   "depends_on": "eval:false",
+   "description": "JSON array of fieldnames in display order (managed by Setup Listview Setting button and in-table gear icon)",
+   "fieldname": "vdr_fields_config",
+   "fieldtype": "Code",
+   "label": "Fields Config"
   }
  ],
  "grid_page_length": 50,

--- a/frappe_theme/frappe_theme/doctype/custom_property_setter/custom_property_setter.json
+++ b/frappe_theme/frappe_theme/doctype/custom_property_setter/custom_property_setter.json
@@ -43,14 +43,15 @@
   "vdr_max_height",
   "vdr_column_batch_size",
   "vdr_column_width",
+  "vdr_label_width",
   "vdr_link_fieldname",
   "vdr_foreign_field",
   "vdr_order_by",
   "vdr_use_custom_script",
   "vdr_custom_docs_script",
   "vdr_fields_config",
-  "setup_vdr_sub_tables",
-  "vdr_sub_tables",
+  "setup_vdr_batch_config",
+  "vdr_batch_config",
   "column_break_fwyn",
   "section_break_ylfd",
   "sdg_report",
@@ -1030,16 +1031,16 @@
   },
   {
    "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
-   "fieldname": "setup_vdr_sub_tables",
+   "fieldname": "setup_vdr_batch_config",
    "fieldtype": "Button",
-   "label": "Setup Sub-tables"
+   "label": "Setup Batch Config"
   },
   {
    "depends_on": "eval:false",
-   "description": "JSON array of sub-table configs [{title, fields_config, collapsed}] (managed by Setup Sub-tables button)",
-   "fieldname": "vdr_sub_tables",
+   "description": "JSON batch config {allow_add_more_table, add_more_button_label, add_more_doctype, grouping_field, plot_link_field, default_collapsed_new_table, batch_title_prefix} — managed by Setup Batch Config button",
+   "fieldname": "vdr_batch_config",
    "fieldtype": "Code",
-   "label": "Sub-tables Config"
+   "label": "Batch Config"
   },
   {
    "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
@@ -1077,6 +1078,13 @@
    "fieldname": "vdr_column_width",
    "fieldtype": "Int",
    "label": "Column Width (px)"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "Width of the Parameters (label) column in px. Default: 160. Remaining table width is distributed equally among data columns.",
+   "fieldname": "vdr_label_width",
+   "fieldtype": "Int",
+   "label": "Parameter Column Width (px)"
   }
  ],
  "grid_page_length": 50,

--- a/frappe_theme/frappe_theme/doctype/custom_property_setter/custom_property_setter.json
+++ b/frappe_theme/frappe_theme/doctype/custom_property_setter/custom_property_setter.json
@@ -34,25 +34,29 @@
   "vdr_fields_to_show",
   "vdr_fields_to_hide",
   "vdr_link_title_fields",
+  "vdr_column_color_rules",
+  "vdr_column_order_rules",
   "vdr_show_sections",
   "vdr_section_configs",
   "vdr_show_unit",
   "vdr_hide_empty_rows",
   "vdr_show_legend",
   "vdr_legend_items",
+  "column_break_jxsm",
   "vdr_max_height",
   "vdr_column_batch_size",
   "vdr_column_width",
   "vdr_label_width",
+  "vdr_table_max_rows",
   "vdr_link_fieldname",
   "vdr_foreign_field",
   "vdr_order_by",
+  "vdr_extra_filters",
   "vdr_use_custom_script",
   "vdr_custom_docs_script",
   "vdr_fields_config",
   "setup_vdr_batch_config",
   "vdr_batch_config",
-  "column_break_fwyn",
   "section_break_ylfd",
   "sdg_report",
   "sdg_name_column",
@@ -309,10 +313,6 @@
   },
   {
    "fieldname": "column_break_vafi",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "column_break_fwyn",
    "fieldtype": "Column Break"
   },
   {
@@ -894,7 +894,7 @@
   },
   {
    "depends_on": "eval:false",
-   "description": "JSON array of {label, bg_color, text_color} — index-aligned to Document Names. Managed by Setup Column Configs button.",
+   "description": "JSON array of {label, bg_color, text_color} \u2014 index-aligned to Document Names. Managed by Setup Column Configs button.",
    "fieldname": "vdr_column_configs",
    "fieldtype": "Code",
    "label": "Column Configs"
@@ -995,7 +995,7 @@
   },
   {
    "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
-   "description": "Field on the parent form whose value is used to filter the source DocType (e.g. 'employee' → show only records where the foreign field matches frm.doc.employee)",
+   "description": "Field on the parent form whose value is used to filter the source DocType (e.g. 'employee' \u2192 show only records where the foreign field matches frm.doc.employee)",
    "fieldname": "vdr_link_fieldname",
    "fieldtype": "Data",
    "label": "Parent Link Field"
@@ -1037,7 +1037,7 @@
   },
   {
    "depends_on": "eval:false",
-   "description": "JSON batch config {allow_add_more_table, add_more_button_label, add_more_doctype, grouping_field, plot_link_field, default_collapsed_new_table, batch_title_prefix} — managed by Setup Batch Config button",
+   "description": "JSON batch config {allow_add_more_table, add_more_button_label, add_more_doctype, grouping_field, plot_link_field, default_collapsed_new_table, batch_title_prefix} \u2014 managed by Setup Batch Config button",
    "fieldname": "vdr_batch_config",
    "fieldtype": "Code",
    "label": "Batch Config"
@@ -1060,10 +1060,36 @@
   },
   {
    "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "JSON array of color rules applied to column headers. Each rule: {key, bg_color, text_color, priority}. key is matched (case-insensitive) as a substring of the column label; highest priority wins when multiple keys match. e.g. [{\"key\":\"NF\",\"bg_color\":\"#7391c5\",\"priority\":0},{\"key\":\"Matured-NF\",\"bg_color\":\"#7da860\",\"priority\":1}]",
+   "fieldname": "vdr_column_color_rules",
+   "fieldtype": "Code",
+   "label": "Column Color Rules",
+   "max_height": "8rem"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "JSON array of ordering rules for columns. Each rule: {key, order, priority}. key is matched (case-insensitive) as a substring of the column label; order is numeric position (lower = first); highest priority wins when multiple keys match. Unmatched columns go to end. e.g. [{\"key\":\"CF\",\"order\":1},{\"key\":\"NF\",\"order\":2,\"priority\":0},{\"key\":\"Matured-NF\",\"order\":3,\"priority\":1}]",
+   "fieldname": "vdr_column_order_rules",
+   "fieldtype": "Code",
+   "label": "Column Order Rules",
+   "max_height": "8rem",
+   "options": "JSON"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
    "description": "Sort order when fetching documents from the server, e.g. \"creation desc\" or \"employee_name asc\". Used when no static doc list is set.",
    "fieldname": "vdr_order_by",
    "fieldtype": "Data",
    "label": "Order By"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "JSON filter array merged with existing filters. Use \"{frm.doc.fieldname}\" to reference the current form's field value. e.g. [[\"research_context\",\"=\",\"{frm.doc.research_context}\"],[\"status\",\"=\",\"Active\"]]",
+   "fieldname": "vdr_extra_filters",
+   "fieldtype": "Code",
+   "label": "Extra Filters",
+   "max_height": "6rem",
+   "options": "JSON"
   },
   {
    "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
@@ -1085,13 +1111,24 @@
    "fieldname": "vdr_label_width",
    "fieldtype": "Int",
    "label": "Parameter Column Width (px)"
+  },
+  {
+   "depends_on": "eval:doc.property_type == \"Vertical Doc Renderer\"",
+   "description": "Max rows allowed per Table field. Set to 1 to skip the row-listing dialog and open the single row directly on click.",
+   "fieldname": "vdr_table_max_rows",
+   "fieldtype": "Int",
+   "label": "Table Field Max Rows"
+  },
+  {
+   "fieldname": "column_break_jxsm",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_virtual": 1,
  "links": [],
- "modified": "2026-03-30 12:54:41.025050",
+ "modified": "2026-05-01 11:49:18.733929",
  "modified_by": "Administrator",
  "module": "Frappe Theme",
  "name": "Custom Property Setter",

--- a/frappe_theme/frappe_theme/doctype/my_theme/my_theme.py
+++ b/frappe_theme/frappe_theme/doctype/my_theme/my_theme.py
@@ -64,8 +64,10 @@ class MyTheme(Document):
 		else:
 			return False
 
-	def get_request_post(self, url, data=None, headers=None, json=None, params=None, timeout=None):
-		return requests.post(url, data=data, headers=headers, json=json, params=params, timeout=timeout)
+	def get_request_post(self, url, data=None, headers=None, json=None, params=None, timeout=None, auth=None):
+		return requests.post(
+			url, data=data, headers=headers, json=json, params=params, timeout=timeout, auth=auth
+		)
 
 	def get_request_get(self, url, headers=None, params=None, timeout=None):
 		return requests.get(url, headers=headers, params=params, timeout=timeout)

--- a/frappe_theme/public/js/doctype/property_setter.js
+++ b/frappe_theme/public/js/doctype/property_setter.js
@@ -275,6 +275,20 @@ const field_changes = {
 
 		let carousel_fields_being_affected = [{ fn: "carousel", ft: "Table" }];
 
+		let vdr_fields_being_affected = [
+			{ fn: "vdr_doctype", ft: "Link" },
+			{ fn: "vdr_docs", ft: "Code" },
+			{ fn: "vdr_column_configs", ft: "Code" },
+			{ fn: "vdr_title", ft: "Data" },
+			{ fn: "vdr_fields_to_show", ft: "Code" },
+			{ fn: "vdr_fields_to_hide", ft: "Code" },
+			{ fn: "vdr_show_sections", ft: "Check" },
+			{ fn: "vdr_show_unit", ft: "Check" },
+			{ fn: "vdr_hide_empty_rows", ft: "Check" },
+			{ fn: "vdr_show_legend", ft: "Check" },
+			{ fn: "vdr_legend_items", ft: "Code" },
+		];
+
 		let connecttion_type_map = {
 			"DocType (Indirect)": "Indirect",
 			"DocType (Direct)": "Direct",
@@ -289,6 +303,7 @@ const field_changes = {
 			clear_fields(frm?.config_dialog, heat_map_fields_being_affected);
 			clear_fields(frm?.config_dialog, number_card_fields_being_affected);
 			clear_fields(frm?.config_dialog, carousel_fields_being_affected);
+			clear_fields(frm?.config_dialog, vdr_fields_being_affected);
 			frm?.config_dialog.set_value("html_block", "");
 			frm?.config_dialog.set_value("chart", "");
 		}

--- a/frappe_theme/public/js/doctype/property_setter.js
+++ b/frappe_theme/public/js/doctype/property_setter.js
@@ -287,6 +287,7 @@ const field_changes = {
 			{ fn: "vdr_hide_empty_rows", ft: "Check" },
 			{ fn: "vdr_show_legend", ft: "Check" },
 			{ fn: "vdr_legend_items", ft: "Code" },
+			{ fn: "crud_permissions", ft: "Code" },
 		];
 
 		let connecttion_type_map = {

--- a/frappe_theme/public/js/doctype/property_setter.js
+++ b/frappe_theme/public/js/doctype/property_setter.js
@@ -279,18 +279,29 @@ const field_changes = {
 			{ fn: "vdr_doctype", ft: "Link" },
 			{ fn: "vdr_docs", ft: "Code" },
 			{ fn: "vdr_column_configs", ft: "Code" },
+			{ fn: "vdr_column_label_field", ft: "Data" },
+			{ fn: "vdr_column_bg_color", ft: "Color" },
+			{ fn: "vdr_column_text_color", ft: "Color" },
 			{ fn: "vdr_title", ft: "Data" },
 			{ fn: "vdr_fields_to_show", ft: "Code" },
 			{ fn: "vdr_fields_to_hide", ft: "Code" },
+			{ fn: "vdr_link_title_fields", ft: "Code" },
 			{ fn: "vdr_show_sections", ft: "Check" },
+			{ fn: "vdr_section_configs", ft: "Code" },
 			{ fn: "vdr_show_unit", ft: "Check" },
 			{ fn: "vdr_hide_empty_rows", ft: "Check" },
 			{ fn: "vdr_show_legend", ft: "Check" },
 			{ fn: "vdr_legend_items", ft: "Code" },
 			{ fn: "vdr_max_height", ft: "Int" },
+			{ fn: "vdr_column_batch_size", ft: "Int" },
+			{ fn: "vdr_column_width", ft: "Int" },
 			{ fn: "vdr_link_fieldname", ft: "Data" },
 			{ fn: "vdr_foreign_field", ft: "Data" },
+			{ fn: "vdr_order_by", ft: "Data" },
+			{ fn: "vdr_use_custom_script", ft: "Check" },
+			{ fn: "vdr_custom_docs_script", ft: "Code" },
 			{ fn: "vdr_fields_config", ft: "Code" },
+			{ fn: "vdr_sub_tables", ft: "Code" },
 			{ fn: "crud_permissions", ft: "Code" },
 		];
 
@@ -453,8 +464,92 @@ const field_changes = {
 	setup_list_settings: function (frm) {
 		set_list_settings(frm.config_dialog);
 	},
+	setup_vdr_sub_tables: function (frm) {
+		set_vdr_sub_tables(frm.config_dialog);
+	},
 	setup_crud_permissions: function (frm) {
 		set_crud_permissiions(frm.config_dialog);
+	},
+	setup_vdr_column_configs: async function (frm) {
+		const row = frm.config_dialog.get_values(true, false);
+		if (!row.vdr_doctype) {
+			frappe.msgprint({
+				message: __("Please set the Source DocType first."),
+				indicator: "orange",
+			});
+			return;
+		}
+		const dtmeta = await frappe.call({
+			method: "frappe_theme.dt_api.get_meta_fields",
+			args: { doctype: row.vdr_doctype, _type: "Direct" },
+		});
+		const SKIP = new Set([
+			"Section Break",
+			"Column Break",
+			"Tab Break",
+			"HTML",
+			"Button",
+			"Fold",
+			"Image",
+			"Signature",
+			"Geolocation",
+			"Barcode",
+			"Table",
+		]);
+		const field_options = [{ label: __("— document name —"), value: "" }].concat(
+			(dtmeta.message || [])
+				.filter((f) => !SKIP.has(f.fieldtype))
+				.map((f) => ({
+					label: `${f.label || f.fieldname} (${f.fieldname})`,
+					value: f.fieldname,
+				}))
+		);
+		const dialog = new frappe.ui.Dialog({
+			title: __("Setup Column Configs"),
+			fields: [
+				{
+					label: __("Column Label Field"),
+					fieldname: "column_label_field",
+					fieldtype: "Select",
+					options: field_options,
+					default: row.vdr_column_label_field || "",
+					description: __(
+						"Field from the source DocType to use as each column header label. Leave blank to use the document name."
+					),
+				},
+				{ fieldtype: "Column Break" },
+				{
+					label: __("Column Background Color"),
+					fieldname: "column_bg_color",
+					fieldtype: "Color",
+					default: row.vdr_column_bg_color || "#4472C4",
+				},
+				{
+					label: __("Column Text Color"),
+					fieldname: "column_text_color",
+					fieldtype: "Color",
+					default: row.vdr_column_text_color || "#ffffff",
+				},
+			],
+			primary_action_label: __("Save"),
+			primary_action: async (values) => {
+				frm.config_dialog.set_value(
+					"vdr_column_label_field",
+					values.column_label_field || ""
+				);
+				frm.config_dialog.set_value("vdr_column_bg_color", values.column_bg_color || "");
+				frm.config_dialog.set_value(
+					"vdr_column_text_color",
+					values.column_text_color || ""
+				);
+				dialog.hide();
+			},
+		});
+		dialog.show();
+		frm.config_dialog.wrapper.append(`<div class="modal-backdrop fade show"></div>`);
+		dialog.on_hide = () => {
+			frm.config_dialog.wrapper.find(".modal-backdrop").remove();
+		};
 	},
 	setup_action_list: function (frm) {
 		let row = frm.config_dialog.get_values(true, false);
@@ -753,6 +848,9 @@ const child_table_field_changes = {
 	setup_list_settings: function (frm) {
 		set_list_settings(frm.child_dialog);
 	},
+	setup_vdr_sub_tables: function (frm) {
+		set_vdr_sub_tables(frm.child_dialog);
+	},
 	setup_crud_permissions: function (frm) {
 		set_crud_permissiions(frm.child_dialog);
 	},
@@ -764,7 +862,7 @@ const child_table_field_changes = {
 const set_list_settings = async (dialog) => {
 	let row = dialog.get_values(true, false);
 
-	// VDR: use vdr_doctype; store result in vdr_fields_config
+	// VDR: custom field-row picker (not SVAListSettings which is for Datatable columns)
 	if (row.property_type === "Vertical Doc Renderer") {
 		if (!row.vdr_doctype) {
 			frappe.msgprint({
@@ -773,29 +871,185 @@ const set_list_settings = async (dialog) => {
 			});
 			return;
 		}
-		let dtmeta = await frappe.call({
+
+		const dtmeta = await frappe.call({
 			method: "frappe_theme.dt_api.get_meta_fields",
 			args: { doctype: row.vdr_doctype, _type: "Direct" },
 		});
-		frappe.require("list_settings.bundle.js").then(() => {
-			let d = new frappe.ui.SVAListSettings({
-				doctype: row.vdr_doctype,
-				meta: dtmeta.message,
-				connection_type: "Direct",
-				settings: row,
-				dialog_primary_action: async (listview_settings) => {
-					// listview_settings is an array of {fieldname, label, ...}
-					// extract ordered fieldnames for vdr_fields_config
-					const fieldsConfig = listview_settings.map((f) => f.fieldname || f.field);
-					dialog.set_value("vdr_fields_config", JSON.stringify(fieldsConfig));
-					frappe.show_alert({ message: __("Row settings updated"), indicator: "green" });
-				},
+
+		// get_meta_fields without meta_attached returns a flat fields array
+		const SKIP_TYPES = new Set([
+			"Column Break",
+			"HTML",
+			"Button",
+			"Fold",
+			"Image",
+			"Signature",
+			"Geolocation",
+			"Barcode",
+			"Tab Break",
+			"Section Break",
+		]);
+		const allFields = (dtmeta.message || []).filter(
+			(f) => !SKIP_TYPES.has(f.fieldtype) && !f.hidden
+		);
+
+		if (!allFields.length) {
+			frappe.msgprint({
+				message: __("No configurable fields found for the selected DocType."),
+				indicator: "orange",
 			});
-			dialog.wrapper.append(`<div class="modal-backdrop fade show"></div>`);
-			d.dialog.on_hide = () => {
-				dialog.wrapper.find(".modal-backdrop").remove();
-			};
+			return;
+		}
+
+		// Pre-populate from existing vdr_fields_config
+		let existingConfig = [];
+		try {
+			existingConfig = JSON.parse(row.vdr_fields_config || "[]");
+		} catch {
+			existingConfig = [];
+		}
+
+		let orderedFields;
+		if (existingConfig.length) {
+			const fieldMap = new Map(allFields.map((f) => [f.fieldname, f]));
+			const configSet = new Set(existingConfig);
+			orderedFields = [
+				...existingConfig
+					.map((fn) => fieldMap.get(fn))
+					.filter(Boolean)
+					.map((f) => ({ f, checked: true })),
+				...allFields
+					.filter((f) => !configSet.has(f.fieldname))
+					.map((f) => ({ f, checked: false })),
+			];
+		} else {
+			orderedFields = allFields.map((f) => ({ f, checked: true }));
+		}
+
+		const listHtml = orderedFields
+			.map(
+				({ f, checked }) => `
+			<div class="sva-vdr-ls-item" data-fieldname="${f.fieldname}" style="
+				display:flex;align-items:center;gap:8px;padding:6px 10px;margin-bottom:2px;
+				background:var(--control-bg,#f8f9fa);border:1px solid var(--border-color,#d1d8dd);
+				border-radius:4px;cursor:grab;user-select:none;
+			">
+				<span class="sva-vdr-ls-handle" style="color:var(--text-muted,#888);font-size:16px;line-height:1;flex-shrink:0;">≡</span>
+				<input type="checkbox" class="sva-vdr-ls-check" ${checked ? "checked" : ""}
+					style="margin:0;cursor:pointer;width:14px;height:14px;flex-shrink:0;" />
+				<span style="font-size:13px;color:var(--text-color,#333);flex:1;">${__(
+					f.label || f.fieldname
+				)}</span>
+				<span style="font-size:11px;color:var(--text-muted,#888);">${f.fieldtype}</span>
+			</div>`
+			)
+			.join("");
+
+		const vdr_ls_dialog = new frappe.ui.Dialog({
+			title: __("Configure Field Rows — {0}", [row.vdr_doctype]),
+			fields: [
+				{
+					fieldname: "hint",
+					fieldtype: "HTML",
+					options: `<p style="color:var(--text-muted,#888);font-size:12px;margin:0 0 10px 0;">
+						${__("Drag ≡ to reorder. Uncheck to hide a row.")}
+					</p>`,
+				},
+				{
+					fieldname: "field_list",
+					fieldtype: "HTML",
+					options: `<div class="sva-vdr-ls-list" style="max-height:460px;overflow-y:auto;padding:2px 0;">${listHtml}</div>`,
+				},
+			],
+			primary_action_label: __("Save"),
+			primary_action() {
+				const listEl = vdr_ls_dialog.$wrapper[0].querySelector(".sva-vdr-ls-list");
+				if (!listEl) return;
+
+				const newConfig = [];
+				listEl.querySelectorAll(".sva-vdr-ls-item").forEach((item) => {
+					const cb = item.querySelector(".sva-vdr-ls-check");
+					if (cb && cb.checked) newConfig.push(item.dataset.fieldname);
+				});
+
+				if (!newConfig.length) {
+					frappe.msgprint({
+						message: __("Select at least one field to display."),
+						indicator: "red",
+					});
+					return;
+				}
+
+				dialog.set_value("vdr_fields_config", JSON.stringify(newConfig));
+				frappe.show_alert({ message: __("Row settings updated"), indicator: "green" });
+				vdr_ls_dialog.hide();
+			},
+			secondary_action_label: __("Select All"),
+			secondary_action() {
+				const listEl = vdr_ls_dialog.$wrapper[0].querySelector(".sva-vdr-ls-list");
+				if (!listEl) return;
+				listEl.querySelectorAll(".sva-vdr-ls-check").forEach((cb) => {
+					cb.checked = true;
+				});
+			},
 		});
+
+		vdr_ls_dialog.show();
+		dialog.wrapper.append(`<div class="modal-backdrop fade show"></div>`);
+		vdr_ls_dialog.on_hide = () => {
+			dialog.wrapper.find(".modal-backdrop").remove();
+		};
+
+		// Frappe HTML fields render synchronously before show() returns — init DnD immediately
+		const _vdrListEl = vdr_ls_dialog.$wrapper[0].querySelector(".sva-vdr-ls-list");
+		if (_vdrListEl) {
+			if (typeof Sortable !== "undefined") {
+				new Sortable(_vdrListEl, {
+					handle: ".sva-vdr-ls-handle",
+					draggable: ".sva-vdr-ls-item",
+					animation: 120,
+				});
+			} else {
+				// Native HTML5 DnD fallback when Sortable.js is not available
+				let _dragSrc = null;
+				_vdrListEl.querySelectorAll(".sva-vdr-ls-item").forEach((item) => {
+					item.setAttribute("draggable", "true");
+					item.addEventListener("dragstart", (e) => {
+						_dragSrc = item;
+						e.dataTransfer.effectAllowed = "move";
+						item.style.opacity = "0.4";
+					});
+					item.addEventListener("dragend", () => {
+						item.style.opacity = "";
+						_vdrListEl
+							.querySelectorAll(".sva-vdr-ls-item")
+							.forEach((i) => (i.style.outline = ""));
+					});
+					item.addEventListener("dragover", (e) => {
+						e.preventDefault();
+						e.dataTransfer.dropEffect = "move";
+						_vdrListEl
+							.querySelectorAll(".sva-vdr-ls-item")
+							.forEach((i) => (i.style.outline = ""));
+						item.style.outline = "2px solid var(--primary,#2490ef)";
+					});
+					item.addEventListener("drop", (e) => {
+						e.preventDefault();
+						item.style.outline = "";
+						if (_dragSrc && _dragSrc !== item) {
+							const allItems = [..._vdrListEl.querySelectorAll(".sva-vdr-ls-item")];
+							if (allItems.indexOf(_dragSrc) < allItems.indexOf(item)) {
+								item.after(_dragSrc);
+							} else {
+								item.before(_dragSrc);
+							}
+						}
+					});
+				});
+			}
+		}
+
 		return;
 	}
 
@@ -838,6 +1092,368 @@ const set_list_settings = async (dialog) => {
 		};
 	});
 };
+// ─── VDR Sub-tables Setup ─────────────────────────────────────────────────────
+
+const set_vdr_sub_tables = async (dialog) => {
+	const row = dialog.get_values(true, false);
+
+	if (!row.vdr_doctype) {
+		frappe.msgprint({
+			message: __("Please set the Source DocType first."),
+			indicator: "orange",
+		});
+		return;
+	}
+
+	const dtmeta = await frappe.call({
+		method: "frappe_theme.dt_api.get_meta_fields",
+		args: { doctype: row.vdr_doctype, _type: "Direct" },
+	});
+
+	const SKIP_TYPES = new Set([
+		"Column Break",
+		"HTML",
+		"Button",
+		"Fold",
+		"Image",
+		"Signature",
+		"Geolocation",
+		"Barcode",
+		"Tab Break",
+		"Section Break",
+	]);
+	const allFields = (dtmeta.message || []).filter(
+		(f) => !SKIP_TYPES.has(f.fieldtype) && !f.hidden
+	);
+
+	if (!allFields.length) {
+		frappe.msgprint({ message: __("No configurable fields found."), indicator: "orange" });
+		return;
+	}
+
+	// Parse existing sub-tables config
+	let stConfigs = [];
+	try {
+		stConfigs = JSON.parse(row.vdr_sub_tables || "[]");
+	} catch {
+		stConfigs = [];
+	}
+	if (!stConfigs.length) {
+		stConfigs = [{ title: __("Table 1"), fields_config: [], collapsed: false }];
+	}
+	stConfigs = stConfigs.map((st) => ({
+		title: st.title || "",
+		fields_config: Array.isArray(st.fields_config) ? st.fields_config : [],
+		collapsed: !!st.collapsed,
+	}));
+
+	// ── Shared DnD helper ──────────────────────────────────────────────────────
+	function _attachNativeDnD(listEl, itemSelector) {
+		let _dragSrc = null;
+		listEl.querySelectorAll(itemSelector).forEach((item) => {
+			item.setAttribute("draggable", "true");
+			item.addEventListener("dragstart", (e) => {
+				_dragSrc = item;
+				e.dataTransfer.effectAllowed = "move";
+				item.style.opacity = "0.4";
+			});
+			item.addEventListener("dragend", () => {
+				item.style.opacity = "";
+				listEl.querySelectorAll(itemSelector).forEach((i) => (i.style.outline = ""));
+			});
+			item.addEventListener("dragover", (e) => {
+				e.preventDefault();
+				e.dataTransfer.dropEffect = "move";
+				listEl.querySelectorAll(itemSelector).forEach((i) => (i.style.outline = ""));
+				item.style.outline = "2px solid var(--primary,#2490ef)";
+			});
+			item.addEventListener("drop", (e) => {
+				e.preventDefault();
+				item.style.outline = "";
+				if (_dragSrc && _dragSrc !== item) {
+					const all = [...listEl.querySelectorAll(itemSelector)];
+					if (all.indexOf(_dragSrc) < all.indexOf(item)) item.after(_dragSrc);
+					else item.before(_dragSrc);
+				}
+			});
+		});
+	}
+
+	// ── Field-picker sub-dialog ────────────────────────────────────────────────
+	function openFieldPicker(idx, parentDialog) {
+		const st = stConfigs[idx];
+		const existing = st.fields_config || [];
+
+		let orderedFields;
+		if (existing.length) {
+			const fieldMap = new Map(allFields.map((f) => [f.fieldname, f]));
+			const existSet = new Set(existing);
+			orderedFields = [
+				...existing
+					.map((fn) => fieldMap.get(fn))
+					.filter(Boolean)
+					.map((f) => ({ f, checked: true })),
+				...allFields
+					.filter((f) => !existSet.has(f.fieldname))
+					.map((f) => ({ f, checked: false })),
+			];
+		} else {
+			orderedFields = allFields.map((f) => ({ f, checked: true }));
+		}
+
+		const fpListHtml = orderedFields
+			.map(
+				({ f, checked }) => `
+			<div class="sva-vdr-ls-item" data-fieldname="${f.fieldname}" style="
+				display:flex;align-items:center;gap:8px;padding:6px 10px;margin-bottom:2px;
+				background:var(--control-bg,#f8f9fa);border:1px solid var(--border-color,#d1d8dd);
+				border-radius:4px;cursor:grab;user-select:none;">
+				<span class="sva-vdr-ls-handle" style="color:var(--text-muted,#888);font-size:16px;line-height:1;flex-shrink:0;">≡</span>
+				<input type="checkbox" class="sva-vdr-ls-check" ${checked ? "checked" : ""}
+					style="margin:0;cursor:pointer;width:14px;height:14px;flex-shrink:0;" />
+				<span style="font-size:13px;color:var(--text-color,#333);flex:1;">${__(
+					f.label || f.fieldname
+				)}</span>
+				<span style="font-size:11px;color:var(--text-muted,#888);">${f.fieldtype}</span>
+			</div>`
+			)
+			.join("");
+
+		const fpDialog = new frappe.ui.Dialog({
+			title: __("Configure Fields — {0}", [st.title || __("Table")]),
+			fields: [
+				{
+					fieldname: "hint",
+					fieldtype: "HTML",
+					options: `<p style="color:var(--text-muted,#888);font-size:12px;margin:0 0 8px 0;">
+						${__("Drag ≡ to reorder. Uncheck to hide a field row.")}
+					</p>`,
+				},
+				{
+					fieldname: "fp_list",
+					fieldtype: "HTML",
+					options: `<div class="sva-vdr-ls-list" style="max-height:420px;overflow-y:auto;padding:2px 0;">${fpListHtml}</div>`,
+				},
+			],
+			primary_action_label: __("Apply"),
+			primary_action() {
+				const listEl = fpDialog.$wrapper[0].querySelector(".sva-vdr-ls-list");
+				if (!listEl) return;
+				const newConfig = [];
+				listEl.querySelectorAll(".sva-vdr-ls-item").forEach((item) => {
+					const cb = item.querySelector(".sva-vdr-ls-check");
+					if (cb && cb.checked) newConfig.push(item.dataset.fieldname);
+				});
+				if (!newConfig.length) {
+					frappe.msgprint({
+						message: __("Select at least one field."),
+						indicator: "red",
+					});
+					return;
+				}
+				// Update stConfigs and the DOM item's data attribute
+				stConfigs[idx].fields_config = newConfig;
+				const stItem = parentDialog.$wrapper[0].querySelector(
+					`.sva-vdr-st-item[data-index="${idx}"]`
+				);
+				if (stItem) {
+					stItem.dataset.fieldsConfig = JSON.stringify(newConfig);
+					const btn = stItem.querySelector(".sva-vdr-st-fields-btn");
+					if (btn) btn.textContent = __("Fields ({0})", [newConfig.length]);
+				}
+				fpDialog.hide();
+			},
+			secondary_action_label: __("Select All"),
+			secondary_action() {
+				const listEl = fpDialog.$wrapper[0].querySelector(".sva-vdr-ls-list");
+				if (listEl)
+					listEl.querySelectorAll(".sva-vdr-ls-check").forEach((cb) => {
+						cb.checked = true;
+					});
+			},
+		});
+
+		fpDialog.show();
+		parentDialog.wrapper.append(`<div class="modal-backdrop fade show sva-fp-bd"></div>`);
+		fpDialog.on_hide = () => parentDialog.wrapper.find(".sva-fp-bd").remove();
+
+		// Init DnD on field picker list
+		const fpListEl = fpDialog.$wrapper[0].querySelector(".sva-vdr-ls-list");
+		if (fpListEl) {
+			if (typeof Sortable !== "undefined") {
+				new Sortable(fpListEl, {
+					handle: ".sva-vdr-ls-handle",
+					draggable: ".sva-vdr-ls-item",
+					animation: 120,
+				});
+			} else {
+				_attachNativeDnD(fpListEl, ".sva-vdr-ls-item");
+			}
+		}
+	}
+
+	// ── Sub-table list builder ──────────────────────────────────────────────────
+	function buildStListHtml() {
+		return stConfigs
+			.map(
+				(st, i) => `
+			<div class="sva-vdr-st-item" data-index="${i}" data-fields-config='${frappe.utils.escape_html(
+					JSON.stringify(st.fields_config || [])
+				)}' style="
+				display:flex;flex-direction:column;gap:6px;padding:10px;margin-bottom:6px;
+				background:var(--control-bg,#f8f9fa);border:1px solid var(--border-color,#d1d8dd);
+				border-radius:4px;">
+				<div style="display:flex;align-items:center;gap:8px;">
+					<span class="sva-vdr-st-handle" style="color:var(--text-muted,#888);font-size:18px;cursor:grab;flex-shrink:0;">≡</span>
+					<input class="sva-vdr-st-title form-control form-control-sm" value="${frappe.utils.escape_html(
+						st.title || ""
+					)}"
+						placeholder="${__("Table title...")}" style="flex:1;min-width:0;" />
+					<label style="display:flex;align-items:center;gap:4px;font-size:12px;color:var(--text-muted,#888);white-space:nowrap;cursor:pointer;flex-shrink:0;margin:0;">
+						<input type="checkbox" class="sva-vdr-st-collapsed" ${
+							st.collapsed ? "checked" : ""
+						} style="margin:0;" />
+						${__("Collapsed")}
+					</label>
+					<button class="btn btn-xs btn-default sva-vdr-st-fields-btn" style="flex-shrink:0;white-space:nowrap;">
+						${__("Fields ({0})", [(st.fields_config || []).length])}
+					</button>
+					<button class="btn btn-xs btn-danger sva-vdr-st-delete" style="flex-shrink:0;" title="${__(
+						"Remove sub-table"
+					)}">×</button>
+				</div>
+			</div>`
+			)
+			.join("");
+	}
+
+	// Read current DOM state into stConfigs (handles Sortable drag reorder)
+	function syncFromDom(listEl) {
+		const newConfigs = [];
+		listEl.querySelectorAll(".sva-vdr-st-item").forEach((item) => {
+			const origIdx = parseInt(item.dataset.index, 10);
+			const titleInput = item.querySelector(".sva-vdr-st-title");
+			const collapsedCb = item.querySelector(".sva-vdr-st-collapsed");
+			let fc = [];
+			try {
+				fc = JSON.parse(item.dataset.fieldsConfig || "[]");
+			} catch {
+				fc = [];
+			}
+			const orig = stConfigs[origIdx] || { fields_config: [] };
+			newConfigs.push({
+				title: titleInput ? titleInput.value : orig.title || "",
+				fields_config: fc.length ? fc : orig.fields_config || [],
+				collapsed: collapsedCb ? collapsedCb.checked : !!orig.collapsed,
+			});
+		});
+		stConfigs.length = 0;
+		newConfigs.forEach((s) => stConfigs.push(s));
+	}
+
+	function reRenderList(listEl) {
+		listEl.innerHTML = buildStListHtml();
+		attachListeners(listEl);
+		initDnD(listEl);
+	}
+
+	function attachListeners(listEl) {
+		listEl.querySelectorAll(".sva-vdr-st-fields-btn").forEach((btn) => {
+			btn.addEventListener("click", () => {
+				syncFromDom(listEl);
+				const idx = parseInt(btn.closest(".sva-vdr-st-item").dataset.index, 10);
+				openFieldPicker(idx, stDialog);
+			});
+		});
+		listEl.querySelectorAll(".sva-vdr-st-delete").forEach((btn) => {
+			btn.addEventListener("click", () => {
+				syncFromDom(listEl);
+				const idx = parseInt(btn.closest(".sva-vdr-st-item").dataset.index, 10);
+				stConfigs.splice(idx, 1);
+				reRenderList(listEl);
+			});
+		});
+	}
+
+	function initDnD(listEl) {
+		if (typeof Sortable !== "undefined") {
+			new Sortable(listEl, {
+				handle: ".sva-vdr-st-handle",
+				draggable: ".sva-vdr-st-item",
+				animation: 120,
+			});
+		} else {
+			_attachNativeDnD(listEl, ".sva-vdr-st-item");
+		}
+	}
+
+	// ── Main sub-tables dialog ─────────────────────────────────────────────────
+	const stDialog = new frappe.ui.Dialog({
+		title: __("Setup Sub-tables — {0}", [row.vdr_doctype]),
+		fields: [
+			{
+				fieldname: "hint",
+				fieldtype: "HTML",
+				options: `<p style="color:var(--text-muted,#888);font-size:12px;margin:0 0 6px 0;">
+					${__("Each sub-table shows the same columns but different field rows. Drag ≡ to reorder tables.")}
+				</p>`,
+			},
+			{
+				fieldname: "st_list",
+				fieldtype: "HTML",
+				options: `<div class="sva-vdr-st-list" style="max-height:440px;overflow-y:auto;padding:2px 0;">
+					${buildStListHtml()}
+				</div>`,
+			},
+			{
+				fieldname: "add_row",
+				fieldtype: "HTML",
+				options: `<div style="margin-top:6px;">
+					<button class="btn btn-xs btn-default sva-vdr-st-add">+ ${__("Add Sub-table")}</button>
+				</div>`,
+			},
+		],
+		primary_action_label: __("Save"),
+		primary_action() {
+			const listEl = stDialog.$wrapper[0].querySelector(".sva-vdr-st-list");
+			if (listEl) syncFromDom(listEl);
+			if (!stConfigs.length) {
+				frappe.msgprint({ message: __("Add at least one sub-table."), indicator: "red" });
+				return;
+			}
+			dialog.set_value("vdr_sub_tables", JSON.stringify(stConfigs));
+			frappe.show_alert({ message: __("Sub-tables saved"), indicator: "green" });
+			stDialog.hide();
+		},
+	});
+
+	stDialog.show();
+	dialog.wrapper.append(`<div class="modal-backdrop fade show sva-st-bd"></div>`);
+	stDialog.on_hide = () => dialog.wrapper.find(".sva-st-bd").remove();
+
+	// Wire up list interactions
+	const stListEl = stDialog.$wrapper[0].querySelector(".sva-vdr-st-list");
+	if (stListEl) {
+		attachListeners(stListEl);
+		initDnD(stListEl);
+	}
+
+	// "Add Sub-table" button
+	const addBtn = stDialog.$wrapper[0].querySelector(".sva-vdr-st-add");
+	if (addBtn) {
+		addBtn.addEventListener("click", () => {
+			if (stListEl) syncFromDom(stListEl);
+			stConfigs.push({
+				title: __("Table {0}", [stConfigs.length + 1]),
+				fields_config: [],
+				collapsed: false,
+			});
+			if (stListEl) reRenderList(stListEl);
+		});
+	}
+};
+
+// ─── List Filters ─────────────────────────────────────────────────────────────
 const set_list_filters = async (dialog) => {
 	let row = dialog.get_values(true, false);
 	let dtmeta = await frappe.call({

--- a/frappe_theme/public/js/doctype/property_setter.js
+++ b/frappe_theme/public/js/doctype/property_setter.js
@@ -307,6 +307,7 @@ const field_changes = {
 			{ fn: "vdr_custom_docs_script", ft: "Code" },
 			{ fn: "vdr_fields_config", ft: "Code" },
 			{ fn: "vdr_batch_config", ft: "Code" },
+			{ fn: "vdr_child_add_row_labels", ft: "Code" },
 			{ fn: "crud_permissions", ft: "Code" },
 		];
 
@@ -471,6 +472,9 @@ const field_changes = {
 	},
 	setup_vdr_batch_config: function (frm) {
 		set_vdr_batch_config(frm.config_dialog);
+	},
+	setup_vdr_child_add_row_labels: function (frm) {
+		set_vdr_child_add_row_labels(frm.config_dialog);
 	},
 	setup_crud_permissions: function (frm) {
 		set_crud_permissiions(frm.config_dialog);
@@ -855,6 +859,9 @@ const child_table_field_changes = {
 	},
 	setup_vdr_batch_config: function (frm) {
 		set_vdr_batch_config(frm.child_dialog);
+	},
+	setup_vdr_child_add_row_labels: function (frm) {
+		set_vdr_child_add_row_labels(frm.child_dialog);
 	},
 	setup_crud_permissions: function (frm) {
 		set_crud_permissiions(frm.child_dialog);
@@ -1310,6 +1317,91 @@ const set_vdr_batch_config = (dialog) => {
 	batchDialog.show();
 	dialog.wrapper.append(`<div class="modal-backdrop fade show sva-batch-bd"></div>`);
 	batchDialog.on_hide = () => dialog.wrapper.find(".sva-batch-bd").remove();
+};
+
+// ─── VDR Child Table Add Row Labels Setup ─────────────────────────────────────
+
+const set_vdr_child_add_row_labels = (dialog) => {
+	const row = dialog.get_values(true, false);
+	let existing = {};
+	try {
+		existing = JSON.parse(row.vdr_child_add_row_labels || "{}");
+	} catch {
+		existing = {};
+	}
+
+	// Build rows from existing config
+	let entries = Object.entries(existing).map(([fieldname, label]) => ({ fieldname, label }));
+
+	const buildRowsHtml = (rows) =>
+		rows
+			.map(
+				(r, i) => `
+		<div class="sva-carl-row" data-idx="${i}" style="display:flex;gap:8px;align-items:center;margin-bottom:6px;">
+			<input class="sva-carl-fieldname form-control form-control-sm" placeholder="${__(
+				"Table fieldname"
+			)}"
+				value="${frappe.utils.escape_html(r.fieldname)}" style="flex:1;" />
+			<input class="sva-carl-label form-control form-control-sm" placeholder="${__("Button label")}"
+				value="${frappe.utils.escape_html(r.label)}" style="flex:1;" />
+			<button class="btn btn-xs btn-danger sva-carl-del" data-idx="${i}">✕</button>
+		</div>`
+			)
+			.join("");
+
+	const subDialog = new frappe.ui.Dialog({
+		title: __("Setup Child Table Add Row Labels"),
+		fields: [
+			{
+				fieldname: "rows_html",
+				fieldtype: "HTML",
+				options: `<div id="sva-carl-list" style="margin-bottom:8px;">${buildRowsHtml(
+					entries
+				)}</div>
+					<button class="btn btn-xs btn-primary sva-carl-add">+ ${__("Add Entry")}</button>`,
+			},
+		],
+		primary_action_label: __("Save"),
+		primary_action() {
+			const result = {};
+			subDialog.$wrapper[0].querySelectorAll(".sva-carl-row").forEach((rowEl) => {
+				const fn = rowEl.querySelector(".sva-carl-fieldname")?.value?.trim();
+				const lbl = rowEl.querySelector(".sva-carl-label")?.value?.trim();
+				if (fn && lbl) result[fn] = lbl;
+			});
+			dialog.set_value("vdr_child_add_row_labels", JSON.stringify(result));
+			subDialog.hide();
+		},
+	});
+
+	subDialog.show();
+
+	const list = subDialog.$wrapper[0].querySelector("#sva-carl-list");
+
+	// Add row
+	subDialog.$wrapper[0].querySelector(".sva-carl-add").addEventListener("click", () => {
+		const div = document.createElement("div");
+		div.className = "sva-carl-row";
+		div.style.cssText = "display:flex;gap:8px;align-items:center;margin-bottom:6px;";
+		div.innerHTML = `
+			<input class="sva-carl-fieldname form-control form-control-sm" placeholder="${__(
+				"Table fieldname"
+			)}" style="flex:1;" />
+			<input class="sva-carl-label form-control form-control-sm" placeholder="${__(
+				"Button label"
+			)}" style="flex:1;" />
+			<button class="btn btn-xs btn-danger sva-carl-del">✕</button>`;
+		list.appendChild(div);
+		div.querySelector(".sva-carl-del").addEventListener("click", () => div.remove());
+	});
+
+	// Delete existing rows
+	list.querySelectorAll(".sva-carl-del").forEach((btn) => {
+		btn.addEventListener("click", () => btn.closest(".sva-carl-row").remove());
+	});
+
+	dialog.wrapper.append(`<div class="modal-backdrop fade show sva-carl-bd"></div>`);
+	subDialog.on_hide = () => dialog.wrapper.find(".sva-carl-bd").remove();
 };
 
 // ─── Copy Fields Picker ───────────────────────────────────────────────────────

--- a/frappe_theme/public/js/doctype/property_setter.js
+++ b/frappe_theme/public/js/doctype/property_setter.js
@@ -1104,6 +1104,7 @@ const set_vdr_batch_config = (dialog) => {
 
 	// Parse existing config, fall back to sensible defaults
 	let cfg = {
+		enable_batch_config: false,
 		allow_add_more_table: false,
 		add_more_button_label: "Add More",
 		add_more_doctype: row.vdr_doctype || "",
@@ -1134,6 +1135,15 @@ const set_vdr_batch_config = (dialog) => {
 				</p>`,
 			},
 			{
+				label: __("Enable Batch Config"),
+				fieldname: "enable_batch_config",
+				fieldtype: "Check",
+				default: cfg.enable_batch_config ? 1 : 0,
+				description: __(
+					"Group records by Grouping Field and display each batch as a separate collapsible table — without an Add More button"
+				),
+			},
+			{
 				label: __("Enable Add More Table"),
 				fieldname: "allow_add_more_table",
 				fieldtype: "Check",
@@ -1146,6 +1156,7 @@ const set_vdr_batch_config = (dialog) => {
 				fieldtype: "Data",
 				default: cfg.add_more_button_label || "Add More",
 				description: __('Text shown on the button (e.g. "Add More")'),
+				depends_on: "eval:doc.allow_add_more_table == 1",
 			},
 			{ fieldtype: "Section Break", label: __("Data Mapping") },
 			{
@@ -1182,7 +1193,9 @@ const set_vdr_batch_config = (dialog) => {
 				fieldname: "batch_title_prefix",
 				fieldtype: "Data",
 				default: cfg.batch_title_prefix || "Soil Parameters - Batch",
-				description: __('Prefix for auto-generated titles. Result: "Prefix - Batch 2"'),
+				description: __(
+					'Prefix for auto-generated titles. Result: "Prefix - Batch 2". Use {fieldname} to insert a source-doc field value, e.g. "Seed Treatment - {crop_name}"'
+				),
 			},
 			{ fieldtype: "Section Break", label: __("Display") },
 			{
@@ -1213,17 +1226,21 @@ const set_vdr_batch_config = (dialog) => {
 		],
 		primary_action_label: __("Save"),
 		primary_action(values) {
-			if (values.allow_add_more_table) {
-				if (!values.add_more_doctype) {
+			// Grouping Field is required whenever either batch mode is active
+			if (values.enable_batch_config || values.allow_add_more_table) {
+				if (!(values.grouping_field || "").trim()) {
 					frappe.msgprint({
-						message: __("Source DocType is required."),
+						message: __("Grouping Field is required."),
 						indicator: "red",
 					});
 					return;
 				}
-				if (!(values.grouping_field || "").trim()) {
+			}
+			// Source DocType and Column Link Field are only needed for Add More
+			if (values.allow_add_more_table) {
+				if (!values.add_more_doctype) {
 					frappe.msgprint({
-						message: __("Grouping Field is required."),
+						message: __("Source DocType is required."),
 						indicator: "red",
 					});
 					return;
@@ -1238,6 +1255,7 @@ const set_vdr_batch_config = (dialog) => {
 			}
 
 			const result = {
+				enable_batch_config: !!values.enable_batch_config,
 				allow_add_more_table: !!values.allow_add_more_table,
 				add_more_button_label: (values.add_more_button_label || "Add More").trim(),
 				add_more_doctype: values.add_more_doctype || "",

--- a/frappe_theme/public/js/doctype/property_setter.js
+++ b/frappe_theme/public/js/doctype/property_setter.js
@@ -287,6 +287,10 @@ const field_changes = {
 			{ fn: "vdr_hide_empty_rows", ft: "Check" },
 			{ fn: "vdr_show_legend", ft: "Check" },
 			{ fn: "vdr_legend_items", ft: "Code" },
+			{ fn: "vdr_max_height", ft: "Int" },
+			{ fn: "vdr_link_fieldname", ft: "Data" },
+			{ fn: "vdr_foreign_field", ft: "Data" },
+			{ fn: "vdr_fields_config", ft: "Code" },
 			{ fn: "crud_permissions", ft: "Code" },
 		];
 
@@ -759,6 +763,42 @@ const child_table_field_changes = {
 
 const set_list_settings = async (dialog) => {
 	let row = dialog.get_values(true, false);
+
+	// VDR: use vdr_doctype; store result in vdr_fields_config
+	if (row.property_type === "Vertical Doc Renderer") {
+		if (!row.vdr_doctype) {
+			frappe.msgprint({
+				message: __("Please set the Source DocType first."),
+				indicator: "orange",
+			});
+			return;
+		}
+		let dtmeta = await frappe.call({
+			method: "frappe_theme.dt_api.get_meta_fields",
+			args: { doctype: row.vdr_doctype, _type: "Direct" },
+		});
+		frappe.require("list_settings.bundle.js").then(() => {
+			let d = new frappe.ui.SVAListSettings({
+				doctype: row.vdr_doctype,
+				meta: dtmeta.message,
+				connection_type: "Direct",
+				settings: row,
+				dialog_primary_action: async (listview_settings) => {
+					// listview_settings is an array of {fieldname, label, ...}
+					// extract ordered fieldnames for vdr_fields_config
+					const fieldsConfig = listview_settings.map((f) => f.fieldname || f.field);
+					dialog.set_value("vdr_fields_config", JSON.stringify(fieldsConfig));
+					frappe.show_alert({ message: __("Row settings updated"), indicator: "green" });
+				},
+			});
+			dialog.wrapper.append(`<div class="modal-backdrop fade show"></div>`);
+			d.dialog.on_hide = () => {
+				dialog.wrapper.find(".modal-backdrop").remove();
+			};
+		});
+		return;
+	}
+
 	let dtmeta = await frappe.call({
 		method: "frappe_theme.dt_api.get_meta_fields",
 		args: {

--- a/frappe_theme/public/js/doctype/property_setter.js
+++ b/frappe_theme/public/js/doctype/property_setter.js
@@ -140,7 +140,7 @@ after_render_control = async function (dialog, _frm) {
 				size: "large",
 				primary_action_label: __("Save"),
 				primary_action: async function () {
-					let values = this.get_values();
+					let values = this.get_values(true, false); // include hidden fields (e.g. vdr_batch_config)
 					if (mode == "create") {
 						rows.push(values);
 					} else {
@@ -295,13 +295,14 @@ const field_changes = {
 			{ fn: "vdr_max_height", ft: "Int" },
 			{ fn: "vdr_column_batch_size", ft: "Int" },
 			{ fn: "vdr_column_width", ft: "Int" },
+			{ fn: "vdr_label_width", ft: "Int" },
 			{ fn: "vdr_link_fieldname", ft: "Data" },
 			{ fn: "vdr_foreign_field", ft: "Data" },
 			{ fn: "vdr_order_by", ft: "Data" },
 			{ fn: "vdr_use_custom_script", ft: "Check" },
 			{ fn: "vdr_custom_docs_script", ft: "Code" },
 			{ fn: "vdr_fields_config", ft: "Code" },
-			{ fn: "vdr_sub_tables", ft: "Code" },
+			{ fn: "vdr_batch_config", ft: "Code" },
 			{ fn: "crud_permissions", ft: "Code" },
 		];
 
@@ -464,8 +465,8 @@ const field_changes = {
 	setup_list_settings: function (frm) {
 		set_list_settings(frm.config_dialog);
 	},
-	setup_vdr_sub_tables: function (frm) {
-		set_vdr_sub_tables(frm.config_dialog);
+	setup_vdr_batch_config: function (frm) {
+		set_vdr_batch_config(frm.config_dialog);
 	},
 	setup_crud_permissions: function (frm) {
 		set_crud_permissiions(frm.config_dialog);
@@ -848,8 +849,8 @@ const child_table_field_changes = {
 	setup_list_settings: function (frm) {
 		set_list_settings(frm.child_dialog);
 	},
-	setup_vdr_sub_tables: function (frm) {
-		set_vdr_sub_tables(frm.child_dialog);
+	setup_vdr_batch_config: function (frm) {
+		set_vdr_batch_config(frm.child_dialog);
 	},
 	setup_crud_permissions: function (frm) {
 		set_crud_permissiions(frm.child_dialog);
@@ -1092,365 +1093,147 @@ const set_list_settings = async (dialog) => {
 		};
 	});
 };
-// ─── VDR Sub-tables Setup ─────────────────────────────────────────────────────
+// ─── VDR Batch Config Setup ───────────────────────────────────────────────────
 
-const set_vdr_sub_tables = async (dialog) => {
+const set_vdr_batch_config = (dialog) => {
 	const row = dialog.get_values(true, false);
 
-	if (!row.vdr_doctype) {
-		frappe.msgprint({
-			message: __("Please set the Source DocType first."),
-			indicator: "orange",
-		});
-		return;
-	}
-
-	const dtmeta = await frappe.call({
-		method: "frappe_theme.dt_api.get_meta_fields",
-		args: { doctype: row.vdr_doctype, _type: "Direct" },
-	});
-
-	const SKIP_TYPES = new Set([
-		"Column Break",
-		"HTML",
-		"Button",
-		"Fold",
-		"Image",
-		"Signature",
-		"Geolocation",
-		"Barcode",
-		"Tab Break",
-		"Section Break",
-	]);
-	const allFields = (dtmeta.message || []).filter(
-		(f) => !SKIP_TYPES.has(f.fieldtype) && !f.hidden
-	);
-
-	if (!allFields.length) {
-		frappe.msgprint({ message: __("No configurable fields found."), indicator: "orange" });
-		return;
-	}
-
-	// Parse existing sub-tables config
-	let stConfigs = [];
+	// Parse existing config, fall back to sensible defaults
+	let cfg = {
+		allow_add_more_table: false,
+		add_more_button_label: "Add More",
+		add_more_doctype: row.vdr_doctype || "",
+		grouping_field: "",
+		plot_link_field: "",
+		default_collapsed_new_table: true,
+		batch_title_prefix: "Soil Parameters - Batch",
+	};
 	try {
-		stConfigs = JSON.parse(row.vdr_sub_tables || "[]");
-	} catch {
-		stConfigs = [];
-	}
-	if (!stConfigs.length) {
-		stConfigs = [{ title: __("Table 1"), fields_config: [], collapsed: false }];
-	}
-	stConfigs = stConfigs.map((st) => ({
-		title: st.title || "",
-		fields_config: Array.isArray(st.fields_config) ? st.fields_config : [],
-		collapsed: !!st.collapsed,
-	}));
-
-	// ── Shared DnD helper ──────────────────────────────────────────────────────
-	function _attachNativeDnD(listEl, itemSelector) {
-		let _dragSrc = null;
-		listEl.querySelectorAll(itemSelector).forEach((item) => {
-			item.setAttribute("draggable", "true");
-			item.addEventListener("dragstart", (e) => {
-				_dragSrc = item;
-				e.dataTransfer.effectAllowed = "move";
-				item.style.opacity = "0.4";
-			});
-			item.addEventListener("dragend", () => {
-				item.style.opacity = "";
-				listEl.querySelectorAll(itemSelector).forEach((i) => (i.style.outline = ""));
-			});
-			item.addEventListener("dragover", (e) => {
-				e.preventDefault();
-				e.dataTransfer.dropEffect = "move";
-				listEl.querySelectorAll(itemSelector).forEach((i) => (i.style.outline = ""));
-				item.style.outline = "2px solid var(--primary,#2490ef)";
-			});
-			item.addEventListener("drop", (e) => {
-				e.preventDefault();
-				item.style.outline = "";
-				if (_dragSrc && _dragSrc !== item) {
-					const all = [...listEl.querySelectorAll(itemSelector)];
-					if (all.indexOf(_dragSrc) < all.indexOf(item)) item.after(_dragSrc);
-					else item.before(_dragSrc);
-				}
-			});
-		});
+		const saved = JSON.parse(row.vdr_batch_config || "{}");
+		Object.assign(cfg, saved);
+	} catch (e) {
+		console.warn("Failed to parse existing batch config, using defaults", e);
 	}
 
-	// ── Field-picker sub-dialog ────────────────────────────────────────────────
-	function openFieldPicker(idx, parentDialog) {
-		const st = stConfigs[idx];
-		const existing = st.fields_config || [];
-
-		let orderedFields;
-		if (existing.length) {
-			const fieldMap = new Map(allFields.map((f) => [f.fieldname, f]));
-			const existSet = new Set(existing);
-			orderedFields = [
-				...existing
-					.map((fn) => fieldMap.get(fn))
-					.filter(Boolean)
-					.map((f) => ({ f, checked: true })),
-				...allFields
-					.filter((f) => !existSet.has(f.fieldname))
-					.map((f) => ({ f, checked: false })),
-			];
-		} else {
-			orderedFields = allFields.map((f) => ({ f, checked: true }));
-		}
-
-		const fpListHtml = orderedFields
-			.map(
-				({ f, checked }) => `
-			<div class="sva-vdr-ls-item" data-fieldname="${f.fieldname}" style="
-				display:flex;align-items:center;gap:8px;padding:6px 10px;margin-bottom:2px;
-				background:var(--control-bg,#f8f9fa);border:1px solid var(--border-color,#d1d8dd);
-				border-radius:4px;cursor:grab;user-select:none;">
-				<span class="sva-vdr-ls-handle" style="color:var(--text-muted,#888);font-size:16px;line-height:1;flex-shrink:0;">≡</span>
-				<input type="checkbox" class="sva-vdr-ls-check" ${checked ? "checked" : ""}
-					style="margin:0;cursor:pointer;width:14px;height:14px;flex-shrink:0;" />
-				<span style="font-size:13px;color:var(--text-color,#333);flex:1;">${__(
-					f.label || f.fieldname
-				)}</span>
-				<span style="font-size:11px;color:var(--text-muted,#888);">${f.fieldtype}</span>
-			</div>`
-			)
-			.join("");
-
-		const fpDialog = new frappe.ui.Dialog({
-			title: __("Configure Fields — {0}", [st.title || __("Table")]),
-			fields: [
-				{
-					fieldname: "hint",
-					fieldtype: "HTML",
-					options: `<p style="color:var(--text-muted,#888);font-size:12px;margin:0 0 8px 0;">
-						${__("Drag ≡ to reorder. Uncheck to hide a field row.")}
-					</p>`,
-				},
-				{
-					fieldname: "fp_list",
-					fieldtype: "HTML",
-					options: `<div class="sva-vdr-ls-list" style="max-height:420px;overflow-y:auto;padding:2px 0;">${fpListHtml}</div>`,
-				},
-			],
-			primary_action_label: __("Apply"),
-			primary_action() {
-				const listEl = fpDialog.$wrapper[0].querySelector(".sva-vdr-ls-list");
-				if (!listEl) return;
-				const newConfig = [];
-				listEl.querySelectorAll(".sva-vdr-ls-item").forEach((item) => {
-					const cb = item.querySelector(".sva-vdr-ls-check");
-					if (cb && cb.checked) newConfig.push(item.dataset.fieldname);
-				});
-				if (!newConfig.length) {
-					frappe.msgprint({
-						message: __("Select at least one field."),
-						indicator: "red",
-					});
-					return;
-				}
-				// Update stConfigs and the DOM item's data attribute
-				stConfigs[idx].fields_config = newConfig;
-				const stItem = parentDialog.$wrapper[0].querySelector(
-					`.sva-vdr-st-item[data-index="${idx}"]`
-				);
-				if (stItem) {
-					stItem.dataset.fieldsConfig = JSON.stringify(newConfig);
-					const btn = stItem.querySelector(".sva-vdr-st-fields-btn");
-					if (btn) btn.textContent = __("Fields ({0})", [newConfig.length]);
-				}
-				fpDialog.hide();
-			},
-			secondary_action_label: __("Select All"),
-			secondary_action() {
-				const listEl = fpDialog.$wrapper[0].querySelector(".sva-vdr-ls-list");
-				if (listEl)
-					listEl.querySelectorAll(".sva-vdr-ls-check").forEach((cb) => {
-						cb.checked = true;
-					});
-			},
-		});
-
-		fpDialog.show();
-		parentDialog.wrapper.append(`<div class="modal-backdrop fade show sva-fp-bd"></div>`);
-		fpDialog.on_hide = () => parentDialog.wrapper.find(".sva-fp-bd").remove();
-
-		// Init DnD on field picker list
-		const fpListEl = fpDialog.$wrapper[0].querySelector(".sva-vdr-ls-list");
-		if (fpListEl) {
-			if (typeof Sortable !== "undefined") {
-				new Sortable(fpListEl, {
-					handle: ".sva-vdr-ls-handle",
-					draggable: ".sva-vdr-ls-item",
-					animation: 120,
-				});
-			} else {
-				_attachNativeDnD(fpListEl, ".sva-vdr-ls-item");
-			}
-		}
-	}
-
-	// ── Sub-table list builder ──────────────────────────────────────────────────
-	function buildStListHtml() {
-		return stConfigs
-			.map(
-				(st, i) => `
-			<div class="sva-vdr-st-item" data-index="${i}" data-fields-config='${frappe.utils.escape_html(
-					JSON.stringify(st.fields_config || [])
-				)}' style="
-				display:flex;flex-direction:column;gap:6px;padding:10px;margin-bottom:6px;
-				background:var(--control-bg,#f8f9fa);border:1px solid var(--border-color,#d1d8dd);
-				border-radius:4px;">
-				<div style="display:flex;align-items:center;gap:8px;">
-					<span class="sva-vdr-st-handle" style="color:var(--text-muted,#888);font-size:18px;cursor:grab;flex-shrink:0;">≡</span>
-					<input class="sva-vdr-st-title form-control form-control-sm" value="${frappe.utils.escape_html(
-						st.title || ""
-					)}"
-						placeholder="${__("Table title...")}" style="flex:1;min-width:0;" />
-					<label style="display:flex;align-items:center;gap:4px;font-size:12px;color:var(--text-muted,#888);white-space:nowrap;cursor:pointer;flex-shrink:0;margin:0;">
-						<input type="checkbox" class="sva-vdr-st-collapsed" ${
-							st.collapsed ? "checked" : ""
-						} style="margin:0;" />
-						${__("Collapsed")}
-					</label>
-					<button class="btn btn-xs btn-default sva-vdr-st-fields-btn" style="flex-shrink:0;white-space:nowrap;">
-						${__("Fields ({0})", [(st.fields_config || []).length])}
-					</button>
-					<button class="btn btn-xs btn-danger sva-vdr-st-delete" style="flex-shrink:0;" title="${__(
-						"Remove sub-table"
-					)}">×</button>
-				</div>
-			</div>`
-			)
-			.join("");
-	}
-
-	// Read current DOM state into stConfigs (handles Sortable drag reorder)
-	function syncFromDom(listEl) {
-		const newConfigs = [];
-		listEl.querySelectorAll(".sva-vdr-st-item").forEach((item) => {
-			const origIdx = parseInt(item.dataset.index, 10);
-			const titleInput = item.querySelector(".sva-vdr-st-title");
-			const collapsedCb = item.querySelector(".sva-vdr-st-collapsed");
-			let fc = [];
-			try {
-				fc = JSON.parse(item.dataset.fieldsConfig || "[]");
-			} catch {
-				fc = [];
-			}
-			const orig = stConfigs[origIdx] || { fields_config: [] };
-			newConfigs.push({
-				title: titleInput ? titleInput.value : orig.title || "",
-				fields_config: fc.length ? fc : orig.fields_config || [],
-				collapsed: collapsedCb ? collapsedCb.checked : !!orig.collapsed,
-			});
-		});
-		stConfigs.length = 0;
-		newConfigs.forEach((s) => stConfigs.push(s));
-	}
-
-	function reRenderList(listEl) {
-		listEl.innerHTML = buildStListHtml();
-		attachListeners(listEl);
-		initDnD(listEl);
-	}
-
-	function attachListeners(listEl) {
-		listEl.querySelectorAll(".sva-vdr-st-fields-btn").forEach((btn) => {
-			btn.addEventListener("click", () => {
-				syncFromDom(listEl);
-				const idx = parseInt(btn.closest(".sva-vdr-st-item").dataset.index, 10);
-				openFieldPicker(idx, stDialog);
-			});
-		});
-		listEl.querySelectorAll(".sva-vdr-st-delete").forEach((btn) => {
-			btn.addEventListener("click", () => {
-				syncFromDom(listEl);
-				const idx = parseInt(btn.closest(".sva-vdr-st-item").dataset.index, 10);
-				stConfigs.splice(idx, 1);
-				reRenderList(listEl);
-			});
-		});
-	}
-
-	function initDnD(listEl) {
-		if (typeof Sortable !== "undefined") {
-			new Sortable(listEl, {
-				handle: ".sva-vdr-st-handle",
-				draggable: ".sva-vdr-st-item",
-				animation: 120,
-			});
-		} else {
-			_attachNativeDnD(listEl, ".sva-vdr-st-item");
-		}
-	}
-
-	// ── Main sub-tables dialog ─────────────────────────────────────────────────
-	const stDialog = new frappe.ui.Dialog({
-		title: __("Setup Sub-tables — {0}", [row.vdr_doctype]),
+	const batchDialog = new frappe.ui.Dialog({
+		title: __("Setup Batch Config"),
 		fields: [
 			{
 				fieldname: "hint",
 				fieldtype: "HTML",
-				options: `<p style="color:var(--text-muted,#888);font-size:12px;margin:0 0 6px 0;">
-					${__("Each sub-table shows the same columns but different field rows. Drag ≡ to reorder tables.")}
+				options: `<p style="color:var(--text-muted,#888);font-size:12px;margin:0 0 10px 0;">
+					${__(
+						'Configure the stacked batch feature. When enabled, an "Add More" button appears below the VDR table and creates a new batch of records (one per existing column).'
+					)}
 				</p>`,
 			},
 			{
-				fieldname: "st_list",
-				fieldtype: "HTML",
-				options: `<div class="sva-vdr-st-list" style="max-height:440px;overflow-y:auto;padding:2px 0;">
-					${buildStListHtml()}
-				</div>`,
+				label: __("Enable Add More Table"),
+				fieldname: "allow_add_more_table",
+				fieldtype: "Check",
+				default: cfg.allow_add_more_table ? 1 : 0,
 			},
+			{ fieldtype: "Column Break" },
 			{
-				fieldname: "add_row",
-				fieldtype: "HTML",
-				options: `<div style="margin-top:6px;">
-					<button class="btn btn-xs btn-default sva-vdr-st-add">+ ${__("Add Sub-table")}</button>
-				</div>`,
+				label: __("Button Label"),
+				fieldname: "add_more_button_label",
+				fieldtype: "Data",
+				default: cfg.add_more_button_label || "Add More",
+				description: __('Text shown on the button (e.g. "Add More")'),
+			},
+			{ fieldtype: "Section Break", label: __("Data Mapping") },
+			{
+				label: __("Source DocType"),
+				fieldname: "add_more_doctype",
+				fieldtype: "Link",
+				options: "DocType",
+				default: cfg.add_more_doctype || row.vdr_doctype || "",
+				description: __(
+					"DocType where new batch records are created (usually the same as the VDR DocType)"
+				),
+			},
+			{ fieldtype: "Column Break" },
+			{
+				label: __("Grouping Field"),
+				fieldname: "grouping_field",
+				fieldtype: "Data",
+				default: cfg.grouping_field || "",
+				description: __("Int field that identifies the batch number (e.g. batch_no)"),
+			},
+			{ fieldtype: "Section Break" },
+			{
+				label: __("Column Link Field"),
+				fieldname: "plot_link_field",
+				fieldtype: "Data",
+				default: cfg.plot_link_field || "",
+				description: __(
+					"Link field that points to the column source — e.g. the plot or sample name (e.g. plot)"
+				),
+			},
+			{ fieldtype: "Column Break" },
+			{
+				label: __("Batch Title Prefix"),
+				fieldname: "batch_title_prefix",
+				fieldtype: "Data",
+				default: cfg.batch_title_prefix || "Soil Parameters - Batch",
+				description: __('Prefix for auto-generated titles. Result: "Prefix - Batch 2"'),
+			},
+			{ fieldtype: "Section Break", label: __("Display") },
+			{
+				label: __("New Tables Start Collapsed"),
+				fieldname: "default_collapsed_new_table",
+				fieldtype: "Check",
+				default: cfg.default_collapsed_new_table ? 1 : 0,
+				description: __("New batch tables start folded; user expands on demand"),
 			},
 		],
 		primary_action_label: __("Save"),
-		primary_action() {
-			const listEl = stDialog.$wrapper[0].querySelector(".sva-vdr-st-list");
-			if (listEl) syncFromDom(listEl);
-			if (!stConfigs.length) {
-				frappe.msgprint({ message: __("Add at least one sub-table."), indicator: "red" });
-				return;
+		primary_action(values) {
+			if (values.allow_add_more_table) {
+				if (!values.add_more_doctype) {
+					frappe.msgprint({
+						message: __("Source DocType is required."),
+						indicator: "red",
+					});
+					return;
+				}
+				if (!(values.grouping_field || "").trim()) {
+					frappe.msgprint({
+						message: __("Grouping Field is required."),
+						indicator: "red",
+					});
+					return;
+				}
+				if (!(values.plot_link_field || "").trim()) {
+					frappe.msgprint({
+						message: __("Column Link Field is required."),
+						indicator: "red",
+					});
+					return;
+				}
 			}
-			dialog.set_value("vdr_sub_tables", JSON.stringify(stConfigs));
-			frappe.show_alert({ message: __("Sub-tables saved"), indicator: "green" });
-			stDialog.hide();
+
+			const result = {
+				allow_add_more_table: !!values.allow_add_more_table,
+				add_more_button_label: (values.add_more_button_label || "Add More").trim(),
+				add_more_doctype: values.add_more_doctype || "",
+				grouping_field: (values.grouping_field || "").trim(),
+				plot_link_field: (values.plot_link_field || "").trim(),
+				default_collapsed_new_table: !!values.default_collapsed_new_table,
+				batch_title_prefix: (
+					values.batch_title_prefix || "Soil Parameters - Batch"
+				).trim(),
+			};
+
+			dialog.set_value("vdr_batch_config", JSON.stringify(result));
+			frappe.show_alert({ message: __("Batch config saved"), indicator: "green" });
+			batchDialog.hide();
 		},
 	});
 
-	stDialog.show();
-	dialog.wrapper.append(`<div class="modal-backdrop fade show sva-st-bd"></div>`);
-	stDialog.on_hide = () => dialog.wrapper.find(".sva-st-bd").remove();
-
-	// Wire up list interactions
-	const stListEl = stDialog.$wrapper[0].querySelector(".sva-vdr-st-list");
-	if (stListEl) {
-		attachListeners(stListEl);
-		initDnD(stListEl);
-	}
-
-	// "Add Sub-table" button
-	const addBtn = stDialog.$wrapper[0].querySelector(".sva-vdr-st-add");
-	if (addBtn) {
-		addBtn.addEventListener("click", () => {
-			if (stListEl) syncFromDom(stListEl);
-			stConfigs.push({
-				title: __("Table {0}", [stConfigs.length + 1]),
-				fields_config: [],
-				collapsed: false,
-			});
-			if (stListEl) reRenderList(stListEl);
-		});
-	}
+	batchDialog.show();
+	dialog.wrapper.append(`<div class="modal-backdrop fade show sva-batch-bd"></div>`);
+	batchDialog.on_hide = () => dialog.wrapper.find(".sva-batch-bd").remove();
 };
 
 // ─── List Filters ─────────────────────────────────────────────────────────────
@@ -1661,7 +1444,7 @@ async function customPropertySetter(frm) {
 										size: frappe.utils.get_dialog_size(dialog_fields),
 										primary_action_label: "Save",
 										primary_action: async function () {
-											let values = dialog.get_values();
+											let values = dialog.get_values(true, false); // include hidden fields (e.g. vdr_batch_config)
 											let new_val = JSON.stringify(
 												Object.keys(values)
 													.filter(

--- a/frappe_theme/public/js/doctype/property_setter.js
+++ b/frappe_theme/public/js/doctype/property_setter.js
@@ -286,6 +286,8 @@ const field_changes = {
 			{ fn: "vdr_fields_to_show", ft: "Code" },
 			{ fn: "vdr_fields_to_hide", ft: "Code" },
 			{ fn: "vdr_link_title_fields", ft: "Code" },
+			{ fn: "vdr_column_color_rules", ft: "Code" },
+			{ fn: "vdr_column_order_rules", ft: "Code" },
 			{ fn: "vdr_show_sections", ft: "Check" },
 			{ fn: "vdr_section_configs", ft: "Code" },
 			{ fn: "vdr_show_unit", ft: "Check" },
@@ -296,9 +298,11 @@ const field_changes = {
 			{ fn: "vdr_column_batch_size", ft: "Int" },
 			{ fn: "vdr_column_width", ft: "Int" },
 			{ fn: "vdr_label_width", ft: "Int" },
+			{ fn: "vdr_table_max_rows", ft: "Int" },
 			{ fn: "vdr_link_fieldname", ft: "Data" },
 			{ fn: "vdr_foreign_field", ft: "Data" },
 			{ fn: "vdr_order_by", ft: "Data" },
+			{ fn: "vdr_extra_filters", ft: "Code" },
 			{ fn: "vdr_use_custom_script", ft: "Check" },
 			{ fn: "vdr_custom_docs_script", ft: "Code" },
 			{ fn: "vdr_fields_config", ft: "Code" },
@@ -1107,6 +1111,8 @@ const set_vdr_batch_config = (dialog) => {
 		plot_link_field: "",
 		default_collapsed_new_table: true,
 		batch_title_prefix: "Soil Parameters - Batch",
+		allow_delete_batch: false,
+		delete_batch_button_label: "Delete Batch",
 	};
 	try {
 		const saved = JSON.parse(row.vdr_batch_config || "{}");
@@ -1186,6 +1192,24 @@ const set_vdr_batch_config = (dialog) => {
 				default: cfg.default_collapsed_new_table ? 1 : 0,
 				description: __("New batch tables start folded; user expands on demand"),
 			},
+			{ fieldtype: "Column Break" },
+			{
+				label: __("Allow Delete Batch"),
+				fieldname: "allow_delete_batch",
+				fieldtype: "Check",
+				default: cfg.allow_delete_batch ? 1 : 0,
+				description: __(
+					"Show a Delete Batch button on each batch header (requires Delete permission on the DocType)"
+				),
+			},
+			{
+				label: __("Delete Button Label"),
+				fieldname: "delete_batch_button_label",
+				fieldtype: "Data",
+				default: cfg.delete_batch_button_label || "Delete Batch",
+				description: __('Text shown on the delete button (e.g. "Remove Batch")'),
+				depends_on: "eval:doc.allow_delete_batch == 1",
+			},
 		],
 		primary_action_label: __("Save"),
 		primary_action(values) {
@@ -1222,6 +1246,10 @@ const set_vdr_batch_config = (dialog) => {
 				default_collapsed_new_table: !!values.default_collapsed_new_table,
 				batch_title_prefix: (
 					values.batch_title_prefix || "Soil Parameters - Batch"
+				).trim(),
+				allow_delete_batch: !!values.allow_delete_batch,
+				delete_batch_button_label: (
+					values.delete_batch_button_label || "Delete Batch"
 				).trim(),
 			};
 

--- a/frappe_theme/public/js/doctype/property_setter.js
+++ b/frappe_theme/public/js/doctype/property_setter.js
@@ -1114,6 +1114,7 @@ const set_vdr_batch_config = (dialog) => {
 		batch_title_prefix: "Soil Parameters - Batch",
 		allow_delete_batch: false,
 		delete_batch_button_label: "Delete Batch",
+		copy_fields_only: [],
 	};
 	try {
 		const saved = JSON.parse(row.vdr_batch_config || "{}");
@@ -1158,6 +1159,25 @@ const set_vdr_batch_config = (dialog) => {
 				description: __('Text shown on the button (e.g. "Add More")'),
 				depends_on: "eval:doc.allow_add_more_table == 1",
 			},
+			{
+				label: __("Setup Copy Fields"),
+				fieldname: "btn_copy_fields",
+				fieldtype: "Button",
+				depends_on: "eval:doc.allow_add_more_table == 1",
+				click() {
+					_openCopyFieldsPicker(batchDialog, cfg);
+				},
+			},
+			{
+				fieldname: "copy_fields_only",
+				fieldtype: "Data",
+				depends_on: "eval:doc.allow_add_more_table == 1",
+				read_only: 1,
+				default:
+					Array.isArray(cfg.copy_fields_only) && cfg.copy_fields_only.length
+						? cfg.copy_fields_only.join(", ")
+						: "plot_parent",
+			},
 			{ fieldtype: "Section Break", label: __("Data Mapping") },
 			{
 				label: __("Source DocType"),
@@ -1197,6 +1217,7 @@ const set_vdr_batch_config = (dialog) => {
 					'Prefix for auto-generated titles. Result: "Prefix - Batch 2". Use {fieldname} to insert a source-doc field value, e.g. "Seed Treatment - {crop_name}"'
 				),
 			},
+
 			{ fieldtype: "Section Break", label: __("Display") },
 			{
 				label: __("New Tables Start Collapsed"),
@@ -1254,6 +1275,14 @@ const set_vdr_batch_config = (dialog) => {
 				}
 			}
 
+			const copyFieldsRaw = (values.copy_fields_only || "").trim();
+			const copyFieldsParsed = copyFieldsRaw
+				? copyFieldsRaw
+						.split(",")
+						.map((s) => s.trim())
+						.filter(Boolean)
+				: [];
+
 			const result = {
 				enable_batch_config: !!values.enable_batch_config,
 				allow_add_more_table: !!values.allow_add_more_table,
@@ -1269,6 +1298,7 @@ const set_vdr_batch_config = (dialog) => {
 				delete_batch_button_label: (
 					values.delete_batch_button_label || "Delete Batch"
 				).trim(),
+				copy_fields_only: copyFieldsParsed,
 			};
 
 			dialog.set_value("vdr_batch_config", JSON.stringify(result));
@@ -1281,6 +1311,105 @@ const set_vdr_batch_config = (dialog) => {
 	dialog.wrapper.append(`<div class="modal-backdrop fade show sva-batch-bd"></div>`);
 	batchDialog.on_hide = () => dialog.wrapper.find(".sva-batch-bd").remove();
 };
+
+// ─── Copy Fields Picker ───────────────────────────────────────────────────────
+async function _openCopyFieldsPicker(batchDialog, cfg) {
+	const vals = batchDialog.get_values(true, false);
+	const doctype = vals.add_more_doctype || "";
+	if (!doctype) {
+		frappe.show_alert({ message: __("Set Source DocType first"), indicator: "orange" });
+		return;
+	}
+
+	const SKIP_TYPES = new Set([
+		"Section Break",
+		"Column Break",
+		"Tab Break",
+		"HTML",
+		"Button",
+		"Fold",
+		"Image",
+		"Signature",
+		"Barcode",
+		"Heading",
+	]);
+	const SYSTEM_FIELDS = new Set([
+		"name",
+		"creation",
+		"modified",
+		"modified_by",
+		"owner",
+		"docstatus",
+		"idx",
+		"parent",
+		"parentfield",
+		"parenttype",
+		"amended_from",
+	]);
+
+	await new Promise((r) => frappe.model.with_doctype(doctype, r));
+	const meta = frappe.get_meta(doctype);
+	const fields = (meta?.fields || []).filter(
+		(f) => !SKIP_TYPES.has(f.fieldtype) && f.fieldname && !SYSTEM_FIELDS.has(f.fieldname)
+	);
+
+	const currentRaw = (vals.copy_fields_only || "plot_parent").trim();
+	const currentSet = new Set(
+		currentRaw
+			? currentRaw
+					.split(",")
+					.map((s) => s.trim())
+					.filter(Boolean)
+			: []
+	);
+
+	// Build checkbox list HTML
+	const rows = fields
+		.map((f) => {
+			const checked = currentSet.has(f.fieldname) ? "checked" : "";
+			return `<label style="display:flex;align-items:center;justify-content:space-between;
+				padding:7px 12px;border-bottom:1px solid var(--border-color,#e8e8e8);
+				cursor:pointer;gap:8px;">
+			<span style="display:flex;align-items:center;gap:8px;flex:1;min-width:0;">
+				<input type="checkbox" data-fieldname="${f.fieldname}" ${checked}
+					style="width:15px;height:15px;flex-shrink:0;cursor:pointer;">
+				<span style="font-size:13px;overflow:hidden;text-overflow:ellipsis;
+					white-space:nowrap;">${frappe.utils.escape_html(f.label || f.fieldname)}</span>
+			</span>
+			<span style="font-size:11px;color:var(--text-muted,#888);white-space:nowrap;
+				flex-shrink:0;">${frappe.utils.escape_html(f.fieldtype)}</span>
+		</label>`;
+		})
+		.join("");
+
+	const listHtml = `
+		<div style="max-height:380px;overflow-y:auto;border:1px solid var(--border-color,#e8e8e8);
+			border-radius:4px;margin-bottom:4px;">
+			${rows || `<p style="padding:16px;color:var(--text-muted,#888);">${__("No fields found")}</p>`}
+		</div>`;
+
+	const picker = new frappe.ui.Dialog({
+		title: __("Select Fields to Copy"),
+		fields: [{ fieldname: "list_html", fieldtype: "HTML", options: listHtml }],
+		primary_action_label: __("Save Settings"),
+		secondary_action_label: __("Reset to Default"),
+		secondary_action() {
+			picker.$wrapper.find("input[type=checkbox]").prop("checked", false);
+			const defField = picker.$wrapper.find(`input[data-fieldname="plot_parent"]`);
+			if (defField.length) defField.prop("checked", true);
+		},
+		primary_action() {
+			const selected = [];
+			picker.$wrapper.find("input[type=checkbox]:checked").each(function () {
+				selected.push($(this).data("fieldname"));
+			});
+			batchDialog.set_value("copy_fields_only", selected.join(", "));
+			frappe.show_alert({ message: __("Copy fields updated"), indicator: "green" });
+			picker.hide();
+		},
+	});
+	picker.show();
+}
 
 // ─── List Filters ─────────────────────────────────────────────────────────────
 const set_list_filters = async (dialog) => {

--- a/frappe_theme/public/js/overwrite_form.bundle.js
+++ b/frappe_theme/public/js/overwrite_form.bundle.js
@@ -77,6 +77,7 @@ import CustomDynamicHtml from "./custom_components/dynamic_html/dynamic_html.bun
 import SVACarousel from "./sva_carousel.bundle.js";
 import FilterRibbon from "./custom_components/filters_ribbon.bundle.js";
 import SVASDGWheel from "./custom_components/sdg_wheel.bundle.js";
+import SVAVerticalDocRenderer from "./vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js";
 // Vue components
 import NumberCardSkeleton from "./vue/sva_card/components/Skeleton.vue";
 import ChartPlaceholder from "./vue/sva_chart/components/Placeholder.vue";
@@ -1091,6 +1092,27 @@ frappe.ui.form.Form = class CustomForm extends frappe.ui.form.Form {
 					placeholder.config.globalProperties.frappe = frappe;
 					placeholder.mount(wrapper);
 				}
+				break;
+			}
+			case "Vertical Doc Renderer": {
+				let conf = field.sva_ft;
+				frm.sva_ft_instances[field.fieldname] = new SVAVerticalDocRenderer({
+					wrapper,
+					frm,
+					doctype: conf.vdr_doctype,
+					docs: conf.vdr_docs ? JSON.parse(conf.vdr_docs) : [],
+					column_configs: conf.vdr_column_configs ? JSON.parse(conf.vdr_column_configs) : [],
+					fields_to_show: conf.vdr_fields_to_show ? JSON.parse(conf.vdr_fields_to_show) : null,
+					fields_to_hide: conf.vdr_fields_to_hide ? JSON.parse(conf.vdr_fields_to_hide) : [],
+					show_section_headers: conf.vdr_show_sections !== 0,
+					show_unit: !!conf.vdr_show_unit,
+					hide_empty_rows: !!conf.vdr_hide_empty_rows,
+					title: conf.vdr_title || null,
+					show_legend: !!conf.vdr_show_legend,
+					legend_items: conf.vdr_legend_items ? JSON.parse(conf.vdr_legend_items) : [],
+					crud_permissions: conf.crud_permissions ? JSON.parse(conf.crud_permissions) : ["read"],
+					signal,
+				});
 				break;
 			}
 		}

--- a/frappe_theme/public/js/overwrite_form.bundle.js
+++ b/frappe_theme/public/js/overwrite_form.bundle.js
@@ -1111,6 +1111,7 @@ frappe.ui.form.Form = class CustomForm extends frappe.ui.form.Form {
 					show_legend: !!conf.vdr_show_legend,
 					legend_items: conf.vdr_legend_items ? JSON.parse(conf.vdr_legend_items) : [],
 					crud_permissions: conf.crud_permissions ? JSON.parse(conf.crud_permissions) : ["read"],
+					max_height: conf.vdr_max_height != null ? Number(conf.vdr_max_height) : 600,
 					signal,
 				});
 				break;

--- a/frappe_theme/public/js/overwrite_form.bundle.js
+++ b/frappe_theme/public/js/overwrite_form.bundle.js
@@ -1096,55 +1096,94 @@ frappe.ui.form.Form = class CustomForm extends frappe.ui.form.Form {
 			case "Vertical Doc Renderer": {
 				let conf = field.sva_ft;
 
-				// Determine doc source: link-field-based (dynamic filter) or static docs list
+				// Determine doc source
 				let vdrDocs = null;
 				let vdrFilters = [];
-				if (conf.vdr_link_fieldname && frm.doc[conf.vdr_link_fieldname]) {
+				let vdrColumnConfigs = conf.vdr_column_configs
+					? JSON.parse(conf.vdr_column_configs)
+					: [];
+
+				if (conf.vdr_use_custom_script && conf.vdr_custom_docs_script) {
+					// Run the user's async script with frm in scope.
+					// Script must return { docs, column_configs? } where:
+					//   docs         — string[] | object[] | null
+					//   column_configs — [{label, bg_color, text_color}] index-aligned to docs
+					try {
+						const _AsyncFn = Object.getPrototypeOf(async function () {}).constructor;
+						const _scriptFn = new _AsyncFn("frm", conf.vdr_custom_docs_script);
+						const _result = await _scriptFn(frm);
+						if (_result) {
+							if (_result.docs !== undefined) vdrDocs = _result.docs;
+							if (_result.column_configs) vdrColumnConfigs = _result.column_configs;
+						}
+					} catch (_err) {
+						console.error("SVAVerticalDocRenderer: custom script error", _err);
+						frappe.show_alert({
+							message: __("VDR custom script error: ") + _err.message,
+							indicator: "red",
+						});
+					}
+				} else if (conf.vdr_link_fieldname && frm.doc[conf.vdr_link_fieldname]) {
 					// Foreign key mode: fetch docs where foreignField = frm.doc[linkField]
 					const foreignField = conf.vdr_foreign_field || "name";
 					vdrFilters = [[foreignField, "=", frm.doc[conf.vdr_link_fieldname]]];
-					vdrDocs = null; // use paginated server-side mode with filters
+					vdrDocs = null;
 				} else if (!conf.vdr_link_fieldname && conf.vdr_docs) {
 					vdrDocs = JSON.parse(conf.vdr_docs);
 				}
 				// else: vdrDocs = null, vdrFilters = [] → paginated without filters
 
-				const instance = new SVAVerticalDocRenderer({
-					wrapper,
+				// Shared options for every VDR instance (single or multi-table)
+				const _vdrShared = {
 					frm,
 					doctype: conf.vdr_doctype,
 					docs: vdrDocs,
 					filters: vdrFilters,
-					column_configs: conf.vdr_column_configs
-						? JSON.parse(conf.vdr_column_configs)
-						: [],
+					order_by: conf.vdr_order_by || undefined,
+					column_configs: vdrColumnConfigs,
+					column_label_field: conf.vdr_column_label_field || null,
+					column_default_bg: conf.vdr_column_bg_color || null,
+					column_default_text: conf.vdr_column_text_color || null,
 					fields_to_show: conf.vdr_fields_to_show
 						? JSON.parse(conf.vdr_fields_to_show)
 						: null,
 					fields_to_hide: conf.vdr_fields_to_hide
 						? JSON.parse(conf.vdr_fields_to_hide)
 						: [],
+					link_title_fields: conf.vdr_link_title_fields
+						? JSON.parse(conf.vdr_link_title_fields)
+						: {},
 					show_section_headers: conf.vdr_show_sections !== 0,
+					section_configs: conf.vdr_section_configs
+						? JSON.parse(conf.vdr_section_configs)
+						: {},
 					show_unit: !!conf.vdr_show_unit,
 					hide_empty_rows: !!conf.vdr_hide_empty_rows,
-					title: conf.vdr_title || null,
 					show_legend: !!conf.vdr_show_legend,
 					legend_items: conf.vdr_legend_items ? JSON.parse(conf.vdr_legend_items) : [],
 					crud_permissions: conf.crud_permissions
 						? JSON.parse(conf.crud_permissions)
 						: ["read"],
 					max_height: conf.vdr_max_height != null ? Number(conf.vdr_max_height) : 600,
+					column_batch_size: conf.vdr_column_batch_size
+						? Number(conf.vdr_column_batch_size)
+						: 0,
+					column_width: conf.vdr_column_width ? Number(conf.vdr_column_width) : 150,
 					signal,
 					vdr_field_name: field.fieldname,
+				};
+
+				const instance = new SVAVerticalDocRenderer({
+					..._vdrShared,
+					wrapper,
+					title: conf.vdr_title || null,
 					fields_config: conf.vdr_fields_config
 						? JSON.parse(conf.vdr_fields_config)
 						: null,
 				});
 
-				// Store link field config on the instance for filter ribbon integration
 				instance._vdr_link_fieldname = conf.vdr_link_fieldname || null;
 				instance._vdr_foreign_field = conf.vdr_foreign_field || "name";
-
 				frm.sva_ft_instances[field.fieldname] = instance;
 				break;
 			}

--- a/frappe_theme/public/js/overwrite_form.bundle.js
+++ b/frappe_theme/public/js/overwrite_form.bundle.js
@@ -1133,6 +1133,33 @@ frappe.ui.form.Form = class CustomForm extends frappe.ui.form.Form {
 				}
 				// else: vdrDocs = null, vdrFilters = [] → paginated without filters
 
+				// ── Merge extra filters (JSON with {frm.doc.x} substitution) ────
+				if (conf.vdr_extra_filters) {
+					try {
+						// Replace "{frm.doc.fieldname}" tokens with live form values
+						const _substituted = conf.vdr_extra_filters.replace(
+							/"\{frm\.doc\.([^}]+)\}"/g,
+							(_, fieldname) => {
+								const val = frm.doc[fieldname];
+								if (val === null || val === undefined) return "null";
+								if (typeof val === "number" || typeof val === "boolean")
+									return String(val);
+								return JSON.stringify(String(val));
+							}
+						);
+						const _extra = JSON.parse(_substituted);
+						if (Array.isArray(_extra) && _extra.length) {
+							vdrFilters = [...vdrFilters, ..._extra];
+						}
+					} catch (_err) {
+						console.error("[VDR] extra filters error", _err);
+						frappe.show_alert({
+							message: __("VDR filters error: ") + _err.message,
+							indicator: "red",
+						});
+					}
+				}
+
 				// Shared options for every VDR instance (single or multi-table)
 				const _vdrShared = {
 					frm,
@@ -1153,6 +1180,12 @@ frappe.ui.form.Form = class CustomForm extends frappe.ui.form.Form {
 					link_title_fields: conf.vdr_link_title_fields
 						? JSON.parse(conf.vdr_link_title_fields)
 						: {},
+					column_color_rules: conf.vdr_column_color_rules
+						? JSON.parse(conf.vdr_column_color_rules)
+						: [],
+					column_order_rules: conf.vdr_column_order_rules
+						? JSON.parse(conf.vdr_column_order_rules)
+						: [],
 					show_section_headers: conf.vdr_show_sections !== 0,
 					section_configs: conf.vdr_section_configs
 						? JSON.parse(conf.vdr_section_configs)
@@ -1170,6 +1203,9 @@ frappe.ui.form.Form = class CustomForm extends frappe.ui.form.Form {
 						: 0,
 					column_width: conf.vdr_column_width ? Number(conf.vdr_column_width) : 150,
 					label_width: conf.vdr_label_width ? Number(conf.vdr_label_width) : 160,
+					table_max_rows: conf.vdr_table_max_rows
+						? Number(conf.vdr_table_max_rows)
+						: null,
 					signal,
 					vdr_field_name: field.fieldname,
 				};

--- a/frappe_theme/public/js/overwrite_form.bundle.js
+++ b/frappe_theme/public/js/overwrite_form.bundle.js
@@ -1169,9 +1169,42 @@ frappe.ui.form.Form = class CustomForm extends frappe.ui.form.Form {
 						? Number(conf.vdr_column_batch_size)
 						: 0,
 					column_width: conf.vdr_column_width ? Number(conf.vdr_column_width) : 150,
+					label_width: conf.vdr_label_width ? Number(conf.vdr_label_width) : 160,
 					signal,
 					vdr_field_name: field.fieldname,
 				};
+
+				// ── Parse vdr_batch_config (nested JSON string inside conf) ────────
+				const _addMoreConfig = (() => {
+					if (!conf.vdr_batch_config) {
+						console.log(
+							"[VDR] vdr_batch_config not found in conf for field:",
+							field.fieldname
+						);
+						return null;
+					}
+					try {
+						const cfg =
+							typeof conf.vdr_batch_config === "string"
+								? JSON.parse(conf.vdr_batch_config)
+								: conf.vdr_batch_config;
+						console.log("[VDR] vdr_batch_config parsed:", cfg);
+						if (!cfg.allow_add_more_table) {
+							console.log(
+								"[VDR] allow_add_more_table is false — Add More button disabled"
+							);
+							return null;
+						}
+						return cfg;
+					} catch (e) {
+						console.warn(
+							"[VDR] Failed to parse vdr_batch_config:",
+							conf.vdr_batch_config,
+							e
+						);
+						return null;
+					}
+				})();
 
 				const instance = new SVAVerticalDocRenderer({
 					..._vdrShared,
@@ -1180,6 +1213,7 @@ frappe.ui.form.Form = class CustomForm extends frappe.ui.form.Form {
 					fields_config: conf.vdr_fields_config
 						? JSON.parse(conf.vdr_fields_config)
 						: null,
+					add_more_config: _addMoreConfig,
 				});
 
 				instance._vdr_link_fieldname = conf.vdr_link_fieldname || null;

--- a/frappe_theme/public/js/overwrite_form.bundle.js
+++ b/frappe_theme/public/js/overwrite_form.bundle.js
@@ -1152,7 +1152,6 @@ frappe.ui.form.Form = class CustomForm extends frappe.ui.form.Form {
 							vdrFilters = [...vdrFilters, ..._extra];
 						}
 					} catch (_err) {
-						console.error("[VDR] extra filters error", _err);
 						frappe.show_alert({
 							message: __("VDR filters error: ") + _err.message,
 							indicator: "red",
@@ -1212,25 +1211,13 @@ frappe.ui.form.Form = class CustomForm extends frappe.ui.form.Form {
 
 				// ── Parse vdr_batch_config (nested JSON string inside conf) ────────
 				const _addMoreConfig = (() => {
-					if (!conf.vdr_batch_config) {
-						console.log(
-							"[VDR] vdr_batch_config not found in conf for field:",
-							field.fieldname
-						);
-						return null;
-					}
+					if (!conf.vdr_batch_config) return null;
 					try {
 						const cfg =
 							typeof conf.vdr_batch_config === "string"
 								? JSON.parse(conf.vdr_batch_config)
 								: conf.vdr_batch_config;
-						console.log("[VDR] vdr_batch_config parsed:", cfg);
-						if (!cfg.allow_add_more_table && !cfg.enable_batch_config) {
-							console.log(
-								"[VDR] Neither allow_add_more_table nor enable_batch_config — batch config disabled"
-							);
-							return null;
-						}
+						if (!cfg.allow_add_more_table && !cfg.enable_batch_config) return null;
 						return cfg;
 					} catch (e) {
 						console.warn(

--- a/frappe_theme/public/js/overwrite_form.bundle.js
+++ b/frappe_theme/public/js/overwrite_form.bundle.js
@@ -27,7 +27,7 @@
 						}
 					});
 				});
-				observer.observe(this.dialog.$wrapper[0], { childList: true, subtree: true })
+				observer.observe(this.dialog.$wrapper[0], { childList: true, subtree: true });
 			}
 		}
 		CustomFileUploader.__patched_for_mgrant = true;
@@ -59,7 +59,6 @@
 		});
 	}
 })();
-
 
 import { get_parent_section_field_by_fieldname } from "./utils.bundle.js";
 import Loader from "./loader-element.js";
@@ -1096,24 +1095,57 @@ frappe.ui.form.Form = class CustomForm extends frappe.ui.form.Form {
 			}
 			case "Vertical Doc Renderer": {
 				let conf = field.sva_ft;
-				frm.sva_ft_instances[field.fieldname] = new SVAVerticalDocRenderer({
+
+				// Determine doc source: link-field-based (dynamic filter) or static docs list
+				let vdrDocs = null;
+				let vdrFilters = [];
+				if (conf.vdr_link_fieldname && frm.doc[conf.vdr_link_fieldname]) {
+					// Foreign key mode: fetch docs where foreignField = frm.doc[linkField]
+					const foreignField = conf.vdr_foreign_field || "name";
+					vdrFilters = [[foreignField, "=", frm.doc[conf.vdr_link_fieldname]]];
+					vdrDocs = null; // use paginated server-side mode with filters
+				} else if (!conf.vdr_link_fieldname && conf.vdr_docs) {
+					vdrDocs = JSON.parse(conf.vdr_docs);
+				}
+				// else: vdrDocs = null, vdrFilters = [] → paginated without filters
+
+				const instance = new SVAVerticalDocRenderer({
 					wrapper,
 					frm,
 					doctype: conf.vdr_doctype,
-					docs: conf.vdr_docs ? JSON.parse(conf.vdr_docs) : [],
-					column_configs: conf.vdr_column_configs ? JSON.parse(conf.vdr_column_configs) : [],
-					fields_to_show: conf.vdr_fields_to_show ? JSON.parse(conf.vdr_fields_to_show) : null,
-					fields_to_hide: conf.vdr_fields_to_hide ? JSON.parse(conf.vdr_fields_to_hide) : [],
+					docs: vdrDocs,
+					filters: vdrFilters,
+					column_configs: conf.vdr_column_configs
+						? JSON.parse(conf.vdr_column_configs)
+						: [],
+					fields_to_show: conf.vdr_fields_to_show
+						? JSON.parse(conf.vdr_fields_to_show)
+						: null,
+					fields_to_hide: conf.vdr_fields_to_hide
+						? JSON.parse(conf.vdr_fields_to_hide)
+						: [],
 					show_section_headers: conf.vdr_show_sections !== 0,
 					show_unit: !!conf.vdr_show_unit,
 					hide_empty_rows: !!conf.vdr_hide_empty_rows,
 					title: conf.vdr_title || null,
 					show_legend: !!conf.vdr_show_legend,
 					legend_items: conf.vdr_legend_items ? JSON.parse(conf.vdr_legend_items) : [],
-					crud_permissions: conf.crud_permissions ? JSON.parse(conf.crud_permissions) : ["read"],
+					crud_permissions: conf.crud_permissions
+						? JSON.parse(conf.crud_permissions)
+						: ["read"],
 					max_height: conf.vdr_max_height != null ? Number(conf.vdr_max_height) : 600,
 					signal,
+					vdr_field_name: field.fieldname,
+					fields_config: conf.vdr_fields_config
+						? JSON.parse(conf.vdr_fields_config)
+						: null,
 				});
+
+				// Store link field config on the instance for filter ribbon integration
+				instance._vdr_link_fieldname = conf.vdr_link_fieldname || null;
+				instance._vdr_foreign_field = conf.vdr_foreign_field || "name";
+
+				frm.sva_ft_instances[field.fieldname] = instance;
 				break;
 			}
 		}
@@ -1187,8 +1219,8 @@ frappe.ui.form.Form = class CustomForm extends frappe.ui.form.Form {
 					field?.connection_type === "Is Custom Design"
 						? field?.template
 						: ["Direct", "Unfiltered", "Indirect"].includes(field.connection_type)
-							? field.link_doctype
-							: field.referenced_link_doctype
+						? field.link_doctype
+						: field.referenced_link_doctype
 				)} items`
 			);
 			element.innerHTML = `

--- a/frappe_theme/public/js/overwrite_form.bundle.js
+++ b/frappe_theme/public/js/overwrite_form.bundle.js
@@ -1237,6 +1237,9 @@ frappe.ui.form.Form = class CustomForm extends frappe.ui.form.Form {
 						? JSON.parse(conf.vdr_fields_config)
 						: null,
 					add_more_config: _addMoreConfig,
+					child_add_row_labels: conf.vdr_child_add_row_labels
+						? JSON.parse(conf.vdr_child_add_row_labels)
+						: null,
 				});
 
 				instance._vdr_link_fieldname = conf.vdr_link_fieldname || null;

--- a/frappe_theme/public/js/overwrite_form.bundle.js
+++ b/frappe_theme/public/js/overwrite_form.bundle.js
@@ -1225,9 +1225,9 @@ frappe.ui.form.Form = class CustomForm extends frappe.ui.form.Form {
 								? JSON.parse(conf.vdr_batch_config)
 								: conf.vdr_batch_config;
 						console.log("[VDR] vdr_batch_config parsed:", cfg);
-						if (!cfg.allow_add_more_table) {
+						if (!cfg.allow_add_more_table && !cfg.enable_batch_config) {
 							console.log(
-								"[VDR] allow_add_more_table is false — Add More button disabled"
+								"[VDR] Neither allow_add_more_table nor enable_batch_config — batch config disabled"
 							);
 							return null;
 						}

--- a/frappe_theme/public/js/vertical_doc_renderer/CLAUDE.md
+++ b/frappe_theme/public/js/vertical_doc_renderer/CLAUDE.md
@@ -22,11 +22,14 @@ vertical_doc_renderer/
 ├── sva_vertical_doc_renderer.bundle.js   ← Main class + mixin assembly
 └── mixins/
     ├── ui_setup.js    ← Wrapper, scroll container, loading state, AbortSignal
-    ├── data.js        ← fetchMeta() + fetchDocs() via frappe.db
+    ├── data.js        ← fetchMeta() + fetchDocs() — three-branch (object[]/string[]/null)
     ├── fields.js      ← formatCellValue() with vdr_events.formatCell hook
-    ├── rendering.js   ← buildTable, buildThead, buildTbody, section/field rows, legend
+    ├── rendering.js   ← buildTable, buildThead (_theadRow + _createTh), buildTbody,
+    │                     _buildDocHeaderCell(), _buildValueCell(), section/field rows, legend
     ├── edit.js        ← Inline editing + dialog editing + beforeSave/afterSave hooks
-    └── helpers.js     ← getColumnCount, sortDataByDocs, isEmptyRow, getFieldUnit
+    ├── helpers.js     ← getColumnCount, isEmptyRow, getFieldUnit, getVisibleFields
+    ├── viewport.js    ← IntersectionObserver sentinel; lazy column loading on scroll
+    └── create.js      ← "+" column header; openCreateDialog(); beforeCreate/afterCreate hooks
 ```
 
 ---
@@ -40,9 +43,13 @@ new SVAVerticalDocRenderer({
 
   doctype,              // string | object
                         //   string  → DocType name; fetchMeta() calls frappe.db.get_meta()
-                        //   object  → pre-built meta (e.g. frm.meta); name derived from .name
+                        //   object  → pre-built/mimicked meta {name, fields[]}; used as-is
 
-  docs,                 // string[] — doc names shown as columns (left-to-right)
+  docs,                 // string[] | object[] | null
+                        //   string[]  → names; fetched in batches as user scrolls
+                        //   object[]  → inline data; zero API calls; lazy-sliced from memory
+                        //   null      → frappe.db.get_list paginated (start + limit per batch)
+
   column_configs,       // [{label, bg_color, text_color}] — index-aligned to docs
   fields_to_show,       // string[] | null — allowlist; null = all non-hidden fields
   fields_to_hide,       // string[] — fieldnames to exclude
@@ -52,7 +59,16 @@ new SVAVerticalDocRenderer({
   title,                // string | null
   show_legend,          // boolean
   legend_items,         // [{label, bg_color, text_color, description}]
-  crud_permissions,     // string[] — ["read"] or ["read","write"]
+
+  crud_permissions,     // string[] — ["read"] | ["read","write"] | ["read","write","create"]
+                        //   "write"  → inline cell editing
+                        //   "create" → "+" column header opens create dialog
+
+  filters,              // frappe filter array — used when docs: null
+  order_by,             // string — used when docs: null
+  column_batch_size,    // number (0 = auto from viewport width)
+  column_width,         // number px (default 150) — for auto batch-size calculation
+
   signal,               // AbortSignal
 });
 ```
@@ -71,6 +87,8 @@ frm.vdr_events = {
   renderColumnHeader(doc, colIndex, th) {},      // mutate th directly
   beforeSave(df, docName, newValue) {},          // return false to cancel save
   afterSave(df, docName, newValue) {},
+  beforeCreate(values, dialog) {},               // return false to cancel create
+  afterCreate(newDoc) {},
   afterRender(instance) {},
 };
 ```
@@ -118,10 +136,11 @@ Override these in your app CSS to restyle:
 
 ## Pending / known gaps
 
-- **Pagination**: no pagination yet; all docs passed in `docs[]` are fetched at once
 - **Refresh method**: no public `refresh()` — re-instantiate to reload
 - **Child table fields**: skipped during fetch (only scalar fields fetched)
 - **Link field display values**: `frappe.format()` resolves link titles asynchronously; initial render shows raw names until resolved
+- **doctype.name not validated**: when `doctype` is an object, `doctype.name` is never checked against the server — any string works (intentional for mimicked meta)
+- **docs: null + mimicked meta**: unsupported — warns and renders empty (no real DB table to query)
 
 ---
 

--- a/frappe_theme/public/js/vertical_doc_renderer/CLAUDE.md
+++ b/frappe_theme/public/js/vertical_doc_renderer/CLAUDE.md
@@ -21,15 +21,26 @@ It is mixin-based (mirrors SVADatatable architecture) and supports per-cell/row/
 vertical_doc_renderer/
 ├── sva_vertical_doc_renderer.bundle.js   ← Main class + mixin assembly
 └── mixins/
-    ├── ui_setup.js    ← Wrapper, scroll container, loading state, AbortSignal
-    ├── data.js        ← fetchMeta() + fetchDocs() — three-branch (object[]/string[]/null)
-    ├── fields.js      ← formatCellValue() with vdr_events.formatCell hook
-    ├── rendering.js   ← buildTable, buildThead (_theadRow + _createTh), buildTbody,
-    │                     _buildDocHeaderCell(), _buildValueCell(), section/field rows, legend
-    ├── edit.js        ← Inline editing + dialog editing + beforeSave/afterSave hooks
-    ├── helpers.js     ← getColumnCount, isEmptyRow, getFieldUnit, getVisibleFields
-    ├── viewport.js    ← IntersectionObserver sentinel; lazy column loading on scroll
-    └── create.js      ← "+" column header; openCreateDialog(); beforeCreate/afterCreate hooks
+    ├── ui_setup.js     ← Wrapper, scroll container (overflow:auto + max_height),
+    │                      loading state, AbortSignal, _ensureStyles() CSS injection
+    ├── data.js         ← fetchMeta() + fetchDocs() — three-branch (object[]/string[]/null)
+    ├── fields.js       ← formatCellValue() with vdr_events.formatCell hook
+    ├── rendering.js    ← buildTable, buildThead, buildTbody, _buildDocHeaderCell(),
+    │                      _buildValueCell() (per-cell validation state + data-raw-value),
+    │                      section/field rows, legend, delete row integration
+    ├── edit.js         ← Auto-sync inline editing (blur/change save, ESC cancel,
+    │                      spinner, revert on fail) + dialog editing + save hooks
+    ├── helpers.js      ← getColumnCount, isEmptyRow, getFieldUnit, getVisibleFields
+    ├── viewport.js     ← IntersectionObserver sentinel; lazy column loading on scroll;
+    │                      calls resolveLinkTitles() + _appendDeleteCell() per batch
+    ├── create.js       ← "+" column header; openCreateDialog(); beforeCreate/afterCreate hooks
+    ├── validation.js   ← _evaluateDepends(), isFieldHidden/ReadOnly/Required(),
+    │                      validateBeforeSave(), showErrorBanner(), clearErrorBanner()
+    ├── link_titles.js  ← resolveLinkTitles() batch-fetch (one get_list per link-doctype),
+    │                      _applyLinkTitles() updates cell textContent + title attr
+    └── delete.js       ← _canDelete() RPM check, _buildDeleteRow(), _buildDeleteCell(),
+                           _appendDeleteCell(), _showDeleteIcon(), _hideDeleteIcon(),
+                           deleteDoc() frappe.xcall, _removeColumn() DOM + data sync
 ```
 
 ---
@@ -42,7 +53,9 @@ new SVAVerticalDocRenderer({
   frm,                  // Frappe form object (for vdr_events + context)
 
   doctype,              // string | object
-                        //   string  → DocType name; fetchMeta() calls frappe.db.get_meta()
+                        //   string  → DocType name; fetchMeta() calls frappe.xcall(
+                        //             "frappe_theme.dt_api.get_meta_fields", { meta_attached: 1 })
+                        //             Returns { fields: [...], meta: {...full frappe meta...} }
                         //   object  → pre-built/mimicked meta {name, fields[]}; used as-is
 
   docs,                 // string[] | object[] | null
@@ -60,14 +73,17 @@ new SVAVerticalDocRenderer({
   show_legend,          // boolean
   legend_items,         // [{label, bg_color, text_color, description}]
 
-  crud_permissions,     // string[] — ["read"] | ["read","write"] | ["read","write","create"]
-                        //   "write"  → inline cell editing
+  crud_permissions,     // string[] — ["read"] | ["read","write"] | ["read","write","create","delete"]
+                        //   "write"  → inline cell auto-sync editing (blur/change)
                         //   "create" → "+" column header opens create dialog
+                        //   "delete" → 🗑 icon row; frappe.model.can_delete() also checked
 
   filters,              // frappe filter array — used when docs: null
   order_by,             // string — used when docs: null
   column_batch_size,    // number (0 = auto from viewport width)
   column_width,         // number px (default 150) — for auto batch-size calculation
+  max_height,           // number px (default 600) — scrollBox max-height for vertical sticky
+                        //   0 = no vertical limit (header sticks to browser viewport)
 
   signal,               // AbortSignal
 });
@@ -99,48 +115,125 @@ frm.vdr_events = {
 
 | File | What was changed |
 |---|---|
-| `public/js/overwrite_form.bundle.js` | Import + `case "Vertical Doc Renderer"` in `renderCustomBlock` switch |
-| `frappe_theme/doctype/custom_property_setter/custom_property_setter.json` | New `property_type` option + 13 config fields (`vdr_doctype`, `vdr_docs`, `vdr_column_configs`, `vdr_fields_to_show`, `vdr_fields_to_hide`, `vdr_show_sections`, `vdr_show_unit`, `vdr_hide_empty_rows`, `vdr_title`, `vdr_show_legend`, `vdr_legend_items`) |
-| `public/js/doctype/property_setter.js` | `vdr_fields_being_affected` added to clear_fields on property_type change |
+| `public/js/overwrite_form.bundle.js` | Import + `case "Vertical Doc Renderer"` in `renderCustomBlock` switch; passes `crud_permissions` and `max_height` from `conf` |
+| `frappe_theme/doctype/custom_property_setter/custom_property_setter.json` | New `property_type` option + VDR config fields; `section_break_qivk` depends_on updated to include "Vertical Doc Renderer" so the shared `crud_permissions` JSON field and "Setup Crud Permissions" button are visible for VDR; `setup_list_settings` button hidden for VDR via depends_on |
+| `public/js/doctype/property_setter.js` | `vdr_fields_being_affected` list includes all VDR fields + `crud_permissions` (cleared to `["read"]` when property_type is emptied) |
+
+### crud_permissions in VDR config dialog
+
+The `crud_permissions` JSON field and "Setup Crud Permissions" button live in `section_break_qivk`, which is shared between Datatable and VDR types. The button calls `set_crud_permissiions(dialog)` — for VDR, `connection_type` is `""` (empty), which falls into the `else` branch showing all four permissions (read/write/create/delete). The dialog sets the JSON value; `overwrite_form.bundle.js` reads `conf.crud_permissions` and passes it as `JSON.parse(conf.crud_permissions)` to the VDR constructor.
 
 ---
 
-## Inline editing
+## Inline editing (auto-sync)
 
 When `crud_permissions` includes `"write"`:
-- **Simple types** (Data, Int, Float, Date, Check, Select, Small Text): in-cell Frappe control with ✓/✗ buttons
-- **Complex types** (Link, Text, Attach, etc.): `frappe.ui.Dialog` popup
+- **Simple types** (Data, Int, Float, Date, Check, Select, Small Text): in-cell Frappe control; saves automatically on `blur` (text) or `change` (Check/Select); ESC cancels
+- **Complex types** (Link, Text, Attach, etc.): `frappe.ui.Dialog` with explicit Save button
+- **Saving state**: cell opacity drops to 0.5 + spinner icon while async save is in-flight
+- **On failure**: cell reverts to original HTML; error banner appears above table
+- **On success**: error banner cleared; `doc[fieldname]` updated in memory
 - Save path: `frappe.db.set_value(doctype, docName, fieldname, newValue)`
+- Read-only fields (`df.read_only = 1` or `read_only_depends_on`) are never editable.
 
-Read-only fields (`df.read_only = 1`) are never editable.
+---
+
+## Validations (per-cell, per-document)
+
+`depends_on`, `mandatory_depends_on`, `read_only_depends_on` are evaluated independently
+for each document column using `frappe.utils.custom_eval`:
+
+| Expression type | Effect |
+|---|---|
+| `df.depends_on` | Cell is `visibility:hidden` if expression is false for this doc |
+| `df.read_only_depends_on` | Cell styled as muted; click-to-edit disabled |
+| `df.mandatory_depends_on` | Attempting to save empty value shows error banner, blocks save |
+
+---
+
+## Link field titles
+
+After render (and after each viewport batch), `resolveLinkTitles()`:
+1. Collects all unique Link field values across `this.data`, grouped by linked DocType
+2. Skips already-cached values (`this._linkTitles`)
+3. Issues **one `frappe.db.get_list` per linked DocType** (never one per cell)
+4. **Title field discovery** (two sources, in priority order):
+   - `frappe.boot.link_title_doctypes[ldt]` — populated by Frappe when `show_title_field_in_link = 1` on the DocType
+   - `frappe.get_meta(ldt)?.title_field` — in-memory fallback; works if the linked DocType's form was opened earlier in the session (zero extra API calls)
+5. Updates cell `textContent` with the resolved title; cell `title` attribute shows raw name
+6. Cells where `title === rawName` (no separate display title exists) are left unchanged
+
+---
+
+## Delete column
+
+When `crud_permissions` includes `"delete"` **and** `frappe.model.can_delete(doctype)`:
+- A `<tr class="sva-vdr-delete-row">` appears as the first tbody row
+- Each doc column gets a 🗑 button (hidden, revealed on column header hover with 150ms debounce)
+- Clicking confirms → `frappe.xcall("frappe.client.delete")` → column removed from DOM + data arrays
+- Hover identification uses `doc.name` (not column index) so remaining columns work after deletion
+
+---
+
+## Sticky freeze
+
+- **Params column** (`left: 0; z-index: 1`): stays visible when scrolling right
+- **Doc header cells** (`top: 0; z-index: 2`): stay visible when scrolling down
+- **Corner cell** (paramTh, `top: 0; left: 0; z-index: 3`): always visible
+- Requires `scrollBox` to have `overflow: auto` + `max-height` — controlled by `max_height` param
+- `container` uses `overflow: visible` (not `hidden`) to allow sticky to propagate
 
 ---
 
 ## CSS custom properties (theming)
 
-Override these in your app CSS to restyle:
-
 ```css
 .sva-vdr-container {
-  --sva-vdr-header-bg:    #1a3a5c;
-  --sva-vdr-header-text:  #fff;
-  --sva-vdr-section-bg:   #1a3a5c;
-  --sva-vdr-section-text: #fff;
-  --sva-vdr-label-bg:     #dce6f1;
-  --sva-vdr-label-text:   #1a3a5c;
-  --sva-vdr-row-hover:    #f0f4ff;
+  --sva-vdr-header-bg:      #1a3a5c;
+  --sva-vdr-header-text:    #fff;
+  --sva-vdr-section-bg:     #1a3a5c;
+  --sva-vdr-section-text:   #fff;
+  --sva-vdr-label-bg:       #dce6f1;
+  --sva-vdr-label-text:     #1a3a5c;
+  --sva-vdr-row-hover:      #f0f4ff;
+  --sva-vdr-readonly-bg:    #f5f5f5;
+  --sva-vdr-readonly-text:  #999;
 }
 ```
 
 ---
 
-## Pending / known gaps
+## API notes
+
+### `fetchMeta()` — why not `frappe.db.get_meta`
+`frappe.db.get_meta` does not exist in the version of Frappe used here. Meta is fetched via:
+```js
+frappe.xcall("frappe_theme.dt_api.get_meta_fields", {
+    doctype, _type: "Direct", meta_attached: 1
+})
+// Returns: { fields: [...filtered fields...], meta: {...full frappe meta...} }
+```
+`frappe.xcall` resolves the `message` payload directly (unlike `frappe.call` which returns `{ message: ... }`).
+The response is spread into `this.meta`:
+```js
+this.meta = { ...(response.meta || {}), name: this.doctype, fields: response.fields || [] };
+```
+
+### `frappe.xcall` vs `frappe.call` vs `SVAHTTP.call`
+- **`frappe.xcall(method, args)`** — flat JSON args, resolves `message` directly → preferred for VDR
+- **`frappe.call({ method, args })`** — nested args, returns `{ message: ... }` → old pattern
+- **`SVAHTTP.call`** — internal HTTP client; sends flat JSON body, similar to xcall
+
+---
+
+## Known gaps
 
 - **Refresh method**: no public `refresh()` — re-instantiate to reload
 - **Child table fields**: skipped during fetch (only scalar fields fetched)
-- **Link field display values**: `frappe.format()` resolves link titles asynchronously; initial render shows raw names until resolved
 - **doctype.name not validated**: when `doctype` is an object, `doctype.name` is never checked against the server — any string works (intentional for mimicked meta)
 - **docs: null + mimicked meta**: unsupported — warns and renders empty (no real DB table to query)
+- **Section row colSpan**: does not include the "+" create column (cosmetic; section headers span data columns only)
+- **Link titles without title_field config**: if neither `frappe.boot.link_title_doctypes` nor the in-memory meta cache has a title field for a linked DocType, the raw document name is shown (correct fallback — configure `show_title_field_in_link = 1` and `title_field` on the linked DocType to enable display titles)
 
 ---
 

--- a/frappe_theme/public/js/vertical_doc_renderer/CLAUDE.md
+++ b/frappe_theme/public/js/vertical_doc_renderer/CLAUDE.md
@@ -1,0 +1,130 @@
+# SVAVerticalDocRenderer — Module Context
+
+This directory contains the `SVAVerticalDocRenderer` component. When working in this module, read this file first for full context.
+
+---
+
+## What this component does
+
+Renders multiple documents of any DocType side-by-side as a comparison table:
+- **Rows** = DocType fields (grouped by section breaks)
+- **Columns** = individual documents
+- **Section Breaks** = styled full-width header rows
+
+It is mixin-based (mirrors SVADatatable architecture) and supports per-cell/row/header overrides via a `vdr_events` hook system.
+
+---
+
+## File map
+
+```
+vertical_doc_renderer/
+├── sva_vertical_doc_renderer.bundle.js   ← Main class + mixin assembly
+└── mixins/
+    ├── ui_setup.js    ← Wrapper, scroll container, loading state, AbortSignal
+    ├── data.js        ← fetchMeta() + fetchDocs() via frappe.db
+    ├── fields.js      ← formatCellValue() with vdr_events.formatCell hook
+    ├── rendering.js   ← buildTable, buildThead, buildTbody, section/field rows, legend
+    ├── edit.js        ← Inline editing + dialog editing + beforeSave/afterSave hooks
+    └── helpers.js     ← getColumnCount, sortDataByDocs, isEmptyRow, getFieldUnit
+```
+
+---
+
+## Constructor API
+
+```js
+new SVAVerticalDocRenderer({
+  wrapper,              // HTMLElement — container
+  frm,                  // Frappe form object (for vdr_events + context)
+
+  doctype,              // string | object
+                        //   string  → DocType name; fetchMeta() calls frappe.db.get_meta()
+                        //   object  → pre-built meta (e.g. frm.meta); name derived from .name
+
+  docs,                 // string[] — doc names shown as columns (left-to-right)
+  column_configs,       // [{label, bg_color, text_color}] — index-aligned to docs
+  fields_to_show,       // string[] | null — allowlist; null = all non-hidden fields
+  fields_to_hide,       // string[] — fieldnames to exclude
+  show_section_headers, // boolean (default true)
+  show_unit,            // boolean — "Unit" column parsed from field.description
+  hide_empty_rows,      // boolean — skip rows where all docs have no value
+  title,                // string | null
+  show_legend,          // boolean
+  legend_items,         // [{label, bg_color, text_color, description}]
+  crud_permissions,     // string[] — ["read"] or ["read","write"]
+  signal,               // AbortSignal
+});
+```
+
+---
+
+## vdr_events hook system
+
+Set on the Frappe form before the component renders:
+
+```js
+frm.vdr_events = {
+  formatCell(value, df, doc, colIndex) {},       // return non-null to override cell HTML
+  renderRow(df, allDocsData, tr) {},             // return true = custom row built
+  renderSectionHeader(label, colCount, tr) {},   // return true = custom header built
+  renderColumnHeader(doc, colIndex, th) {},      // mutate th directly
+  beforeSave(df, docName, newValue) {},          // return false to cancel save
+  afterSave(df, docName, newValue) {},
+  afterRender(instance) {},
+};
+```
+
+---
+
+## Integration points (files outside this directory)
+
+| File | What was changed |
+|---|---|
+| `public/js/overwrite_form.bundle.js` | Import + `case "Vertical Doc Renderer"` in `renderCustomBlock` switch |
+| `frappe_theme/doctype/custom_property_setter/custom_property_setter.json` | New `property_type` option + 13 config fields (`vdr_doctype`, `vdr_docs`, `vdr_column_configs`, `vdr_fields_to_show`, `vdr_fields_to_hide`, `vdr_show_sections`, `vdr_show_unit`, `vdr_hide_empty_rows`, `vdr_title`, `vdr_show_legend`, `vdr_legend_items`) |
+| `public/js/doctype/property_setter.js` | `vdr_fields_being_affected` added to clear_fields on property_type change |
+
+---
+
+## Inline editing
+
+When `crud_permissions` includes `"write"`:
+- **Simple types** (Data, Int, Float, Date, Check, Select, Small Text): in-cell Frappe control with ✓/✗ buttons
+- **Complex types** (Link, Text, Attach, etc.): `frappe.ui.Dialog` popup
+- Save path: `frappe.db.set_value(doctype, docName, fieldname, newValue)`
+
+Read-only fields (`df.read_only = 1`) are never editable.
+
+---
+
+## CSS custom properties (theming)
+
+Override these in your app CSS to restyle:
+
+```css
+.sva-vdr-container {
+  --sva-vdr-header-bg:    #1a3a5c;
+  --sva-vdr-header-text:  #fff;
+  --sva-vdr-section-bg:   #1a3a5c;
+  --sva-vdr-section-text: #fff;
+  --sva-vdr-label-bg:     #dce6f1;
+  --sva-vdr-label-text:   #1a3a5c;
+  --sva-vdr-row-hover:    #f0f4ff;
+}
+```
+
+---
+
+## Pending / known gaps
+
+- **Pagination**: no pagination yet; all docs passed in `docs[]` are fetched at once
+- **Refresh method**: no public `refresh()` — re-instantiate to reload
+- **Child table fields**: skipped during fetch (only scalar fields fetched)
+- **Link field display values**: `frappe.format()` resolves link titles asynchronously; initial render shows raw names until resolved
+
+---
+
+## Branch
+
+`claude/create-sva-vertical-doc-renderer`

--- a/frappe_theme/public/js/vertical_doc_renderer/CLAUDE.md
+++ b/frappe_theme/public/js/vertical_doc_renderer/CLAUDE.md
@@ -76,6 +76,12 @@ new SVAVerticalDocRenderer({
   show_legend,          // boolean
   legend_items,         // [{label, bg_color, text_color, description}]
 
+  section_configs,      // object (default {}) — keyed by Section Break fieldname or label
+                        //   Values: { label, bg_color, text_color, collapsed, hidden }
+                        //   collapsed: true → section starts folded; click header to toggle
+                        //   hidden:    true → section header + all fields not rendered
+                        //   Fieldname key wins over label key when both match.
+
   crud_permissions,     // string[] — ["read"] | ["read","write"] | ["read","write","create","delete"]
                         //   "write"  → inline cell auto-sync editing (blur/change)
                         //   "create" → "+" column header opens create dialog

--- a/frappe_theme/public/js/vertical_doc_renderer/CLAUDE.md
+++ b/frappe_theme/public/js/vertical_doc_renderer/CLAUDE.md
@@ -272,6 +272,22 @@ this.meta = { ...(response.meta || {}), name: this.doctype, fields: response.fie
 
 ---
 
+## Geolocation field rendering
+
+`Geolocation` fields are rendered in the comparison table (not skipped). `_formatGeolocation()` in `fields.js` parses the stored GeoJSON string:
+
+| Geometry type | Cell display |
+|---|---|
+| Single `Point` | `📍 lat, lng` — a Google Maps link (opens in new tab) |
+| `Polygon` / `LineString` / mixed | `🗺 <Type>` label with feature count when > 1 |
+| Empty / unparseable | empty cell |
+
+GeoJSON stores coordinates as `[longitude, latitude]`; the cell displays them as `latitude, longitude` (conventional).
+
+When `"write"` is in `crud_permissions`, clicking a Geolocation cell opens the standard `frappe.ui.Dialog` with the Frappe Geolocation control (map picker). Inline editing is not used for this field type.
+
+---
+
 ## Known gaps
 
 - **Refresh method**: `reloadTable()` is available; `refresh()` falls back to `reloadTable()` in overwrite_form.bundle.js

--- a/frappe_theme/public/js/vertical_doc_renderer/CLAUDE.md
+++ b/frappe_theme/public/js/vertical_doc_renderer/CLAUDE.md
@@ -87,6 +87,11 @@ new SVAVerticalDocRenderer({
                         //   "create" → "+" column header opens create dialog
                         //   "delete" → 🗑 icon row; frappe.model.can_delete() also checked
 
+  link_title_fields,    // object (default {}) — { [LinkedDocType]: fieldname }
+                        //   Highest-priority override for link title resolution.
+                        //   Use when the linked DocType has no title_field configured.
+                        //   e.g. { "District": "district_name", "Mandal": "mandal_name" }
+
   filters,              // frappe filter array — used when docs: null
   order_by,             // string — used when docs: null
   column_batch_size,    // number (0 = auto from viewport width)
@@ -166,11 +171,43 @@ After render (and after each viewport batch), `resolveLinkTitles()`:
 1. Collects all unique Link field values across `this.data`, grouped by linked DocType
 2. Skips already-cached values (`this._linkTitles`)
 3. Issues **one `frappe.db.get_list` per linked DocType** (never one per cell)
-4. **Title field discovery** (two sources, in priority order):
+4. **Title field discovery** (three sources, in priority order):
+   - `this.link_title_fields[ldt]` — explicit per-DocType override passed in the constructor
    - `frappe.boot.link_title_doctypes[ldt]` — populated by Frappe when `show_title_field_in_link = 1` on the DocType
    - `frappe.get_meta(ldt)?.title_field` — in-memory fallback; works if the linked DocType's form was opened earlier in the session (zero extra API calls)
 5. Updates cell `textContent` with the resolved title; cell `title` attribute shows raw name
 6. Cells where `title === rawName` (no separate display title exists) are left unchanged
+
+### `link_title_fields` constructor option
+
+Use this when the linked DocType has no `title_field` configured in Frappe but you know which field holds the display name:
+
+```js
+new SVAVerticalDocRenderer({
+    wrapper,
+    doctype: "IGGAARL Farmer",
+    docs: [...],
+    link_title_fields: {
+        "State":     "state_name",
+        "District":  "district_name",
+        "Mandal":    "mandal_name",
+        "Village":   "village_name",
+        "Panchayat": "panchayat_name",
+        "RBK":       "rbk_name",
+    },
+});
+```
+
+Keys are the linked DocType names (the `options` value on the Link field). Values are the field to fetch and display from that DocType.
+
+### Dialog-edit cell refresh (fix)
+
+After a Link/complex field is saved via the `frappe.ui.Dialog` popup (`cell = null` path), `saveValue()` now:
+1. Finds the target cell via `[data-fieldname][data-docname]`
+2. Updates `data-raw-value`, re-renders cell HTML, re-attaches click listener
+3. Invalidates the `_linkTitles` cache entry for the new value, then calls `resolveLinkTitles()`
+
+This ensures the cell displays the new value (and its resolved display name) immediately after the dialog closes — without a full table reload.
 
 ---
 
@@ -242,7 +279,7 @@ this.meta = { ...(response.meta || {}), name: this.doctype, fields: response.fie
 - **doctype.name not validated**: when `doctype` is an object, `doctype.name` is never checked against the server — any string works (intentional for mimicked meta)
 - **docs: null + mimicked meta**: unsupported — warns and renders empty (no real DB table to query)
 - **Section row colSpan**: does not include the "+" create column (cosmetic; section headers span data columns only)
-- **Link titles without title_field config**: if neither `frappe.boot.link_title_doctypes` nor the in-memory meta cache has a title field for a linked DocType, the raw document name is shown (correct fallback — configure `show_title_field_in_link = 1` and `title_field` on the linked DocType to enable display titles)
+- **Link titles without title_field config**: if none of the three sources (`link_title_fields`, `frappe.boot.link_title_doctypes`, `frappe.get_meta()`) has a title field for a linked DocType, the raw document name is shown (correct fallback). Use the `link_title_fields` constructor option to override without touching the DocType config.
 
 ---
 

--- a/frappe_theme/public/js/vertical_doc_renderer/CLAUDE.md
+++ b/frappe_theme/public/js/vertical_doc_renderer/CLAUDE.md
@@ -33,7 +33,10 @@ vertical_doc_renderer/
     ├── helpers.js      ← getColumnCount, isEmptyRow, getFieldUnit, getVisibleFields
     ├── viewport.js     ← IntersectionObserver sentinel; lazy column loading on scroll;
     │                      calls resolveLinkTitles() + _appendDeleteCell() per batch
-    ├── create.js       ← "+" column header; openCreateDialog(); beforeCreate/afterCreate hooks
+    ├── create.js       ← "+" column header; openCreateDialog() adds a draft column inline
+    │                      (no dialog); _buildDraftHeaderCell/_buildDraftValueCell;
+    │                      _commitDraftColumn(frappe.db.insert); _removeDraftColumn;
+    │                      beforeCreate/afterCreate hooks
     ├── validation.js   ← _evaluateDepends(), isFieldHidden/ReadOnly/Required(),
     │                      validateBeforeSave(), showErrorBanner(), clearErrorBanner()
     ├── link_titles.js  ← resolveLinkTitles() batch-fetch (one get_list per link-doctype),
@@ -228,7 +231,7 @@ this.meta = { ...(response.meta || {}), name: this.doctype, fields: response.fie
 
 ## Known gaps
 
-- **Refresh method**: no public `refresh()` — re-instantiate to reload
+- **Refresh method**: `reloadTable()` is available; `refresh()` falls back to `reloadTable()` in overwrite_form.bundle.js
 - **Child table fields**: skipped during fetch (only scalar fields fetched)
 - **doctype.name not validated**: when `doctype` is an object, `doctype.name` is never checked against the server — any string works (intentional for mimicked meta)
 - **docs: null + mimicked meta**: unsupported — warns and renders empty (no real DB table to query)

--- a/frappe_theme/public/js/vertical_doc_renderer/README.md
+++ b/frappe_theme/public/js/vertical_doc_renderer/README.md
@@ -226,9 +226,10 @@ new SVAVerticalDocRenderer({
 
     // ── Permissions & editing ───────────────────────────────────────────────
     crud_permissions,     // string[] (default ["read"])
-                          //   "write"  → inline cell editing
+                          //   "write"  → inline cell auto-sync editing (blur/change saves)
                           //   "create" → "+" column header to create new docs in a dialog
-                          //   e.g. ["read", "write", "create"]
+                          //   "delete" → 🗑 icon row (frappe.model.can_delete() also checked)
+                          //   e.g. ["read", "write", "create", "delete"]
 
     // ── Pagination / lazy loading ───────────────────────────────────────────
     filters,              // frappe filter array — used when docs: null
@@ -237,6 +238,8 @@ new SVAVerticalDocRenderer({
     column_batch_size,    // number (default 0 = auto-calculate from viewport width)
                           //   Number of columns to render per scroll batch
     column_width,         // number px (default 150) — column width estimate for auto batch size
+    max_height,           // number px (default 600) — scrollBox max-height for vertical sticky
+                          //   0 = no limit (header sticks to browser viewport via window scroll)
 
     // ── Integration ─────────────────────────────────────────────────────────
     frm,                  // Frappe form object (optional)
@@ -380,7 +383,7 @@ frm.vdr_events = {
 
 ---
 
-## Inline editing
+## Inline editing (auto-sync)
 
 Enable by adding `"write"` to `crud_permissions`:
 
@@ -395,12 +398,102 @@ new SVAVerticalDocRenderer({
 
 **Behavior by field type:**
 
-| Field types | Edit mode |
+| Field types | Edit behaviour |
 |---|---|
-| Data, Int, Float, Currency, Percent, Date, Datetime, Time, Check, Select, Small Text | In-cell editor (Frappe control with ✓ / ✗ buttons) |
-| Link, Text, Long Text, Attach, and all others | Dialog popup (`frappe.ui.Dialog`) |
+| Data, Int, Float, Currency, Percent, Date, Datetime, Time, Small Text | In-cell editor — saves automatically when focus leaves the input (blur) |
+| Check, Select | In-cell editor — saves immediately on `change` |
+| Link, Text, Long Text, Attach, and all others | Dialog popup (`frappe.ui.Dialog`) with an explicit Save button |
 
-Clicking a cell opens the editor. Saving calls `frappe.db.set_value(doctype, docName, fieldname, newValue)` and refreshes the cell. Fields with `read_only: 1` in the meta are never editable.
+**UX details:**
+- Click a cell to open the editor — no separate Edit button needed.
+- **ESC** while editing reverts the cell to its original content without saving.
+- While saving: cell opacity drops to 0.5 and a spinner (↻) appears.
+- **On success**: error banner (if any) is cleared; in-memory `doc[fieldname]` is updated.
+- **On failure**: cell reverts to original content; a red error banner appears above the table.
+- Read-only fields (`df.read_only = 1` or `read_only_depends_on` evaluated true) are never editable.
+
+---
+
+## Validations (depends_on per cell per document)
+
+`depends_on`, `mandatory_depends_on`, and `read_only_depends_on` are evaluated **independently for each document column** using `frappe.utils.custom_eval` (falling back to `new Function` evaluation):
+
+| Field attribute | Effect |
+|---|---|
+| `depends_on` | Cell is `visibility: hidden` for documents where the expression is false |
+| `read_only_depends_on` | Cell styled as muted; click-to-edit disabled for that document |
+| `mandatory_depends_on` | Saving an empty value shows the error banner and blocks the API call |
+
+Example — show "Verified By" only when Status is "Active":
+```js
+// In your DocType field definition:
+{ fieldname: "verified_by", label: "Verified By", fieldtype: "Link",
+  depends_on: "eval:doc.status == 'Active'" }
+```
+In the comparison table, the "Verified By" row is visible only in columns where `status === "Active"`.
+
+---
+
+## Link field titles
+
+After render (and after each lazy-loaded viewport batch), the component resolves display names for Link fields in a single batch per linked DocType — never one API call per cell:
+
+```
+Customer CUST-001 → "John's Company"   (customer_name field)
+Item     ITEM-001 → "Steel Bolt 5mm"   (item_name field)
+```
+
+**How title fields are discovered (in priority order):**
+1. `frappe.boot.link_title_doctypes` — Frappe populates this at boot for DocTypes with `show_title_field_in_link = 1`
+2. `frappe.get_meta(linkedDoctype)?.title_field` — in-memory fallback; available if the linked DocType's form was opened during the same session (zero extra API calls)
+
+If neither source has a title field, the raw document name is shown (correct default).
+
+To enable display titles for a custom DocType: open **Customize Form** → the DocType → check **Show Title in Link** and set the **Title Field**.
+
+---
+
+## Delete column
+
+Enable by adding `"delete"` to `crud_permissions` (frappe Role Permission Manager is also checked):
+
+```js
+new SVAVerticalDocRenderer({
+    wrapper,
+    doctype: "Employee",
+    docs: ["EMP-0001", "EMP-0002"],
+    crud_permissions: ["read", "write", "create", "delete"],
+});
+```
+
+- A 🗑 button appears in each column header on hover (150 ms debounce so you can move the mouse from header to button).
+- Clicking shows a `frappe.confirm` dialog.
+- On confirm: `frappe.xcall("frappe.client.delete", { doctype, name })` → column removed from DOM and data arrays.
+- Hover state is tracked by `doc.name` (not column index), so remaining columns continue to work correctly after a deletion.
+
+---
+
+## Sticky freeze
+
+The "Parameters" label column and the document header row are both sticky:
+
+| Element | CSS | Result |
+|---|---|---|
+| Parameters column | `position: sticky; left: 0; z-index: 1` | Stays visible while scrolling right |
+| Doc header cells | `position: sticky; top: 0; z-index: 2` | Stays visible while scrolling down |
+| Corner cell (Parameters header) | `position: sticky; top: 0; left: 0; z-index: 3` | Always visible |
+
+Sticky works because `scrollBox` has `overflow: auto` and `max-height`. Control the height with `max_height`:
+
+```js
+new SVAVerticalDocRenderer({
+    wrapper,
+    doctype: "Employee",
+    docs: ["EMP-0001"],
+    max_height: 400,   // px — scrollBox height cap; sticky works within the box
+    // max_height: 0   // no cap — header sticks to the browser viewport via window scroll
+});
+```
 
 ---
 
@@ -461,6 +554,7 @@ Developers who prefer a UI-driven approach can configure the component via the *
    - **Document Names** — JSON array, e.g. `["DOC-001", "DOC-002"]`
    - **Column Configs** — JSON array, e.g. `[{"label":"A","bg_color":"#4472C4","text_color":"#fff"}]`
    - **Fields to Show / Hide**, **Show Section Headers**, **Show Unit Column**, etc.
+   - **Setup Crud Permissions** — click the button to open a dialog for configuring read/write/create/delete access; defaults to `["read"]` only
 
 The component is then rendered automatically on form load. `vdr_events` can still be set from the form's DocType JS to override rendering.
 
@@ -474,17 +568,27 @@ frappe.ui.form.on("My DocType", {
         const wrapper = frm.fields_dict.comparison_view.$wrapper[0];
         wrapper.innerHTML = "";
 
-        // Set event overrides before creating the component
+        // Event overrides — set before instantiating
         frm.vdr_events = {
+            // Colour-code the "status" field per document
             formatCell(value, df, doc, colIndex) {
                 if (df.fieldname === "status") {
                     const colors = { Active: "green", Inactive: "red", Pending: "orange" };
                     return `<span style="color:${colors[value] || "inherit"}">${value || "-"}</span>`;
                 }
-                return null;
+                return null; // use default frappe.format() for everything else
             },
+
+            // Block saving "Blocked" status
+            beforeSave(df, docName, newValue) {
+                if (df.fieldname === "status" && newValue === "Blocked") {
+                    frappe.msgprint("Status cannot be set to Blocked here.");
+                    return false; // cancels the save
+                }
+            },
+
             afterRender(instance) {
-                console.log("VDR ready:", instance);
+                console.log("VDR ready — columns:", instance.docs.length);
             },
         };
 
@@ -492,17 +596,32 @@ frappe.ui.form.on("My DocType", {
             wrapper,
             frm,
             doctype: "Employee",
-            docs: [frm.doc.primary_employee, frm.doc.secondary_employee, frm.doc.tertiary_employee].filter(Boolean),
+
+            // Three docs pinned by the parent form; lazy batches load on scroll
+            docs: [
+                frm.doc.primary_employee,
+                frm.doc.secondary_employee,
+                frm.doc.tertiary_employee,
+            ].filter(Boolean),
+
             column_configs: [
                 { label: "Primary",   bg_color: "#4472C4", text_color: "#fff" },
                 { label: "Secondary", bg_color: "#70AD47", text_color: "#fff" },
                 { label: "Tertiary",  bg_color: "#ED7D31", text_color: "#fff" },
             ],
+
             fields_to_hide: ["naming_series", "full_name", "employee_number"],
             show_section_headers: true,
             show_unit: false,
+            hide_empty_rows: true,
+
             title: "Employee Comparison",
-            crud_permissions: ["read", "write"],
+
+            // Inline editing + create + delete enabled; RPM still enforced
+            crud_permissions: ["read", "write", "create", "delete"],
+
+            max_height: 500,    // px — params column and header row stick within this box
+
             show_legend: true,
             legend_items: [
                 { label: "Primary",   bg_color: "#4472C4", description: "Primary employee for this record" },

--- a/frappe_theme/public/js/vertical_doc_renderer/README.md
+++ b/frappe_theme/public/js/vertical_doc_renderer/README.md
@@ -1,0 +1,425 @@
+# SVAVerticalDocRenderer
+
+A reusable Frappe component that renders multiple documents of any DocType side-by-side as a comparison table — fields as rows, documents as columns, section breaks as styled header rows.
+
+```
+┌─────────────────┬──────────────┬──────────────┬──────────────┐
+│  Parameters     │   Doc A      │   Doc B      │   Doc C      │
+├─────────────────┼──────────────┼──────────────┼──────────────┤
+│ ── Contact ─────────────────────────────────────────────────── │
+│  First Name     │  Alice       │  Bob         │  Carol       │
+│  Last Name      │  Smith       │  Jones       │  White       │
+│  Mobile No.     │  9876543210  │  9123456789  │  9000001111  │
+├─────────────────┼──────────────┼──────────────┼──────────────┤
+│ ── Address ─────────────────────────────────────────────────── │
+│  Village        │  Kadakella   │  Santhavurity│  Kambara     │
+│  District       │  Srikakulam  │  East Godavar│  East Godavar│
+└─────────────────┴──────────────┴──────────────┴──────────────┘
+```
+
+---
+
+## Quick start
+
+The component is automatically available anywhere in the Frappe desk after `bench build` because it is imported by `overwrite_form.bundle.js`. Import it directly in any JS file:
+
+```js
+import SVAVerticalDocRenderer from "../../vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js";
+```
+
+Or, if you're writing inline DocType JS (registered via `doctype_js` in hooks.py), the class is available on `window` after the bundle loads — but the import approach is recommended for bundle files.
+
+---
+
+## Basic usage
+
+### Minimal — doctype name + doc list
+
+```js
+const container = document.createElement("div");
+document.body.appendChild(container);
+
+new SVAVerticalDocRenderer({
+    wrapper: container,
+    doctype: "Employee",
+    docs: ["EMP-0001", "EMP-0002", "EMP-0003"],
+});
+```
+
+This fetches the `Employee` meta automatically, fetches the three documents, and renders the table.
+
+---
+
+### Inside a Frappe form (DocType JS)
+
+```js
+// my_doctype.js
+frappe.ui.form.on("My DocType", {
+    refresh(frm) {
+        // Render a comparison of related records inside an HTML field
+        const wrapper = frm.fields_dict.my_html_field.$wrapper[0];
+        wrapper.innerHTML = "";
+
+        new SVAVerticalDocRenderer({
+            wrapper,
+            frm,
+            doctype: "Employee",
+            docs: ["EMP-0001", "EMP-0002", "EMP-0003"],
+            column_configs: [
+                { label: "Alice",  bg_color: "#4472C4", text_color: "#fff" },
+                { label: "Bob",    bg_color: "#70AD47", text_color: "#fff" },
+                { label: "Carol",  bg_color: "#ED7D31", text_color: "#fff" },
+            ],
+        });
+    },
+});
+```
+
+---
+
+### Pass a pre-built meta object (skip the network fetch)
+
+When you already have the meta (e.g. you're inside the form's own JS and `frm.meta` is available), pass the object directly. The component detects the type and skips `frappe.db.get_meta()`:
+
+```js
+new SVAVerticalDocRenderer({
+    wrapper,
+    frm,
+    doctype: frm.meta,          // object → used as-is; name derived from frm.meta.name
+    docs: ["REC-001", "REC-002"],
+});
+```
+
+Any plain object with a `.name` string and a `.fields` array is accepted:
+
+```js
+const customMeta = {
+    name: "Employee",
+    fields: [
+        { fieldname: "employee_name", label: "Name",       fieldtype: "Data" },
+        { fieldname: "department",    label: "Department", fieldtype: "Link", options: "Department" },
+        { fieldname: "date_of_joining", label: "Joined",  fieldtype: "Date" },
+    ],
+};
+
+new SVAVerticalDocRenderer({
+    wrapper,
+    doctype: customMeta,
+    docs: ["EMP-0001", "EMP-0002"],
+});
+```
+
+---
+
+## All constructor options
+
+```js
+new SVAVerticalDocRenderer({
+    // ── Required ────────────────────────────────────────────────────────────
+    wrapper,              // HTMLElement — where the table is rendered
+
+    doctype,              // string | object
+                          //   "Employee"  → fetches meta via frappe.db.get_meta("Employee")
+                          //   frm.meta    → used directly; doctype name = frm.meta.name
+                          //   customMeta  → any object with .name and .fields
+
+    docs,                 // string[] — doc names shown as columns, left to right
+                          //   e.g. ["EMP-0001", "EMP-0002", "EMP-0003"]
+
+    // ── Column headers ───────────────────────────────────────────────────────
+    column_configs,       // object[] — styling per column, index-aligned with docs
+                          //   { label, bg_color, text_color }
+                          //   Defaults: label = doc name, bg = #4472C4, text = #fff
+                          //   e.g. [
+                          //     { label: "NF",   bg_color: "#4472C4", text_color: "#fff" },
+                          //     { label: "M-NF", bg_color: "#70AD47", text_color: "#fff" },
+                          //     { label: "CF",   bg_color: "#ED7D31", text_color: "#fff" },
+                          //   ]
+
+    // ── Field visibility ────────────────────────────────────────────────────
+    fields_to_show,       // string[] | null (default null = show all non-hidden fields)
+                          //   e.g. ["first_name", "last_name", "mobile_number"]
+    fields_to_hide,       // string[] (default [])
+                          //   e.g. ["naming_series", "full_name"]
+
+    // ── Layout ──────────────────────────────────────────────────────────────
+    show_section_headers, // boolean (default true)
+                          //   Renders Section Break / Tab Break labels as full-width rows
+    show_unit,            // boolean (default false)
+                          //   Adds a "Unit" column. Value is parsed from field.description:
+                          //     "in acre" → "ac", "in year" → "yr", "(kg)" → "kg"
+    hide_empty_rows,      // boolean (default false)
+                          //   Skip rows where every doc has null/empty value
+
+    // ── Optional extras ─────────────────────────────────────────────────────
+    title,                // string | null — heading shown above the table
+    show_legend,          // boolean (default false)
+    legend_items,         // object[] — footnote legend below the table
+                          //   { label, bg_color, text_color, description }
+                          //   e.g. [
+                          //     { label: "NF",   bg_color: "#4472C4", description: "Natural Farming Farmer" },
+                          //     { label: "M-NF", bg_color: "#70AD47", description: "Matured NF Farmer" },
+                          //   ]
+
+    // ── Permissions & editing ───────────────────────────────────────────────
+    crud_permissions,     // string[] (default ["read"])
+                          //   Add "write" to enable inline editing on cells
+                          //   e.g. ["read", "write"]
+
+    // ── Integration ─────────────────────────────────────────────────────────
+    frm,                  // Frappe form object (optional)
+                          //   - Used to read frm.vdr_events (see Events section)
+                          //   - Not required for standalone use
+    signal,               // AbortSignal (optional)
+                          //   Pass an AbortController signal to clean up on navigation
+                          //   e.g. signal: controller.signal
+});
+```
+
+---
+
+## Overriding rendering with `vdr_events`
+
+Set `frm.vdr_events` before instantiating the component (or pass `events` directly — see tip below). Each handler is optional; return the specified value to override default behavior, or return nothing/`null` to fall through to the default.
+
+### Override a specific cell's display
+
+```js
+frm.vdr_events = {
+    formatCell(value, df, doc, colIndex) {
+        // Highlight zero values in red
+        if (df.fieldtype === "Int" && value === 0) {
+            return `<span style="color:red;">0</span>`;
+        }
+        // Return null/undefined to use default frappe.format()
+        return null;
+    },
+};
+```
+
+### Override an entire field row
+
+```js
+frm.vdr_events = {
+    renderRow(df, allDocsData, tr) {
+        if (df.fieldname === "mobile_number") {
+            // Build a completely custom <tr>
+            tr.innerHTML = `
+                <td style="font-weight:bold;padding:4px 10px;">Mobile</td>
+                ${allDocsData.map(doc =>
+                    `<td style="padding:4px 10px;">
+                        <a href="tel:${doc.mobile_number}">${doc.mobile_number || "-"}</a>
+                    </td>`
+                ).join("")}
+            `;
+            return true; // signal: row is fully built, skip default rendering
+        }
+        return null;     // fall through to default for all other rows
+    },
+};
+```
+
+### Override a section header
+
+```js
+frm.vdr_events = {
+    renderSectionHeader(label, colCount, tr) {
+        const td = document.createElement("td");
+        td.colSpan = colCount;
+        td.style.cssText = "background:#2c3e50;color:#ecf0f1;padding:6px 12px;font-size:14px;font-weight:bold;";
+        td.textContent = `▸ ${label}`;
+        tr.appendChild(td);
+        return true; // signal: header is fully built
+    },
+};
+```
+
+### Override a column header cell
+
+```js
+frm.vdr_events = {
+    renderColumnHeader(doc, colIndex, th) {
+        // Mutate the th directly — no return value needed
+        th.innerHTML = `
+            <div style="font-size:14px;font-weight:bold;">${th.textContent}</div>
+            <div style="font-size:11px;opacity:0.8;">${doc.name}</div>
+        `;
+    },
+};
+```
+
+### Save hooks (inline editing)
+
+```js
+frm.vdr_events = {
+    beforeSave(df, docName, newValue) {
+        if (df.fieldname === "status" && newValue === "Blocked") {
+            frappe.msgprint("You cannot set status to Blocked.");
+            return false; // cancels the save
+        }
+        return true;
+    },
+
+    afterSave(df, docName, newValue) {
+        frappe.show_alert({ message: `${df.label} updated`, indicator: "green" });
+    },
+};
+```
+
+### Run code after the table is fully rendered
+
+```js
+frm.vdr_events = {
+    afterRender(instance) {
+        console.log("Rendered", instance.docs.length, "columns");
+        // instance.meta, instance.data, instance._table are all available here
+    },
+};
+```
+
+> **Tip — passing events without a form:**
+> If you're using the component standalone (no `frm`), pass events directly:
+> ```js
+> const instance = new SVAVerticalDocRenderer({ wrapper, doctype, docs, ... });
+> // OR monkey-patch before init (not recommended)
+> ```
+> A cleaner pattern: wrap the constructor so you can pass `events` as a param:
+> ```js
+> const fakefrm = { vdr_events: { formatCell(v, df) { ... } } };
+> new SVAVerticalDocRenderer({ wrapper, frm: fakefrm, doctype, docs });
+> ```
+
+---
+
+## Inline editing
+
+Enable by adding `"write"` to `crud_permissions`:
+
+```js
+new SVAVerticalDocRenderer({
+    wrapper,
+    doctype: "Employee",
+    docs: ["EMP-0001", "EMP-0002"],
+    crud_permissions: ["read", "write"],
+});
+```
+
+**Behavior by field type:**
+
+| Field types | Edit mode |
+|---|---|
+| Data, Int, Float, Currency, Percent, Date, Datetime, Time, Check, Select, Small Text | In-cell editor (Frappe control with ✓ / ✗ buttons) |
+| Link, Text, Long Text, Attach, and all others | Dialog popup (`frappe.ui.Dialog`) |
+
+Clicking a cell opens the editor. Saving calls `frappe.db.set_value(doctype, docName, fieldname, newValue)` and refreshes the cell. Fields with `read_only: 1` in the meta are never editable.
+
+---
+
+## AbortSignal — clean teardown on navigation
+
+If the wrapper is part of a Frappe tab or modal that can be destroyed, pass an `AbortSignal` so the component cleans up:
+
+```js
+const controller = new AbortController();
+
+new SVAVerticalDocRenderer({
+    wrapper,
+    doctype: "Employee",
+    docs: ["EMP-0001"],
+    signal: controller.signal,
+});
+
+// Later, when the tab/modal closes:
+controller.abort(); // clears the wrapper content
+```
+
+---
+
+## CSS theming
+
+The component uses CSS custom properties so you can restyle it globally or per-page without touching the component code:
+
+```css
+/* Global override */
+:root {
+    --sva-vdr-header-bg:    #2c3e50;   /* "Parameters" column header background */
+    --sva-vdr-header-text:  #ecf0f1;   /* "Parameters" column header text */
+    --sva-vdr-section-bg:   #2c3e50;   /* Section break row background */
+    --sva-vdr-section-text: #ecf0f1;   /* Section break row text */
+    --sva-vdr-label-bg:     #d5e8f7;   /* Field label cell background */
+    --sva-vdr-label-text:   #1a3a5c;   /* Field label cell text */
+    --sva-vdr-row-hover:    #eaf3ff;   /* Row hover highlight */
+}
+
+/* Scoped override — only inside a specific wrapper */
+#my-comparison-block {
+    --sva-vdr-section-bg: #1a6b3a;
+    --sva-vdr-label-bg:   #d5f0e0;
+}
+```
+
+---
+
+## No-code configuration (Property Setter)
+
+Developers who prefer a UI-driven approach can configure the component via the **Custom Property Setter** dialog in Frappe desk without writing any JS:
+
+1. Open a DocType in **Customize Form**
+2. Click an HTML field → **Set Property**
+3. Set **Property Type** = `Vertical Doc Renderer`
+4. Fill in:
+   - **Source DocType** — which DocType to display
+   - **Document Names** — JSON array, e.g. `["DOC-001", "DOC-002"]`
+   - **Column Configs** — JSON array, e.g. `[{"label":"A","bg_color":"#4472C4","text_color":"#fff"}]`
+   - **Fields to Show / Hide**, **Show Section Headers**, **Show Unit Column**, etc.
+
+The component is then rendered automatically on form load. `vdr_events` can still be set from the form's DocType JS to override rendering.
+
+---
+
+## Full example
+
+```js
+frappe.ui.form.on("My DocType", {
+    refresh(frm) {
+        const wrapper = frm.fields_dict.comparison_view.$wrapper[0];
+        wrapper.innerHTML = "";
+
+        // Set event overrides before creating the component
+        frm.vdr_events = {
+            formatCell(value, df, doc, colIndex) {
+                if (df.fieldname === "status") {
+                    const colors = { Active: "green", Inactive: "red", Pending: "orange" };
+                    return `<span style="color:${colors[value] || "inherit"}">${value || "-"}</span>`;
+                }
+                return null;
+            },
+            afterRender(instance) {
+                console.log("VDR ready:", instance);
+            },
+        };
+
+        new SVAVerticalDocRenderer({
+            wrapper,
+            frm,
+            doctype: "Employee",
+            docs: [frm.doc.primary_employee, frm.doc.secondary_employee, frm.doc.tertiary_employee].filter(Boolean),
+            column_configs: [
+                { label: "Primary",   bg_color: "#4472C4", text_color: "#fff" },
+                { label: "Secondary", bg_color: "#70AD47", text_color: "#fff" },
+                { label: "Tertiary",  bg_color: "#ED7D31", text_color: "#fff" },
+            ],
+            fields_to_hide: ["naming_series", "full_name", "employee_number"],
+            show_section_headers: true,
+            show_unit: false,
+            title: "Employee Comparison",
+            crud_permissions: ["read", "write"],
+            show_legend: true,
+            legend_items: [
+                { label: "Primary",   bg_color: "#4472C4", description: "Primary employee for this record" },
+                { label: "Secondary", bg_color: "#70AD47", description: "Secondary employee for this record" },
+            ],
+        });
+    },
+});
+```

--- a/frappe_theme/public/js/vertical_doc_renderer/README.md
+++ b/frappe_theme/public/js/vertical_doc_renderer/README.md
@@ -33,7 +33,7 @@ Or, if you're writing inline DocType JS (registered via `doctype_js` in hooks.py
 
 ## Basic usage
 
-### Minimal — doctype name + doc list
+### Minimal — doctype name + doc names (`string[]`)
 
 ```js
 const container = document.createElement("div");
@@ -46,7 +46,68 @@ new SVAVerticalDocRenderer({
 });
 ```
 
-This fetches the `Employee` meta automatically, fetches the three documents, and renders the table.
+Fetches the `Employee` meta automatically, fetches the three documents, and renders the table. If you pass more names than fit in the viewport, the rest are lazily fetched as the user scrolls right.
+
+---
+
+### `docs: null` — auto-fetch with server-side pagination
+
+Never loads more than one batch per API call:
+
+```js
+new SVAVerticalDocRenderer({
+    wrapper: container,
+    doctype: "Employee",
+    docs: null,                              // auto-fetch
+    filters: [["department", "=", "IT"]],   // frappe.db.get_list filters
+    order_by: "employee_name asc",
+    column_batch_size: 5,                   // columns per scroll batch (0 = auto from viewport)
+});
+```
+
+Initial load: `get_list({ start: 0, limit: 5 })`. On scroll: `start: 5`, `start: 10`, … Stops when the server returns fewer than `batch_size` records.
+
+---
+
+### `docs: object[]` — inline data, zero API calls for data
+
+```js
+const records = [
+    { name: "EMP-0001", first_name: "Alice", department: "IT" },
+    { name: "EMP-0002", first_name: "Bob",   department: "HR" },
+];
+
+new SVAVerticalDocRenderer({
+    wrapper: container,
+    doctype: "Employee",   // string — meta still fetched from server
+    docs: records,         // object[] — used as-is, no get_list call
+});
+```
+
+---
+
+### Mimicked meta — zero network calls
+
+Any `{ name, fields[] }` object works as the `doctype` param — no real DB table required:
+
+```js
+const fakeMeta = {
+    name: "My Comparison",
+    fields: [
+        { fieldname: "info_section", label: "Info",      fieldtype: "Section Break" },
+        { fieldname: "full_name",    label: "Full Name", fieldtype: "Data" },
+        { fieldname: "score",        label: "Score",     fieldtype: "Float" },
+    ],
+};
+
+const fakeData = [
+    { name: "row-1", full_name: "Alice", score: 9.5 },
+    { name: "row-2", full_name: "Bob",   score: 8.2 },
+];
+
+// Zero network calls — meta and data both provided inline
+new SVAVerticalDocRenderer({ wrapper: container, doctype: fakeMeta, docs: fakeData });
+```
 
 ---
 
@@ -123,8 +184,10 @@ new SVAVerticalDocRenderer({
                           //   frm.meta    → used directly; doctype name = frm.meta.name
                           //   customMeta  → any object with .name and .fields
 
-    docs,                 // string[] — doc names shown as columns, left to right
-                          //   e.g. ["EMP-0001", "EMP-0002", "EMP-0003"]
+    docs,                 // string[] | object[] | null
+                          //   string[]  → doc names fetched in viewport batches
+                          //   object[]  → inline data; zero API calls; lazy from memory
+                          //   null      → auto-fetch via frappe.db.get_list (paginated)
 
     // ── Column headers ───────────────────────────────────────────────────────
     column_configs,       // object[] — styling per column, index-aligned with docs
@@ -163,8 +226,17 @@ new SVAVerticalDocRenderer({
 
     // ── Permissions & editing ───────────────────────────────────────────────
     crud_permissions,     // string[] (default ["read"])
-                          //   Add "write" to enable inline editing on cells
-                          //   e.g. ["read", "write"]
+                          //   "write"  → inline cell editing
+                          //   "create" → "+" column header to create new docs in a dialog
+                          //   e.g. ["read", "write", "create"]
+
+    // ── Pagination / lazy loading ───────────────────────────────────────────
+    filters,              // frappe filter array — used when docs: null
+                          //   e.g. [["department", "=", "IT"]]
+    order_by,             // string — e.g. "creation desc" — used when docs: null
+    column_batch_size,    // number (default 0 = auto-calculate from viewport width)
+                          //   Number of columns to render per scroll batch
+    column_width,         // number px (default 150) — column width estimate for auto batch size
 
     // ── Integration ─────────────────────────────────────────────────────────
     frm,                  // Frappe form object (optional)
@@ -262,6 +334,23 @@ frm.vdr_events = {
 
     afterSave(df, docName, newValue) {
         frappe.show_alert({ message: `${df.label} updated`, indicator: "green" });
+    },
+};
+```
+
+### Create hooks (inline creation)
+
+```js
+frm.vdr_events = {
+    beforeCreate(values, dialog) {
+        if (!values.full_name) {
+            frappe.msgprint("Full name is required.");
+            return false; // cancels the insert
+        }
+    },
+
+    afterCreate(newDoc) {
+        frappe.show_alert({ message: `Created ${newDoc.name}`, indicator: "green" });
     },
 };
 ```

--- a/frappe_theme/public/js/vertical_doc_renderer/README.md
+++ b/frappe_theme/public/js/vertical_doc_renderer/README.md
@@ -685,11 +685,42 @@ Developers who prefer a UI-driven approach can configure the component via the *
 4. Fill in:
    - **Source DocType** — which DocType to display
    - **Document Names** — JSON array, e.g. `["DOC-001", "DOC-002"]`
-   - **Column Configs** — JSON array, e.g. `[{"label":"A","bg_color":"#4472C4","text_color":"#fff"}]`
+   - **Column Configs** — click **Setup Column Configs** to pick a label field and default colors
    - **Fields to Show / Hide**, **Show Section Headers**, **Show Unit Column**, etc.
-   - **Setup Crud Permissions** — click the button to open a dialog for configuring read/write/create/delete access; defaults to `["read"]` only
+   - **Setup Listview Setting** — choose which field rows to show and in what order
+   - **Setup Sub-tables** — stack multiple collapsible tables on the same field (see below)
+   - **Setup Crud Permissions** — configure read/write/create/delete access; defaults to `["read"]`
 
 The component is then rendered automatically on form load. `vdr_events` can still be set from the form's DocType JS to override rendering.
+
+### Sub-tables (stacked collapsible VDRs)
+
+Use **Setup Sub-tables** when you need to display the same DocType's data split across multiple sections — each section has its own title, its own set of field rows, and can start collapsed.
+
+| Control | Purpose |
+|---------|---------|
+| `≡` drag handle | Reorder sub-tables |
+| Title input | Heading shown above each table |
+| **Fields (n)** button | Pick and order which field rows this table shows |
+| **Collapsed** checkbox | Whether this table starts folded |
+| **×** button | Remove the sub-table |
+| **+ Add Sub-table** | Append a new entry |
+
+All sub-tables share the same column configuration (docs, colors, CRUD permissions).
+
+**Example visual result:**
+
+```
+▼  Inputs (S&P)
+┌────────────────┬──────────┬──────────┬──────────┐
+│ Parameters     │ NF/T₁R₁  │ TₙRₙ     │  M-NF    │
+├────────────────┼──────────┼──────────┼──────────┤
+│ Date of Input  │          │          │          │
+│ Type of Input  │ Dropdown │          │          │
+└────────────────┴──────────┴──────────┴──────────┘
+
+▶  Outputs (S&P)   ← collapsed
+```
 
 ---
 

--- a/frappe_theme/public/js/vertical_doc_renderer/README.md
+++ b/frappe_theme/public/js/vertical_doc_renderer/README.md
@@ -250,6 +250,17 @@ new SVAVerticalDocRenderer({
                           //   "delete" → 🗑 icon row (frappe.model.can_delete() also checked)
                           //   e.g. ["read", "write", "create", "delete"]
 
+    // ── Link title overrides ────────────────────────────────────────────────
+    link_title_fields,    // object (default {}) — { [LinkedDocType]: fieldname }
+                          //   Highest-priority override for link display-name resolution.
+                          //   Use when the linked DocType has no title_field configured in Frappe.
+                          //   e.g. {
+                          //     "District":  "district_name",
+                          //     "Mandal":    "mandal_name",
+                          //     "Village":   "village_name",
+                          //     "State":     "state_name",
+                          //   }
+
     // ── Pagination / lazy loading ───────────────────────────────────────────
     filters,              // frappe filter array — used when docs: null
                           //   e.g. [["department", "=", "IT"]]
@@ -506,9 +517,10 @@ new SVAVerticalDocRenderer({
 - Click a cell to open the editor — no separate Edit button needed.
 - **ESC** while editing reverts the cell to its original content without saving.
 - While saving: cell opacity drops to 0.5 and a spinner (↻) appears.
-- **On success**: error banner (if any) is cleared; in-memory `doc[fieldname]` is updated.
+- **On success**: error banner (if any) is cleared; in-memory `doc[fieldname]` is updated; the cell immediately reflects the new value.
 - **On failure**: cell reverts to original content; a red error banner appears above the table.
 - Read-only fields (`df.read_only = 1` or `read_only_depends_on` evaluated true) are never editable.
+- **Dialog fields (Link, Text, Attach, etc.)**: after the Save button is clicked and the DB write succeeds, the table cell is refreshed in-place — no full reload required. For Link fields, the display name is re-resolved immediately.
 
 ---
 
@@ -542,12 +554,35 @@ Item     ITEM-001 → "Steel Bolt 5mm"   (item_name field)
 ```
 
 **How title fields are discovered (in priority order):**
-1. `frappe.boot.link_title_doctypes` — Frappe populates this at boot for DocTypes with `show_title_field_in_link = 1`
-2. `frappe.get_meta(linkedDoctype)?.title_field` — in-memory fallback; available if the linked DocType's form was opened during the same session (zero extra API calls)
+1. `link_title_fields[linkedDoctype]` — explicit override passed to the constructor (highest priority)
+2. `frappe.boot.link_title_doctypes` — Frappe populates this at boot for DocTypes with `show_title_field_in_link = 1`
+3. `frappe.get_meta(linkedDoctype)?.title_field` — in-memory fallback; available if the linked DocType's form was opened during the same session (zero extra API calls)
 
-If neither source has a title field, the raw document name is shown (correct default).
+If no source has a title field, the raw document name is shown (correct default).
 
-To enable display titles for a custom DocType: open **Customize Form** → the DocType → check **Show Title in Link** and set the **Title Field**.
+### Using `link_title_fields`
+
+Use this when the linked DocType stores human-readable names in a separate field but doesn't have `title_field` configured in Frappe:
+
+```js
+new SVAVerticalDocRenderer({
+    wrapper,
+    doctype: "IGGAARL Farmer",
+    docs: [...],
+    link_title_fields: {
+        "State":     "state_name",
+        "District":  "district_name",
+        "Mandal":    "mandal_name",
+        "Village":   "village_name",
+        "Panchayat": "panchayat_name",
+        "RBK":       "rbk_name",
+    },
+});
+```
+
+Keys are the linked DocType names (the `options` value on the Link field definition). Values are the field on that DocType to use as the display label.
+
+To enable display titles via Frappe config instead: open **Customize Form** → the DocType → check **Show Title in Link** and set the **Title Field**.
 
 ---
 

--- a/frappe_theme/public/js/vertical_doc_renderer/README.md
+++ b/frappe_theme/public/js/vertical_doc_renderer/README.md
@@ -199,6 +199,25 @@ new SVAVerticalDocRenderer({
                           //     { label: "CF",   bg_color: "#ED7D31", text_color: "#fff" },
                           //   ]
 
+    // ── Section-level configuration ─────────────────────────────────────────
+    section_configs,      // object (default {}) — keyed by Section Break fieldname or label
+                          //   Each value is an object with any of:
+                          //     label      — override the displayed section heading
+                          //     bg_color   — section header background (overrides CSS var)
+                          //     text_color — section header text color (overrides CSS var)
+                          //     collapsed  — boolean; true = start collapsed, click to expand
+                          //     hidden     — boolean; true = hide section + all its fields
+                          //   Key priority: fieldname wins over label when both match.
+                          //   e.g. {
+                          //     "section_break_contact": {
+                          //       label: "Contact Info",
+                          //       bg_color: "#2c3e50",
+                          //       text_color: "#ecf0f1",
+                          //       collapsed: true,
+                          //     },
+                          //     "Address": { hidden: true },
+                          //   }
+
     // ── Field visibility ────────────────────────────────────────────────────
     fields_to_show,       // string[] | null (default null = show all non-hidden fields)
                           //   e.g. ["first_name", "last_name", "mobile_number"]
@@ -380,6 +399,85 @@ frm.vdr_events = {
 > const fakefrm = { vdr_events: { formatCell(v, df) { ... } } };
 > new SVAVerticalDocRenderer({ wrapper, frm: fakefrm, doctype, docs });
 > ```
+
+---
+
+## Section-level configuration
+
+Use `section_configs` to customise individual sections without touching `vdr_events`.  
+Keys are the Section Break **fieldname** (preferred) or its **label** (fallback).
+
+### Custom colours
+
+```js
+new SVAVerticalDocRenderer({
+    wrapper,
+    doctype: "Employee",
+    docs: ["EMP-0001", "EMP-0002"],
+    section_configs: {
+        "section_break_contact": {
+            label: "Contact Details",   // override displayed heading
+            bg_color: "#2c3e50",
+            text_color: "#ecf0f1",
+        },
+        "Address": {                    // matched by label when fieldname not found
+            bg_color: "#1a6b3a",
+            text_color: "#fff",
+        },
+    },
+});
+```
+
+### Collapsible sections
+
+Set `collapsed: true` to start a section folded. A ▶/▼ arrow appears; clicking the header row expands or collapses it.
+
+```js
+new SVAVerticalDocRenderer({
+    wrapper,
+    doctype: "Employee",
+    docs: ["EMP-0001", "EMP-0002"],
+    section_configs: {
+        "section_break_contact": { collapsed: false },   // expanded by default (arrow shown)
+        "section_break_address": { collapsed: true },    // starts collapsed
+    },
+});
+```
+
+### Hiding an entire section
+
+Set `hidden: true` to suppress both the section header and all fields belonging to it.
+
+```js
+new SVAVerticalDocRenderer({
+    wrapper,
+    doctype: "Employee",
+    docs: ["EMP-0001", "EMP-0002"],
+    section_configs: {
+        "section_break_internal": { hidden: true },   // header + fields not rendered
+    },
+});
+```
+
+### Combining all options
+
+```js
+section_configs: {
+    "section_break_contact": {
+        label: "Contact Info",
+        bg_color: "#2c3e50",
+        text_color: "#ecf0f1",
+        collapsed: true,
+    },
+    "section_break_address": {
+        bg_color: "#1a6b3a",
+        text_color: "#fff",
+    },
+    "section_break_internal": { hidden: true },
+}
+```
+
+> **vdr_events compatibility** — `vdr_events.renderSectionHeader` still fires for sections that are not hidden. When it returns `true` (custom row), the collapse toggle is wired automatically so collapsible behaviour still works.
 
 ---
 

--- a/frappe_theme/public/js/vertical_doc_renderer/README.md
+++ b/frappe_theme/public/js/vertical_doc_renderer/README.md
@@ -688,39 +688,9 @@ Developers who prefer a UI-driven approach can configure the component via the *
    - **Column Configs** — click **Setup Column Configs** to pick a label field and default colors
    - **Fields to Show / Hide**, **Show Section Headers**, **Show Unit Column**, etc.
    - **Setup Listview Setting** — choose which field rows to show and in what order
-   - **Setup Sub-tables** — stack multiple collapsible tables on the same field (see below)
    - **Setup Crud Permissions** — configure read/write/create/delete access; defaults to `["read"]`
 
 The component is then rendered automatically on form load. `vdr_events` can still be set from the form's DocType JS to override rendering.
-
-### Sub-tables (stacked collapsible VDRs)
-
-Use **Setup Sub-tables** when you need to display the same DocType's data split across multiple sections — each section has its own title, its own set of field rows, and can start collapsed.
-
-| Control | Purpose |
-|---------|---------|
-| `≡` drag handle | Reorder sub-tables |
-| Title input | Heading shown above each table |
-| **Fields (n)** button | Pick and order which field rows this table shows |
-| **Collapsed** checkbox | Whether this table starts folded |
-| **×** button | Remove the sub-table |
-| **+ Add Sub-table** | Append a new entry |
-
-All sub-tables share the same column configuration (docs, colors, CRUD permissions).
-
-**Example visual result:**
-
-```
-▼  Inputs (S&P)
-┌────────────────┬──────────┬──────────┬──────────┐
-│ Parameters     │ NF/T₁R₁  │ TₙRₙ     │  M-NF    │
-├────────────────┼──────────┼──────────┼──────────┤
-│ Date of Input  │          │          │          │
-│ Type of Input  │ Dropdown │          │          │
-└────────────────┴──────────┴──────────┴──────────┘
-
-▶  Outputs (S&P)   ← collapsed
-```
 
 ---
 

--- a/frappe_theme/public/js/vertical_doc_renderer/README.md
+++ b/frappe_theme/public/js/vertical_doc_renderer/README.md
@@ -388,6 +388,181 @@ frm.vdr_events = {
 };
 ```
 
+### Intercept a child table cell click (`openTableDialog`)
+
+By default, clicking a Table field cell opens a generic Add/Edit row dialog with all child fields. Return `true` to suppress the default and open your own dialog instead:
+
+```js
+frm.vdr_events = {
+    openTableDialog(df, doc, rows, saveFn, vdrInstance) {
+        if (df.fieldname === "plant_biometrics") {
+            open_plant_biometrics_dialog(
+                df.parent,          // parent DocType
+                doc.name,           // parent doc name
+                doc.main_crop || "",
+                doc.plant_type || "",
+                rows,               // existing child rows
+                saveFn,             // call this with updated rows to persist
+            );
+            return true;           // suppress default dialog
+        }
+        return false;              // fall through to default for all other table fields
+    },
+};
+```
+
+**Arguments:**
+
+| Arg | Type | Description |
+|---|---|---|
+| `df` | object | Field descriptor of the Table field (`df.fieldname`, `df.options` = child DocType) |
+| `doc` | object | The column's parent document (includes all fetched field values) |
+| `rows` | object[] | Current child rows for this column |
+| `saveFn` | function | Call `saveFn(updatedRows)` to save changes. Returns a Promise. |
+| `vdrInstance` | SVAVerticalDocRenderer | The VDR instance that fired the hook — use `vdrInstance.doctype` or `vdrInstance.vdr_field_name` to target only one VDR when the form has multiple. |
+
+---
+
+### Allowlist child table dialog fields (`getTableFields`)
+
+Return a string array of fieldnames to show in the default Add/Edit row dialog. Useful for filtering dialog columns based on dynamic data (e.g. the parent doc's `main_crop` value). Async supported.
+
+```js
+frm.vdr_events = {
+    async getTableFields(tableDf, parentDoc, vdrInstance) {
+        // Only filter for a specific VDR / child DocType
+        if (vdrInstance.doctype !== "My DocType") return null;
+
+        const config = await fetchSomeConfig();
+        const allowed = config
+            .filter((c) => c.reference_doctype === tableDf.options && c[parentDoc.crop_key] === 1)
+            .map((c) => c.fieldname);
+
+        return allowed.length ? allowed : null; // null = show all fields (default)
+    },
+};
+```
+
+**Return value:**
+- `string[]` — only these fieldnames appear in the dialog (order is preserved from child meta)
+- `null` / `undefined` — no filtering; all non-hidden child fields are shown
+
+**Arguments:**
+
+| Arg | Type | Description |
+|---|---|---|
+| `tableDf` | object | Field descriptor of the Table field (`tableDf.options` = child DocType) |
+| `parentDoc` | object | The column's parent document |
+| `vdrInstance` | SVAVerticalDocRenderer | The VDR instance — identify via `vdrInstance.doctype` or `vdrInstance.vdr_field_name` |
+
+---
+
+### Per-field filter for child table dialog (`filterTableField`)
+
+A finer-grained gate that runs **after** `getTableFields`. Receives each field descriptor individually; return `false` to hide it. Async supported.
+
+```js
+frm.vdr_events = {
+    filterTableField(tableDf, fieldDf, parentDoc, vdrInstance) {
+        // Example: hide "weed_density" when crop type is Horticulture
+        if (
+            vdrInstance.doctype === "Harvesting of Crop" &&
+            tableDf.fieldname === "harvesting_details" &&
+            fieldDf.fieldname === "weed_density" &&
+            parentDoc.crop_type === "Horticulture"
+        ) {
+            return false;
+        }
+        return true; // show by default
+    },
+};
+```
+
+**Return value:**
+- `false` — hide this field from the dialog
+- anything else — show it
+
+**Arguments:**
+
+| Arg | Type | Description |
+|---|---|---|
+| `tableDf` | object | Field descriptor of the Table field |
+| `fieldDf` | object | Field descriptor of the individual child field being tested |
+| `parentDoc` | object | The column's parent document |
+| `vdrInstance` | SVAVerticalDocRenderer | The VDR instance |
+
+> **Execution order:** `getTableFields` runs first (allowlist), then `filterTableField` runs on each field that passed the allowlist. Use `getTableFields` for bulk config-driven filtering and `filterTableField` for doc-value-driven per-field conditions.
+
+---
+
+### Filter which rows appear in the table (`filterRow`)
+
+Sync gate called for each field row during render. Return `false` to hide the row entirely. Useful for crop/context-driven field visibility without changing `fields_to_show`.
+
+```js
+frm.vdr_events = {
+    filterRow(df, vdrInstance) {
+        // Only filter a specific VDR
+        if (vdrInstance.doctype !== "Harvesting of Crop") return true;
+
+        const cropKey = getCropKey(frm.doc.main_crop); // e.g. "wheat"
+        if (!cropKey) return true;
+
+        const config = getCachedConfig(); // must be synchronous
+        const entry = config.find(
+            (c) => c.reference_doctype === vdrInstance.doctype && c.fieldname === df.fieldname
+        );
+        // If no entry → show the row; if entry exists → show only when crop flag is 1
+        return !entry || entry[cropKey] === 1;
+    },
+};
+```
+
+**Return value:**
+- `false` — row is not rendered
+- anything else — row is rendered normally
+
+**Arguments:**
+
+| Arg | Type | Description |
+|---|---|---|
+| `df` | object | Field descriptor of the row |
+| `vdrInstance` | SVAVerticalDocRenderer | The VDR instance |
+
+> **Important:** `filterRow` must be **synchronous** — it is called inside the rendering loop. Pre-fetch any async config (e.g. with a module-level cache warmed on form load) before the VDR renders.
+
+> **Works with `fields_config`:** `filterRow` is applied in both rendering paths — whether `fields_config` (row-settings saved order) is set or not.
+
+---
+
+### Identifying which VDR fired the hook
+
+All hooks receive `vdrInstance` as their last argument. The most reliable identifiers:
+
+```js
+vdrInstance.doctype          // DocType being rendered — "Harvesting of Crop"
+vdrInstance.vdr_field_name   // HTML field name on the parent form — "my_vdr_field"
+                             // (set only when rendered via Custom Property Setter)
+```
+
+Use this when the same form has two VDRs for different DocTypes and you need different hook logic for each:
+
+```js
+frm.vdr_events = {
+    filterRow(df, vdrInstance) {
+        if (vdrInstance.doctype === "Harvesting of Crop") {
+            return harvestingFilter(df);
+        }
+        if (vdrInstance.doctype === "Crop Parameter Monitoring") {
+            return cropParamFilter(df);
+        }
+        return true;
+    },
+};
+```
+
+---
+
 ### Run code after the table is fully rendered
 
 ```js

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/add_more.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/add_more.js
@@ -43,6 +43,9 @@ const AddMoreMixin = {
 				filters: JSON.stringify(this.filters || []),
 				grouping_field: groupingField,
 				link_field: linkField,
+				copy_fields_only: cfg.copy_fields_only
+					? JSON.stringify(cfg.copy_fields_only)
+					: null,
 			});
 
 			if (!result || result.created === 0) {

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/add_more.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/add_more.js
@@ -1,0 +1,133 @@
+const AddMoreMixin = {
+	/**
+	 * Handle the "Add More" button click.
+	 *
+	 * Calls the backend to:
+	 *   1. Find the latest batch (max grouping_field value) for this parent
+	 *   2. Duplicate every record in that batch with grouping_field = max + 1
+	 *
+	 * After success the table is reloaded so the new batch appears immediately.
+	 *
+	 * Config keys used from add_more_config:
+	 *   add_more_doctype  — child DocType to duplicate (defaults to this.doctype)
+	 *   grouping_field    — field that identifies batches (e.g. "batch_no") [required]
+	 *   plot_link_field   — field that links to the item/plot (passed to backend for reference)
+	 *
+	 * @param {object} cfg — add_more_config object from the constructor
+	 */
+	async _onAddMoreClick(cfg) {
+		const doctype = cfg.add_more_doctype || this.doctype;
+		const groupingField = cfg.grouping_field;
+		const linkField = cfg.plot_link_field || null;
+
+		if (!groupingField) {
+			frappe.show_alert({
+				message: __("Add More: grouping_field is not configured"),
+				indicator: "red",
+			});
+			return;
+		}
+
+		// ── Disable button + show spinner ────────────────────────────────────
+		const btn = this._addMoreBtnEl;
+		const originalHTML = btn ? btn.innerHTML : "";
+		if (btn) {
+			btn.disabled = true;
+			btn.style.opacity = "0.6";
+			btn.innerHTML = `<span class="sva-vdr-spinner">⏳</span> ${__("Creating…")}`;
+		}
+
+		try {
+			const result = await frappe.xcall("frappe_theme.apis.add_more_batch.add_more_batch", {
+				doctype,
+				filters: JSON.stringify(this.filters || []),
+				grouping_field: groupingField,
+				link_field: linkField,
+			});
+
+			if (!result || result.created === 0) {
+				frappe.show_alert({
+					message: __("No records found to duplicate"),
+					indicator: "orange",
+				});
+				return;
+			}
+
+			// ── Fetch full data for the newly created records ─────────────────
+			const fields = this._getDataFields ? this._getDataFields() : ["name"];
+			let newDocs = [];
+			try {
+				const fetched = await frappe.db.get_list(doctype, {
+					filters: [["name", "in", result.names]],
+					fields,
+					limit: result.names.length + 1,
+				});
+				const nameMap = {};
+				fetched.forEach((d) => (nameMap[d.name] = d));
+				newDocs = result.names.map((n) => nameMap[n] || { name: n });
+			} catch (fetchErr) {
+				console.error("[VDR AddMore] failed to fetch new docs", fetchErr);
+				newDocs = result.names.map((n) => ({ name: n }));
+			}
+
+			// ── Batched mode: add a new collapsible table section ─────────────
+			if (this._isBatchGrouped && this._isBatchGrouped()) {
+				const collapsed = !!(
+					this.add_more_config && this.add_more_config.default_collapsed_new_table
+				);
+				const subVDR = this._addBatchSection(result.next_batch, newDocs, collapsed);
+				if (subVDR && subVDR._ready) await subVDR._ready;
+
+				// Scroll new section into view
+				const newSection = this.container.querySelector(
+					`.sva-vdr-batch-section[data-batch="${result.next_batch}"]`
+				);
+				if (newSection) {
+					newSection.scrollIntoView({ behavior: "smooth", block: "start" });
+				}
+			} else {
+				// ── Standard mode: append columns to the flat table ───────────
+				newDocs.forEach((doc) => {
+					const absIndex = this.data.length;
+					this._appendDocColumn(doc, absIndex);
+				});
+
+				this._rendered_count = this.data.length;
+
+				if (Array.isArray(this._docs_input)) {
+					this._docs_input = [...this._docs_input, ...result.names];
+					this._all_inputs = this._docs_input;
+				}
+
+				if (typeof this._placeSentinel === "function") {
+					this._placeSentinel();
+				}
+
+				if (typeof this.resolveLinkTitles === "function") {
+					this.resolveLinkTitles();
+				}
+			}
+
+			frappe.show_alert({
+				message: __("{0} records created for Batch {1}", [
+					result.created,
+					result.next_batch,
+				]),
+				indicator: "green",
+			});
+		} catch (err) {
+			frappe.show_alert({
+				message: __("Failed to create batch: {0}", [err.message || String(err)]),
+				indicator: "red",
+			});
+		} finally {
+			if (btn) {
+				btn.disabled = false;
+				btn.style.opacity = "";
+				btn.innerHTML = originalHTML;
+			}
+		}
+	},
+};
+
+export default AddMoreMixin;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/batch_group.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/batch_group.js
@@ -200,6 +200,7 @@ const BatchGroupMixin = {
 			max_height: 0, // each batch table expands naturally; no inner scroll cap
 			table_max_rows: this.table_max_rows || null,
 			signal: this.signal || null,
+			child_add_row_labels: this.child_add_row_labels || null,
 			// No add_more_config, no vdr_field_name → no nested "Add More" / settings / reload
 			_is_sub_vdr: true,
 		});

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/batch_group.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/batch_group.js
@@ -116,7 +116,9 @@ const BatchGroupMixin = {
 		header.appendChild(document.createTextNode(label));
 
 		// ── Delete button (right-aligned, shown when allow_delete_batch) ─────
+		// First batch (batchNo == 1) never gets a delete button.
 		const canDeleteBatch =
+			parseInt(batchNo) !== 1 &&
 			this.add_more_config &&
 			this.add_more_config.allow_delete_batch &&
 			frappe.model.can_delete(this.doctype);

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/batch_group.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/batch_group.js
@@ -203,6 +203,7 @@ const BatchGroupMixin = {
 			child_add_row_labels: this.child_add_row_labels || null,
 			// No add_more_config, no vdr_field_name → no nested "Add More" / settings / reload
 			_is_sub_vdr: true,
+			_parent_vdr: this,
 		});
 
 		this._batchInstances[batchNo] = subVDR;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/batch_group.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/batch_group.js
@@ -8,7 +8,8 @@ const BatchGroupMixin = {
 	_isBatchGrouped() {
 		return !!(
 			this.add_more_config &&
-			this.add_more_config.allow_add_more_table &&
+			(this.add_more_config.allow_add_more_table ||
+				this.add_more_config.enable_batch_config) &&
 			this.add_more_config.grouping_field
 		);
 	},
@@ -75,8 +76,14 @@ const BatchGroupMixin = {
 	 * @returns {SVAVerticalDocRenderer} sub-VDR instance
 	 */
 	_addBatchSection(batchNo, docs, collapsed = false) {
-		const prefix =
+		const rawPrefix =
 			(this.add_more_config && this.add_more_config.batch_title_prefix) || "Batch";
+		// Replace {fieldname} placeholders with values from the first doc in this batch.
+		// e.g. "Seed Treatment - {crop_name}" → "Seed Treatment - Paddy"
+		const firstDoc = docs && docs.length ? docs[0] : null;
+		const prefix = rawPrefix.replace(/\{(\w+)\}/g, (_, fn) =>
+			firstDoc && firstDoc[fn] != null ? String(firstDoc[fn]) : `{${fn}}`
+		);
 		const label = `${__(prefix)} ${batchNo}`;
 
 		// ── Section wrapper ──────────────────────────────────────────────────
@@ -205,8 +212,14 @@ const BatchGroupMixin = {
 	 * @param {HTMLElement}   section  — the .sva-vdr-batch-section element to remove
 	 */
 	_deleteBatchSection(batchNo, section) {
-		const prefix =
+		const rawPrefix =
 			(this.add_more_config && this.add_more_config.batch_title_prefix) || "Batch";
+		// Interpolate {fieldname} using data from the sub-VDR for this batch
+		const subVDR = this._batchInstances && this._batchInstances[batchNo];
+		const firstDoc = subVDR && subVDR.data && subVDR.data.length ? subVDR.data[0] : null;
+		const prefix = rawPrefix.replace(/\{(\w+)\}/g, (_, fn) =>
+			firstDoc && firstDoc[fn] != null ? String(firstDoc[fn]) : `{${fn}}`
+		);
 		const label = `${__(prefix)} ${batchNo}`;
 
 		frappe.confirm(

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/batch_group.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/batch_group.js
@@ -1,0 +1,265 @@
+const BatchGroupMixin = {
+	/**
+	 * Returns true when the VDR should render each batch_no as a separate
+	 * collapsible table (stacked vertically) instead of one flat column set.
+	 *
+	 * Activated when add_more_config has both allow_add_more_table and grouping_field.
+	 */
+	_isBatchGrouped() {
+		return !!(
+			this.add_more_config &&
+			this.add_more_config.allow_add_more_table &&
+			this.add_more_config.grouping_field
+		);
+	},
+
+	/**
+	 * Fetch every matching record, group by grouping_field, and call
+	 * _addBatchSection() for each group in ascending order.
+	 */
+	async _renderBatchGroups() {
+		const groupField = this.add_more_config.grouping_field;
+		const fields = this._getDataFields();
+
+		let allDocs = [];
+		try {
+			allDocs = await frappe.db.get_list(this.doctype, {
+				filters: this.filters || [],
+				fields,
+				limit: 0,
+				order_by: `${groupField} asc`,
+			});
+		} catch (e) {
+			console.error("[VDR BatchGroup] Failed to fetch all docs", e);
+		}
+
+		// Group docs by batch value, preserving server order within each group
+		const groups = new Map();
+		allDocs.forEach((doc) => {
+			const key = doc[groupField] ?? 0;
+			if (!groups.has(key)) groups.set(key, []);
+			groups.get(key).push(doc);
+		});
+
+		if (!this._batchInstances) this._batchInstances = {};
+
+		const sortedKeys = [...groups.keys()].sort((a, b) => Number(a) - Number(b));
+		for (const key of sortedKeys) {
+			// Apply column_order_rules at parent level so sub-VDR receives pre-sorted docs
+			let batchDocs = groups.get(key);
+			if (this.column_order_rules && this.column_order_rules.length) {
+				const labelField = this.column_label_field;
+				batchDocs = [...batchDocs].sort((a, b) => {
+					const la = (labelField && a[labelField]) || a.name || "";
+					const lb = (labelField && b[labelField]) || b.name || "";
+					const ra = this._matchOrderRule(la);
+					const rb = this._matchOrderRule(lb);
+					return (
+						(ra ? ra.order ?? Infinity : Infinity) -
+						(rb ? rb.order ?? Infinity : Infinity)
+					);
+				});
+			}
+			const subVDR = this._addBatchSection(key, batchDocs, false);
+			// Wait for sub-VDR to finish initialising (meta + render) before next
+			if (subVDR && subVDR._ready) await subVDR._ready;
+		}
+	},
+
+	/**
+	 * Create one collapsible batch section and a sub-VDR inside it.
+	 *
+	 * @param {number|string} batchNo — grouping field value (e.g. 1, 2, 3)
+	 * @param {object[]}      docs    — inline document objects for this batch
+	 * @param {boolean}       collapsed — start collapsed?
+	 * @returns {SVAVerticalDocRenderer} sub-VDR instance
+	 */
+	_addBatchSection(batchNo, docs, collapsed = false) {
+		const prefix =
+			(this.add_more_config && this.add_more_config.batch_title_prefix) || "Batch";
+		const label = `${__(prefix)} ${batchNo}`;
+
+		// ── Section wrapper ──────────────────────────────────────────────────
+		const section = document.createElement("div");
+		section.className = "sva-vdr-batch-section";
+		section.dataset.batch = String(batchNo);
+		section.style.marginBottom = "6px";
+
+		// ── Collapsible header ───────────────────────────────────────────────
+		const header = document.createElement("div");
+		header.className = "sva-vdr-batch-header";
+		header.style.cssText = `
+			background: var(--sva-vdr-section-bg, #1a3a5c);
+			color: var(--sva-vdr-section-text, #fff);
+			font-weight: 600;
+			padding: 7px 14px;
+			cursor: pointer;
+			user-select: none;
+			font-size: 13px;
+			border-radius: 4px 4px 0 0;
+			display: flex;
+			align-items: center;
+			gap: 6px;
+		`;
+
+		const arrow = document.createElement("span");
+		arrow.style.cssText = "font-size:10px;display:inline-block;";
+		arrow.textContent = collapsed ? "▶" : "▼";
+		header.appendChild(arrow);
+		header.appendChild(document.createTextNode(label));
+
+		// ── Delete button (right-aligned, shown when allow_delete_batch) ─────
+		const canDeleteBatch =
+			this.add_more_config &&
+			this.add_more_config.allow_delete_batch &&
+			frappe.model.can_delete(this.doctype);
+
+		if (canDeleteBatch) {
+			const delBtn = document.createElement("button");
+			delBtn.type = "button";
+			delBtn.title = __("Delete this batch");
+			delBtn.style.cssText = `
+				margin-left: auto;
+				background: transparent;
+				border: 1px solid rgba(255,255,255,0.5);
+				border-radius: 3px;
+				color: inherit;
+				cursor: pointer;
+				font-size: 12px;
+				padding: 2px 7px;
+				line-height: 1.4;
+				opacity: 0.85;
+			`;
+			const delLabel = (
+				this.add_more_config.delete_batch_button_label || "Delete Batch"
+			).trim();
+			delBtn.textContent = "🗑 " + __(delLabel);
+			delBtn.addEventListener("click", (e) => {
+				e.stopPropagation(); // don't toggle collapse
+				this._deleteBatchSection(batchNo, section);
+			});
+			header.appendChild(delBtn);
+		}
+
+		// ── Content area (holds sub-VDR) ─────────────────────────────────────
+		const content = document.createElement("div");
+		content.className = "sva-vdr-batch-content";
+		if (collapsed) content.style.display = "none";
+
+		header.addEventListener("click", () => {
+			const nowHidden = content.style.display === "none";
+			content.style.display = nowHidden ? "" : "none";
+			arrow.textContent = nowHidden ? "▼" : "▶";
+		});
+
+		section.appendChild(header);
+		section.appendChild(content);
+
+		// Append directly to the main container (after the empty scrollWrapper)
+		this.container.appendChild(section);
+
+		// ── Sub-VDR instance ─────────────────────────────────────────────────
+		const VDRClass = frappe.ui && frappe.ui.SVAVerticalDocRenderer;
+		if (!VDRClass) {
+			console.error("[VDR BatchGroup] frappe.ui.SVAVerticalDocRenderer not found");
+			return null;
+		}
+
+		const subVDR = new VDRClass({
+			wrapper: content,
+			frm: this.frm,
+			// Pass full meta object so sub-VDR skips the meta API call
+			doctype: this.meta,
+			docs, // object[] — zero extra API calls
+			column_configs: this.column_configs || [],
+			column_label_field: this.column_label_field || null,
+			column_default_bg: this.column_default_bg || null,
+			column_default_text: this.column_default_text || null,
+			column_color_rules: this.column_color_rules || [],
+			column_order_rules: this.column_order_rules || [],
+			fields_to_show: this.fields_to_show || null,
+			fields_to_hide: this.fields_to_hide || [],
+			fields_config: this.fields_config || null,
+			show_section_headers: this.show_section_headers,
+			section_configs: this.section_configs || {},
+			show_unit: this.show_unit,
+			hide_empty_rows: this.hide_empty_rows,
+			crud_permissions: (this.crud_permissions || ["read"]).filter((p) => p !== "create"),
+			link_title_fields: this.link_title_fields || {},
+			column_width: this.column_width || 150,
+			label_width: this.label_width || 160,
+			max_height: 0, // each batch table expands naturally; no inner scroll cap
+			table_max_rows: this.table_max_rows || null,
+			signal: this.signal || null,
+			// No add_more_config, no vdr_field_name → no nested "Add More" / settings
+		});
+
+		this._batchInstances[batchNo] = subVDR;
+		return subVDR;
+	},
+
+	/**
+	 * Confirm + delete all records for a given batch, then remove the section from DOM.
+	 *
+	 * @param {number|string} batchNo  — value of the grouping field for this batch
+	 * @param {HTMLElement}   section  — the .sva-vdr-batch-section element to remove
+	 */
+	_deleteBatchSection(batchNo, section) {
+		const prefix =
+			(this.add_more_config && this.add_more_config.batch_title_prefix) || "Batch";
+		const label = `${__(prefix)} ${batchNo}`;
+
+		frappe.confirm(
+			__("Are you sure you want to delete all records in {0}? This cannot be undone.", [
+				`<strong>${label}</strong>`,
+			]),
+			async () => {
+				// Disable the delete button while deleting
+				const delBtn = section.querySelector("button[title]");
+				const originalHTML = delBtn ? delBtn.innerHTML : "";
+				if (delBtn) {
+					delBtn.disabled = true;
+					delBtn.style.opacity = "0.5";
+					delBtn.innerHTML = `⏳ ${__("Deleting…")}`;
+				}
+
+				try {
+					const result = await frappe.xcall(
+						"frappe_theme.apis.add_more_batch.delete_batch_records",
+						{
+							doctype: this.doctype,
+							filters: JSON.stringify(this.filters || []),
+							grouping_field: this.add_more_config.grouping_field,
+							batch_value: batchNo,
+						}
+					);
+
+					// Remove from DOM
+					section.remove();
+
+					// Clean up internal instance reference
+					if (this._batchInstances) {
+						delete this._batchInstances[batchNo];
+					}
+
+					frappe.show_alert({
+						message: __("{0} record(s) deleted from {1}", [result.deleted, label]),
+						indicator: "green",
+					});
+				} catch (err) {
+					if (delBtn) {
+						delBtn.disabled = false;
+						delBtn.style.opacity = "";
+						delBtn.innerHTML = originalHTML;
+					}
+					frappe.show_alert({
+						message: __("Failed to delete batch: {0}", [err.message || String(err)]),
+						indicator: "red",
+					});
+				}
+			}
+		);
+	},
+};
+
+export default BatchGroupMixin;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/batch_group.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/batch_group.js
@@ -198,7 +198,8 @@ const BatchGroupMixin = {
 			max_height: 0, // each batch table expands naturally; no inner scroll cap
 			table_max_rows: this.table_max_rows || null,
 			signal: this.signal || null,
-			// No add_more_config, no vdr_field_name → no nested "Add More" / settings
+			// No add_more_config, no vdr_field_name → no nested "Add More" / settings / reload
+			_is_sub_vdr: true,
 		});
 
 		this._batchInstances[batchNo] = subVDR;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/create.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/create.js
@@ -1,0 +1,116 @@
+/**
+ * CreateMixin — "+" column header to create a new doc from within the table
+ *
+ * Activated by including "create" in crud_permissions:
+ *   crud_permissions: ["read", "write", "create"]
+ *
+ * A "+" <th> is appended after all doc columns (before the sentinel).
+ * Clicking it opens a frappe.ui.Dialog pre-populated with visible,
+ * non-read-only fields. On save, the new doc is inserted via
+ * frappe.db.insert() and immediately appended as a new column.
+ *
+ * vdr_events hooks:
+ *   beforeCreate(values, dialog)  — return false to cancel
+ *   afterCreate(newDoc)           — called after successful insert
+ */
+const CreateMixin = {
+	/**
+	 * Build the "+" <th> column header cell.
+	 * Called by rendering.js _buildThead() when allow_create is true.
+	 * @returns {HTMLElement}
+	 */
+	_buildCreateHeaderCell() {
+		const th = document.createElement("th");
+		th.className = "sva-vdr-header-cell sva-vdr-create-col";
+		th.title = __("Add new record");
+		th.style.cssText = `
+			background: var(--sva-vdr-header-bg, #1a3a5c);
+			color: var(--sva-vdr-header-text, #fff);
+			font-weight: 700;
+			font-size: 20px;
+			padding: 2px 14px;
+			text-align: center;
+			white-space: nowrap;
+			border: 1px solid rgba(0,0,0,.08);
+			cursor: pointer;
+			min-width: 48px;
+			user-select: none;
+			transition: opacity .15s;
+		`;
+		th.textContent = "+";
+
+		th.addEventListener("mouseenter", () => (th.style.opacity = "0.75"));
+		th.addEventListener("mouseleave", () => (th.style.opacity = "1"));
+		th.addEventListener("click", () => this.openCreateDialog());
+
+		return th;
+	},
+
+	/**
+	 * Open a frappe.ui.Dialog with controls for all visible, non-read-only
+	 * fields derived from the current meta. On primary action, inserts the
+	 * document and appends it as a new column.
+	 */
+	openCreateDialog() {
+		// Build field descriptors for the dialog — visible, writable fields only
+		const dialogFields = this.getVisibleFields()
+			.filter((df) => !df.read_only)
+			.map((df) => ({
+				fieldname: df.fieldname,
+				label: df.label || df.fieldname,
+				fieldtype: df.fieldtype,
+				options: df.options || "",
+				reqd: df.reqd || 0,
+				default: df.default || "",
+				description: df.description || "",
+			}));
+
+		const dialog = new frappe.ui.Dialog({
+			title: __("Create New {0}", [__(this.doctype)]),
+			fields: dialogFields,
+			primary_action_label: __("Create"),
+			primary_action: async (values) => {
+				// vdr_events.beforeCreate hook — return false to cancel
+				if (typeof this.events.beforeCreate === "function") {
+					const result = this.events.beforeCreate(values, dialog);
+					if (result === false) return;
+				}
+
+				try {
+					const newDoc = await frappe.db.insert({
+						doctype: this.doctype,
+						...values,
+					});
+
+					dialog.hide();
+
+					// Append the new document as the next column
+					const absIndex = this.docs.length;
+					this._appendDocColumn(newDoc, absIndex);
+					this._rendered_count = (this._rendered_count || 0) + 1;
+
+					// vdr_events.afterCreate hook
+					if (typeof this.events.afterCreate === "function") {
+						this.events.afterCreate(newDoc);
+					}
+
+					frappe.show_alert({
+						message: __("{0} created successfully", [newDoc.name || __("Record")]),
+						indicator: "green",
+					});
+				} catch (e) {
+					const msg = (e && (e.message || e.exc_type)) || String(e);
+					frappe.msgprint({
+						title: __("Create failed"),
+						message: msg,
+						indicator: "red",
+					});
+				}
+			},
+		});
+
+		dialog.show();
+	},
+};
+
+export default CreateMixin;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/create.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/create.js
@@ -1,17 +1,22 @@
 /**
- * CreateMixin — "+" column header to create a new doc from within the table
+ * CreateMixin — "+" toolbar button to create a new doc from within the table
  *
  * Activated by including "create" in crud_permissions:
  *   crud_permissions: ["read", "write", "create"]
  *
- * A "+" <th> is appended after all doc columns (before the sentinel).
- * Clicking it opens a frappe.ui.Dialog pre-populated with visible,
- * non-read-only fields. On save, the new doc is inserted via
- * frappe.db.insert() and immediately appended as a new column.
+ * The "+" button is rendered in the toolbar (top-left corner above the table)
+ * by ui_setup._buildToolbar(). No <th> column is added to the thead.
+ * Clicking it adds a "draft" column immediately — no dialog opens.
+ * The draft column shows inline input controls for all simple editable fields.
+ * Complex field types (Link, Text, Attach, etc.) show a "—" placeholder that
+ * opens a small dialog when clicked to set the value.
+ * Clicking "Create" in the draft header calls frappe.db.insert() with the
+ * collected values and replaces the draft column with the real column.
+ * Clicking "Cancel" removes the draft column without any server call.
  *
  * vdr_events hooks:
- *   beforeCreate(values, dialog)  — return false to cancel
- *   afterCreate(newDoc)           — called after successful insert
+ *   beforeCreate(values, null)  — return false to cancel
+ *   afterCreate(newDoc)         — called after successful insert
  */
 const CreateMixin = {
 	/**
@@ -47,69 +52,274 @@ const CreateMixin = {
 	},
 
 	/**
-	 * Open a frappe.ui.Dialog with controls for all visible, non-read-only
-	 * fields derived from the current meta. On primary action, inserts the
-	 * document and appends it as a new column.
+	 * Add a draft column to the table immediately — no dialog, no DB call.
+	 * The user fills in values inline and clicks "Create" to persist.
 	 */
 	openCreateDialog() {
-		// Build field descriptors for the dialog — visible, writable fields only
-		const dialogFields = this.getVisibleFields()
-			.filter((df) => !df.read_only)
-			.map((df) => ({
-				fieldname: df.fieldname,
-				label: df.label || df.fieldname,
-				fieldtype: df.fieldtype,
-				options: df.options || "",
-				reqd: df.reqd || 0,
-				default: df.default || "",
-				description: df.description || "",
-			}));
+		// Prevent multiple draft columns
+		if (this._hasDraftColumn) return;
 
-		const dialog = new frappe.ui.Dialog({
-			title: __("Create New {0}", [__(this.doctype)]),
-			fields: dialogFields,
-			primary_action_label: __("Create"),
-			primary_action: async (values) => {
-				// vdr_events.beforeCreate hook — return false to cancel
-				if (typeof this.events.beforeCreate === "function") {
-					const result = this.events.beforeCreate(values, dialog);
-					if (result === false) return;
-				}
+		// vdr_events.beforeCreate hook — return false to cancel
+		if (typeof this.events.beforeCreate === "function") {
+			const result = this.events.beforeCreate({}, null);
+			if (result === false) return;
+		}
 
-				try {
-					const newDoc = await frappe.db.insert({
-						doctype: this.doctype,
-						...values,
-					});
+		this._hasDraftColumn = true;
+		this._draftValues = {};
 
-					dialog.hide();
+		const absIndex = this.docs.length;
 
-					// Append the new document as the next column
-					const absIndex = this.docs.length;
-					this._appendDocColumn(newDoc, absIndex);
-					this._rendered_count = (this._rendered_count || 0) + 1;
+		// 1. Draft header cell (with Create / Cancel buttons)
+		const th = this._buildDraftHeaderCell(absIndex);
+		const insertBefore = this._sentinel;
+		if (insertBefore) {
+			this._theadRow.insertBefore(th, insertBefore);
+		} else {
+			this._theadRow.appendChild(th);
+		}
 
-					// vdr_events.afterCreate hook
-					if (typeof this.events.afterCreate === "function") {
-						this.events.afterCreate(newDoc);
-					}
-
-					frappe.show_alert({
-						message: __("{0} created successfully", [newDoc.name || __("Record")]),
-						indicator: "green",
-					});
-				} catch (e) {
-					const msg = (e && (e.message || e.exc_type)) || String(e);
-					frappe.msgprint({
-						title: __("Create failed"),
-						message: msg,
-						indicator: "red",
-					});
-				}
-			},
+		// 2. Draft value cells in each field row
+		const fieldRows = this._table.querySelectorAll("tr.sva-vdr-field-row");
+		fieldRows.forEach((tr) => {
+			const fieldname = tr.dataset.fieldname;
+			const df = (this.meta.fields || []).find((f) => f.fieldname === fieldname);
+			if (!df) return;
+			tr.appendChild(this._buildDraftValueCell(df));
 		});
 
+		// 3. Widen section header rows by 1
+		this._table.querySelectorAll("tr.sva-vdr-section-row td").forEach((td) => {
+			td.colSpan = (td.colSpan || 1) + 1;
+		});
+	},
+
+	/**
+	 * Build the draft column header with "New Record" label and
+	 * "Create" + "Cancel" buttons.
+	 *
+	 * @param {number} absIndex — column index used when committing
+	 * @returns {HTMLElement}
+	 */
+	_buildDraftHeaderCell(absIndex) {
+		const th = document.createElement("th");
+		th.className = "sva-vdr-header-cell sva-vdr-doc-header sva-vdr-draft-header";
+		th.dataset.docname = "__draft__";
+		th.style.cssText = `
+			background: #6c757d;
+			color: #fff;
+			font-weight: 600;
+			padding: 4px 8px;
+			text-align: center;
+			white-space: nowrap;
+			border: 1px solid rgba(0,0,0,.08);
+			min-width: 120px;
+			position: sticky;
+			top: 0;
+			z-index: 2;
+		`;
+
+		const label = document.createElement("div");
+		label.textContent = __("New Record");
+		label.style.cssText = "font-size: 12px; margin-bottom: 4px;";
+		th.appendChild(label);
+
+		const btnRow = document.createElement("div");
+		btnRow.style.cssText = "display: flex; gap: 4px; justify-content: center;";
+
+		const saveBtn = document.createElement("button");
+		saveBtn.className = "btn btn-xs btn-success";
+		saveBtn.textContent = __("Create");
+		saveBtn.addEventListener("click", () => this._commitDraftColumn(absIndex, th));
+
+		const cancelBtn = document.createElement("button");
+		cancelBtn.className = "btn btn-xs btn-default";
+		cancelBtn.textContent = __("Cancel");
+		cancelBtn.addEventListener("click", () => this._removeDraftColumn());
+
+		btnRow.appendChild(saveBtn);
+		btnRow.appendChild(cancelBtn);
+		th.appendChild(btnRow);
+
+		return th;
+	},
+
+	/**
+	 * Build a single draft value cell.
+	 * Simple field types (Data, Int, Select, etc.) show an inline control
+	 * immediately. Complex types (Link, Text, Attach, etc.) show a "—"
+	 * placeholder that opens a small dialog on click.
+	 *
+	 * @param {Object} df — field descriptor
+	 * @returns {HTMLElement}
+	 */
+	_buildDraftValueCell(df) {
+		const td = document.createElement("td");
+		td.className = "sva-vdr-value-cell sva-vdr-draft-cell";
+		td.dataset.fieldname = df.fieldname;
+		td.dataset.docname = "__draft__";
+		td.style.cssText = `
+			padding: 4px 6px;
+			border: 1px solid rgba(0,0,0,.06);
+			vertical-align: middle;
+			min-width: 100px;
+			max-width: 280px;
+		`;
+
+		if (df.read_only) {
+			td.style.background = "var(--sva-vdr-readonly-bg, #f5f5f5)";
+			td.style.color = "var(--sva-vdr-readonly-text, #999)";
+			td.textContent = "—";
+			return td;
+		}
+
+		const simpleTypes = this.getEditableCellTypes
+			? this.getEditableCellTypes()
+			: [
+					"Data",
+					"Int",
+					"Float",
+					"Currency",
+					"Percent",
+					"Date",
+					"Datetime",
+					"Time",
+					"Check",
+					"Select",
+					"Small Text",
+			  ];
+
+		if (simpleTypes.includes(df.fieldtype)) {
+			// Inline control — always visible, no click needed
+			const inputHolder = document.createElement("div");
+			inputHolder.style.cssText = "min-width: 0; width: 100%;";
+			td.appendChild(inputHolder);
+
+			const ctrl = frappe.ui.form.make_control({
+				df: { ...df, label: "" },
+				parent: inputHolder,
+				only_input: df.fieldtype !== "Check",
+				render_input: true,
+			});
+			ctrl.refresh();
+
+			const defaultVal = df.default || "";
+			ctrl.set_value(defaultVal);
+			if (defaultVal) this._draftValues[df.fieldname] = defaultVal;
+
+			const storeValue = () => {
+				this._draftValues[df.fieldname] = ctrl.get_value();
+			};
+
+			if (ctrl.$input) {
+				ctrl.$input.on("change blur", storeValue);
+			}
+		} else {
+			// Complex type — show placeholder, open dialog on click
+			td.style.cursor = "pointer";
+			td.style.color = "#adb5bd";
+			td.title = __("Click to set");
+			td.textContent = "—";
+
+			td.addEventListener("click", () => this._openDraftFieldDialog(df, td));
+		}
+
+		return td;
+	},
+
+	/**
+	 * Open a small dialog to set a complex-type field value on the draft column.
+	 *
+	 * @param {Object}      df — field descriptor
+	 * @param {HTMLElement} td — the draft cell to update after selection
+	 */
+	_openDraftFieldDialog(df, td) {
+		const dialog = new frappe.ui.Dialog({
+			title: __(df.label || df.fieldname),
+			fields: [{ ...df, label: df.label, reqd: 0 }],
+			primary_action_label: __("Set"),
+			primary_action: (values) => {
+				const val = values[df.fieldname];
+				this._draftValues[df.fieldname] = val;
+				td.textContent = val || "—";
+				td.style.color = val ? "" : "#adb5bd";
+				dialog.hide();
+			},
+		});
+		dialog.set_value(df.fieldname, this._draftValues[df.fieldname] || "");
 		dialog.show();
+	},
+
+	/**
+	 * Commit the draft column: call frappe.db.insert() with collected values,
+	 * remove the draft column, then append the real column.
+	 *
+	 * @param {number}      absIndex — column index for config lookup
+	 * @param {HTMLElement} th       — draft header cell (for button state)
+	 */
+	async _commitDraftColumn(absIndex, th) {
+		const valuesToInsert = { ...this._draftValues };
+
+		const saveBtn = th.querySelector(".btn-success");
+		const cancelBtn = th.querySelector(".btn-default");
+		if (saveBtn) {
+			saveBtn.disabled = true;
+			saveBtn.textContent = __("Saving…");
+		}
+		if (cancelBtn) cancelBtn.disabled = true;
+
+		try {
+			const newDoc = await frappe.db.insert({
+				doctype: this.doctype,
+				...valuesToInsert,
+			});
+
+			this._removeDraftColumn();
+
+			this._appendDocColumn(newDoc, absIndex);
+			this._rendered_count = (this._rendered_count || 0) + 1;
+
+			if (typeof this.events.afterCreate === "function") {
+				this.events.afterCreate(newDoc);
+			}
+
+			frappe.show_alert({
+				message: __("{0} created successfully", [newDoc.name || __("Record")]),
+				indicator: "green",
+			});
+		} catch (e) {
+			if (saveBtn) {
+				saveBtn.disabled = false;
+				saveBtn.textContent = __("Create");
+			}
+			if (cancelBtn) cancelBtn.disabled = false;
+
+			const msg = (e && (e.message || e.exc_type)) || String(e);
+			frappe.msgprint({
+				title: __("Create failed"),
+				message: msg,
+				indicator: "red",
+			});
+		}
+	},
+
+	/**
+	 * Remove the draft column from the DOM and reset draft state.
+	 */
+	_removeDraftColumn() {
+		// Remove draft header
+		this._theadRow?.querySelector("th[data-docname='__draft__']")?.remove();
+
+		// Remove all draft value cells
+		this._table?.querySelectorAll("td[data-docname='__draft__']").forEach((td) => td.remove());
+
+		// Shrink section header colspans
+		this._table?.querySelectorAll("tr.sva-vdr-section-row td").forEach((td) => {
+			if ((td.colSpan || 1) > 1) td.colSpan -= 1;
+		});
+
+		this._hasDraftColumn = false;
+		this._draftValues = {};
 	},
 };
 

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/data.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/data.js
@@ -20,14 +20,37 @@ const DataMixin = {
 	/**
 	 * Load DocType meta.
 	 * If this._meta_override is set (caller passed a meta object), use it directly.
-	 * Otherwise fetch via frappe.db.get_meta().
+	 *
+	 * Otherwise uses frappe_theme.dt_api.get_meta_fields with meta_attached=1,
+	 * which returns { fields: [...], meta: {...full frappe meta...} }.
+	 * This mirrors the exact pattern used by SVADatatable.
+	 *
+	 * frappe.xcall is used (instead of frappe.call) because it resolves to the
+	 * message payload directly, just like SVAHTTP.call does in the datatable.
 	 */
 	async fetchMeta() {
 		if (this._meta_override) {
 			this.meta = this._meta_override;
 			return;
 		}
-		this.meta = await frappe.db.get_meta(this.doctype);
+		try {
+			// response = { fields: [...filtered fields (no Tab Break)...], meta: {...} }
+			const response = await frappe.xcall(
+				"frappe_theme.dt_api.get_meta_fields",
+				{ doctype: this.doctype, _type: "Direct", meta_attached: 1 }
+			);
+			// Spread full Frappe meta dict so all properties are available,
+			// then override fields with the filtered list (no Tab Break) and
+			// set name explicitly from this.doctype.
+			this.meta = {
+				...(response?.meta || {}),
+				name: this.doctype,
+				fields: response?.fields || [],
+			};
+		} catch (e) {
+			console.error("SVAVerticalDocRenderer: fetchMeta failed", e);
+			this.meta = { name: this.doctype, fields: [] };
+		}
 	},
 
 	/**

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/data.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/data.js
@@ -1,0 +1,53 @@
+const DataMixin = {
+	/**
+	 * Load DocType meta.
+	 * If this._meta_override is set (caller passed a meta object), use it directly.
+	 * Otherwise fetch via frappe.get_meta().
+	 */
+	async fetchMeta() {
+		if (this._meta_override) {
+			this.meta = this._meta_override;
+			return;
+		}
+		this.meta = await frappe.db.get_meta(this.doctype);
+	},
+
+	/**
+	 * Fetch all document data for the doc names listed in this.docs.
+	 * Builds the field list from meta (all non-layout fieldnames).
+	 * Results are stored in this.data, sorted to match this.docs order.
+	 */
+	async fetchDocs() {
+		if (!this.docs || !this.docs.length) {
+			this.data = [];
+			return;
+		}
+
+		// Collect all data-bearing fieldnames from meta
+		const LAYOUT_TYPES = new Set([
+			"Section Break", "Column Break", "Tab Break",
+			"HTML", "Button", "Fold", "Image",
+		]);
+		const fields = ["name"];
+		(this.meta.fields || []).forEach((df) => {
+			if (!LAYOUT_TYPES.has(df.fieldtype) && df.fieldname) {
+				fields.push(df.fieldname);
+			}
+		});
+
+		let data = [];
+		try {
+			data = await frappe.db.get_list(this.doctype, {
+				filters: [["name", "in", this.docs]],
+				fields,
+				limit: this.docs.length + 1,
+			});
+		} catch (e) {
+			console.error("SVAVerticalDocRenderer: fetchDocs failed", e);
+		}
+
+		this.data = this.sortDataByDocs(data);
+	},
+};
+
+export default DataMixin;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/data.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/data.js
@@ -1,29 +1,9 @@
 const DataMixin = {
 	/**
-	 * Load DocType meta.
-	 * If this._meta_override is set (caller passed a meta object), use it directly.
-	 * Otherwise fetch via frappe.get_meta().
+	 * Build the list of data-bearing fieldnames from meta (no layout fields).
+	 * Used by fetchDocs() and viewport._fetchBatchData() to request consistent fields.
 	 */
-	async fetchMeta() {
-		if (this._meta_override) {
-			this.meta = this._meta_override;
-			return;
-		}
-		this.meta = await frappe.db.get_meta(this.doctype);
-	},
-
-	/**
-	 * Fetch all document data for the doc names listed in this.docs.
-	 * Builds the field list from meta (all non-layout fieldnames).
-	 * Results are stored in this.data, sorted to match this.docs order.
-	 */
-	async fetchDocs() {
-		if (!this.docs || !this.docs.length) {
-			this.data = [];
-			return;
-		}
-
-		// Collect all data-bearing fieldnames from meta
+	_getDataFields() {
 		const LAYOUT_TYPES = new Set([
 			"Section Break", "Column Break", "Tab Break",
 			"HTML", "Button", "Fold", "Image",
@@ -34,19 +14,110 @@ const DataMixin = {
 				fields.push(df.fieldname);
 			}
 		});
+		return fields;
+	},
 
+	/**
+	 * Load DocType meta.
+	 * If this._meta_override is set (caller passed a meta object), use it directly.
+	 * Otherwise fetch via frappe.db.get_meta().
+	 */
+	async fetchMeta() {
+		if (this._meta_override) {
+			this.meta = this._meta_override;
+			return;
+		}
+		this.meta = await frappe.db.get_meta(this.doctype);
+	},
+
+	/**
+	 * Fetch the first batch of document data.
+	 *
+	 * Three input shapes for this._docs_input:
+	 *
+	 *   object[]  → data is already provided inline; no network call; sliced to batch_size
+	 *   string[]  → fetch the first batch of doc names from the server
+	 *   null      → paginated frappe.db.get_list (start=0, limit=column_batch_size)
+	 *
+	 * After this call:
+	 *   this.data        = first-batch records (array of plain objects)
+	 *   this.docs        = first-batch doc names (aligned with this.data)
+	 *   this._all_inputs = full input array (for viewport.js to slice on scroll)
+	 *                      OR null when docs:null (unknown total; keep fetching until server returns empty)
+	 */
+	async fetchDocs() {
+		const input = this._docs_input;
+		const batchSize = this.column_batch_size || 10;
+
+		// Guard: mimicked/custom meta object + docs:null is unsupported — we can't
+		// call frappe.db.get_list against a name that has no real DB table.
+		if (input === null && this._meta_override) {
+			console.warn(
+				"SVAVerticalDocRenderer: docs: null is not supported when doctype is a " +
+				"mimicked meta object. Pass docs as an array of objects instead."
+			);
+			this._all_inputs = null;
+			this.data = [];
+			this.docs = [];
+			return;
+		}
+
+		// ── object[] — inline data, zero network calls ───────────────────────
+		if (Array.isArray(input) && input.length > 0 && typeof input[0] === "object") {
+			this._all_inputs = input;
+			const batch = input.slice(0, batchSize);
+			this.data = batch;
+			this.docs = batch.map((d) => d.name);
+			return;
+		}
+
+		const fields = this._getDataFields();
+
+		// ── string[] — names known; fetch first batch from server ────────────
+		if (Array.isArray(input)) {
+			this._all_inputs = input;
+			const names = input.slice(0, batchSize);
+			if (!names.length) {
+				this.data = [];
+				this.docs = [];
+				return;
+			}
+			let data = [];
+			try {
+				data = await frappe.db.get_list(this.doctype, {
+					filters: [["name", "in", names]],
+					fields,
+					limit: names.length + 1,
+				});
+			} catch (e) {
+				console.error("SVAVerticalDocRenderer: fetchDocs failed", e);
+			}
+			// Re-sort to match the caller-specified order
+			const nameMap = {};
+			data.forEach((d) => (nameMap[d.name] = d));
+			this.data = names.map((name) => nameMap[name] || { name });
+			this.docs = this.data.map((d) => d.name);
+			return;
+		}
+
+		// ── null — paginated API (start=0, limit=batchSize) ──────────────────
+		// this._all_inputs stays null to signal "unknown total; keep paginating
+		// until server returns fewer records than batchSize".
+		this._all_inputs = null;
 		let data = [];
 		try {
 			data = await frappe.db.get_list(this.doctype, {
-				filters: [["name", "in", this.docs]],
+				filters: this.filters || [],
 				fields,
-				limit: this.docs.length + 1,
+				limit: batchSize,
+				start: 0,
+				...(this.order_by ? { order_by: this.order_by } : {}),
 			});
 		} catch (e) {
 			console.error("SVAVerticalDocRenderer: fetchDocs failed", e);
 		}
-
-		this.data = this.sortDataByDocs(data);
+		this.data = data;
+		this.docs = data.map((d) => d.name);
 	},
 };
 

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/data.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/data.js
@@ -5,8 +5,13 @@ const DataMixin = {
 	 */
 	_getDataFields() {
 		const LAYOUT_TYPES = new Set([
-			"Section Break", "Column Break", "Tab Break",
-			"HTML", "Button", "Fold", "Image",
+			"Section Break",
+			"Column Break",
+			"Tab Break",
+			"HTML",
+			"Button",
+			"Fold",
+			"Image",
 		]);
 		const fields = ["name"];
 		(this.meta.fields || []).forEach((df) => {
@@ -35,10 +40,11 @@ const DataMixin = {
 		}
 		try {
 			// response = { fields: [...filtered fields (no Tab Break)...], meta: {...} }
-			const response = await frappe.xcall(
-				"frappe_theme.dt_api.get_meta_fields",
-				{ doctype: this.doctype, _type: "Direct", meta_attached: 1 }
-			);
+			const response = await frappe.xcall("frappe_theme.dt_api.get_meta_fields", {
+				doctype: this.doctype,
+				_type: "Direct",
+				meta_attached: 1,
+			});
 			// Spread full Frappe meta dict so all properties are available,
 			// then override fields with the filtered list (no Tab Break) and
 			// set name explicitly from this.doctype.
@@ -77,7 +83,7 @@ const DataMixin = {
 		if (input === null && this._meta_override) {
 			console.warn(
 				"SVAVerticalDocRenderer: docs: null is not supported when doctype is a " +
-				"mimicked meta object. Pass docs as an array of objects instead."
+					"mimicked meta object. Pass docs as an array of objects instead."
 			);
 			this._all_inputs = null;
 			this.data = [];

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/delete.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/delete.js
@@ -1,0 +1,270 @@
+/**
+ * DeleteMixin — trash-icon row for removing document columns
+ *
+ * Activated by including "delete" in crud_permissions AND the current user
+ * having frappe.model.can_delete(doctype) permission.
+ *
+ * A <tr class="sva-vdr-delete-row"> is inserted as the first row of <tbody>.
+ * Each doc column gets a 🗑 <button> in that row. The buttons are hidden by
+ * default (opacity 0) and revealed when the user hovers the corresponding
+ * document <th> in the header.
+ *
+ * CSS cross-section selectors (thead:hover → tbody td) don't work, so hover
+ * is wired via JS mouseenter/mouseleave with a 150ms hide debounce that lets
+ * the user move the mouse from the header to the button without it disappearing.
+ *
+ * Hover identification uses doc.name (not column index) so that remaining
+ * columns continue to work correctly after a column is deleted and indices shift.
+ *
+ * Delete flow:
+ *   frappe.confirm → frappe.xcall("frappe.client.delete")
+ *     → _removeColumn(docName) (DOM cleanup + data arrays)
+ */
+const DeleteMixin = {
+	/**
+	 * Returns true when delete is both in crud_permissions and allowed by RPM.
+	 * @returns {boolean}
+	 */
+	_canDelete() {
+		return (
+			this.crud_permissions.includes("delete") &&
+			frappe.model.can_delete(this.doctype)
+		);
+	},
+
+	/**
+	 * Build the <tr> that holds one 🗑 button per document column.
+	 * Stores the row as this._deleteRow so viewport can append to it later.
+	 * @returns {HTMLElement} <tr>
+	 */
+	_buildDeleteRow() {
+		const tr = document.createElement("tr");
+		tr.className = "sva-vdr-delete-row";
+		this._deleteRow = tr;
+
+		// Sticky label-column spacer
+		const labelTd = document.createElement("td");
+		labelTd.className = "sva-vdr-sticky-col";
+		labelTd.style.cssText = `
+			position: sticky;
+			left: 0;
+			z-index: 1;
+			background: var(--sva-vdr-label-bg, #dce6f1);
+			border: 1px solid rgba(0,0,0,.06);
+			min-width: 140px;
+			padding: 2px 10px;
+		`;
+		tr.appendChild(labelTd);
+
+		// Optional Unit column spacer
+		if (this.show_unit) {
+			const unitTd = document.createElement("td");
+			unitTd.style.cssText = `border: 1px solid rgba(0,0,0,.06); padding: 2px 8px;`;
+			tr.appendChild(unitTd);
+		}
+
+		// One delete button cell per already-rendered doc
+		this.data.forEach((doc) => {
+			tr.appendChild(this._buildDeleteCell(doc));
+		});
+
+		// "+" column spacer (stays at far right; viewport inserts before it)
+		if (this.allow_create) {
+			const createTd = document.createElement("td");
+			createTd.style.cssText = `border: 1px solid rgba(0,0,0,.06); padding: 2px 6px;`;
+			tr.appendChild(createTd);
+		}
+
+		return tr;
+	},
+
+	/**
+	 * Build a single <td> containing the 🗑 button for one document column.
+	 * Uses doc.name as the identifier so hover/delete work correctly even
+	 * after other columns are deleted and indices shift.
+	 *
+	 * @param {object} doc — document data object (must have .name)
+	 * @returns {HTMLElement} <td>
+	 */
+	_buildDeleteCell(doc) {
+		const td = document.createElement("td");
+		td.className = "sva-vdr-delete-cell";
+		td.dataset.docname = doc.name;
+		td.style.cssText = `
+			text-align: center;
+			padding: 2px 6px;
+			border: 1px solid rgba(0,0,0,.06);
+			vertical-align: middle;
+		`;
+
+		const btn = document.createElement("button");
+		btn.className = "btn btn-xs btn-danger sva-vdr-delete-btn";
+		btn.textContent = "\uD83D\uDDD1"; // 🗑
+		btn.title = __("Delete {0}", [doc.name]);
+		btn.style.cssText = `
+			opacity: 0;
+			pointer-events: none;
+			transition: opacity .15s;
+			padding: 1px 6px;
+			line-height: 1.4;
+			cursor: pointer;
+			font-size: 12px;
+		`;
+
+		btn.addEventListener("mouseenter", () => {
+			// Cancel any pending hide when mouse moves onto the button
+			clearTimeout(this._deleteHideTimer);
+		});
+		btn.addEventListener("mouseleave", () => {
+			this._hideDeleteIcon(doc.name);
+		});
+		btn.addEventListener("click", (e) => {
+			e.stopPropagation();
+			this.deleteDoc(doc.name);
+		});
+
+		td.appendChild(btn);
+		return td;
+	},
+
+	/**
+	 * Append a delete cell for a newly viewport-loaded document column.
+	 * Called by viewport.js after _appendDocColumn().
+	 * @param {object} doc — document data object
+	 */
+	_appendDeleteCell(doc) {
+		if (!this._deleteRow) return;
+
+		const newCell = this._buildDeleteCell(doc);
+
+		// Insert before the "+" spacer td (last child) if create is enabled
+		if (this.allow_create) {
+			const last = this._deleteRow.lastElementChild;
+			this._deleteRow.insertBefore(newCell, last);
+		} else {
+			this._deleteRow.appendChild(newCell);
+		}
+	},
+
+	/**
+	 * Show the 🗑 button for the column identified by docName.
+	 * Cancels any pending hide timer.
+	 * @param {string} docName
+	 */
+	_showDeleteIcon(docName) {
+		clearTimeout(this._deleteHideTimer);
+		const btn = this._getDeleteBtnByDocName(docName);
+		if (btn) {
+			btn.style.opacity = "1";
+			btn.style.pointerEvents = "auto";
+		}
+	},
+
+	/**
+	 * Hide the 🗑 button for the column identified by docName after 150ms.
+	 * The debounce lets the user move the mouse from the header to the button.
+	 * @param {string} docName
+	 */
+	_hideDeleteIcon(docName) {
+		clearTimeout(this._deleteHideTimer);
+		this._deleteHideTimer = setTimeout(() => {
+			const btn = this._getDeleteBtnByDocName(docName);
+			if (btn) {
+				btn.style.opacity = "0";
+				btn.style.pointerEvents = "none";
+			}
+		}, 150);
+	},
+
+	/**
+	 * Locate the 🗑 button in the delete row for a given document name.
+	 * @param {string} docName
+	 * @returns {HTMLElement|null}
+	 */
+	_getDeleteBtnByDocName(docName) {
+		if (!this._deleteRow) return null;
+		const td = this._deleteRow.querySelector(`td[data-docname="${docName}"]`);
+		return td ? td.querySelector(".sva-vdr-delete-btn") : null;
+	},
+
+	/**
+	 * Show a confirm dialog, then delete the document via frappe.xcall and
+	 * remove its column from the DOM.
+	 * @param {string} docName
+	 */
+	deleteDoc(docName) {
+		frappe.confirm(
+			__("Are you sure you want to delete <b>{0}</b>?", [docName]),
+			async () => {
+				try {
+					await frappe.xcall("frappe.client.delete", {
+						doctype: this.doctype,
+						name: docName,
+					});
+					this._removeColumn(docName);
+					frappe.show_alert({
+						message: __("{0} deleted successfully", [docName]),
+						indicator: "green",
+					});
+				} catch (e) {
+					const msg = (e && (e.message || e.exc_type)) || String(e);
+					frappe.msgprint({
+						title: __("Delete failed"),
+						message: msg,
+						indicator: "red",
+					});
+				}
+			}
+		);
+	},
+
+	/**
+	 * Remove a document's column from the DOM and sync all data arrays.
+	 * All lookups are by docName so indices don't need to be maintained.
+	 * @param {string} docName — document name to remove
+	 */
+	_removeColumn(docName) {
+		if (!this._table) return;
+
+		// 1. Header <th>
+		const headerTh = this._theadRow.querySelector(`th[data-docname="${docName}"]`);
+		if (headerTh) headerTh.remove();
+
+		// 2. Value cells in every field row
+		this._table
+			.querySelectorAll(`td.sva-vdr-value-cell[data-docname="${docName}"]`)
+			.forEach((td) => td.remove());
+
+		// 3. Delete row cell
+		if (this._deleteRow) {
+			const deleteTd = this._deleteRow.querySelector(
+				`td[data-docname="${docName}"]`
+			);
+			if (deleteTd) deleteTd.remove();
+		}
+
+		// 4. Decrement colSpan on all section-header rows
+		this._table
+			.querySelectorAll("tr.sva-vdr-section-row td")
+			.forEach((td) => {
+				if (td.colSpan > 1) td.colSpan -= 1;
+			});
+
+		// 5. Sync data arrays
+		this.data = this.data.filter((d) => d.name !== docName);
+		this.docs = this.docs.filter((n) => n !== docName);
+
+		if (Array.isArray(this._all_inputs)) {
+			this._all_inputs = this._all_inputs.filter((item) => {
+				const name = typeof item === "object" ? item.name : item;
+				return name !== docName;
+			});
+		}
+
+		if (typeof this._rendered_count === "number") {
+			this._rendered_count = Math.max(0, this._rendered_count - 1);
+		}
+	},
+};
+
+export default DeleteMixin;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/delete.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/delete.js
@@ -26,10 +26,7 @@ const DeleteMixin = {
 	 * @returns {boolean}
 	 */
 	_canDelete() {
-		return (
-			this.crud_permissions.includes("delete") &&
-			frappe.model.can_delete(this.doctype)
-		);
+		return this.crud_permissions.includes("delete") && frappe.model.can_delete(this.doctype);
 	},
 
 	/**
@@ -193,29 +190,26 @@ const DeleteMixin = {
 	 * @param {string} docName
 	 */
 	deleteDoc(docName) {
-		frappe.confirm(
-			__("Are you sure you want to delete <b>{0}</b>?", [docName]),
-			async () => {
-				try {
-					await frappe.xcall("frappe.client.delete", {
-						doctype: this.doctype,
-						name: docName,
-					});
-					this._removeColumn(docName);
-					frappe.show_alert({
-						message: __("{0} deleted successfully", [docName]),
-						indicator: "green",
-					});
-				} catch (e) {
-					const msg = (e && (e.message || e.exc_type)) || String(e);
-					frappe.msgprint({
-						title: __("Delete failed"),
-						message: msg,
-						indicator: "red",
-					});
-				}
+		frappe.confirm(__("Are you sure you want to delete <b>{0}</b>?", [docName]), async () => {
+			try {
+				await frappe.xcall("frappe.client.delete", {
+					doctype: this.doctype,
+					name: docName,
+				});
+				this._removeColumn(docName);
+				frappe.show_alert({
+					message: __("{0} deleted successfully", [docName]),
+					indicator: "green",
+				});
+			} catch (e) {
+				const msg = (e && (e.message || e.exc_type)) || String(e);
+				frappe.msgprint({
+					title: __("Delete failed"),
+					message: msg,
+					indicator: "red",
+				});
 			}
-		);
+		});
 	},
 
 	/**
@@ -237,18 +231,14 @@ const DeleteMixin = {
 
 		// 3. Delete row cell
 		if (this._deleteRow) {
-			const deleteTd = this._deleteRow.querySelector(
-				`td[data-docname="${docName}"]`
-			);
+			const deleteTd = this._deleteRow.querySelector(`td[data-docname="${docName}"]`);
 			if (deleteTd) deleteTd.remove();
 		}
 
 		// 4. Decrement colSpan on all section-header rows
-		this._table
-			.querySelectorAll("tr.sva-vdr-section-row td")
-			.forEach((td) => {
-				if (td.colSpan > 1) td.colSpan -= 1;
-			});
+		this._table.querySelectorAll("tr.sva-vdr-section-row td").forEach((td) => {
+			if (td.colSpan > 1) td.colSpan -= 1;
+		});
 
 		// 5. Sync data arrays
 		this.data = this.data.filter((d) => d.name !== docName);

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -1,0 +1,170 @@
+const EditMixin = {
+	/**
+	 * Field types that get inline (in-cell) editing.
+	 * All others open a dialog.
+	 */
+	getEditableCellTypes() {
+		return ["Data", "Int", "Float", "Currency", "Percent", "Date", "Datetime", "Time", "Check", "Select", "Small Text"];
+	},
+
+	/**
+	 * Entry point: attach a click listener to a value cell so it becomes editable
+	 * when write permission is present.
+	 *
+	 * @param {HTMLElement} cell     — the <td> to make editable
+	 * @param {Object}      df       — field descriptor
+	 * @param {Object}      doc      — the document row object
+	 * @param {number}      colIndex — 0-based column index
+	 */
+	attachEditListener(cell, df, doc, colIndex) {
+		if (!this.crud_permissions.includes("write")) return;
+		// Read-only fields
+		if (df.read_only) return;
+
+		cell.style.cursor = "pointer";
+		cell.title = __("Click to edit");
+
+		cell.addEventListener("click", () => {
+			if (cell.dataset.editing === "1") return;
+			if (this.getEditableCellTypes().includes(df.fieldtype)) {
+				this.renderInlineEditor(cell, df, doc, colIndex);
+			} else {
+				this.openEditDialog(df, doc, colIndex);
+			}
+		});
+	},
+
+	/**
+	 * Replace cell content with a Frappe control + ✓ / ✗ action buttons.
+	 */
+	renderInlineEditor(cell, df, doc, colIndex) {
+		cell.dataset.editing = "1";
+		const originalContent = cell.innerHTML;
+		cell.innerHTML = "";
+
+		// Wrapper for the control
+		const controlWrapper = document.createElement("div");
+		controlWrapper.style.cssText = "display:flex;align-items:center;gap:4px;padding:2px;";
+
+		const inputHolder = document.createElement("div");
+		inputHolder.style.cssText = "flex:1;min-width:0;";
+		controlWrapper.appendChild(inputHolder);
+
+		// ✓ save
+		const saveBtn = document.createElement("button");
+		saveBtn.className = "btn btn-xs btn-success";
+		saveBtn.innerHTML = "✓";
+		saveBtn.title = __("Save");
+		saveBtn.style.cssText = "padding:1px 5px;line-height:1.4;";
+
+		// ✗ cancel
+		const cancelBtn = document.createElement("button");
+		cancelBtn.className = "btn btn-xs btn-default";
+		cancelBtn.innerHTML = "✗";
+		cancelBtn.title = __("Cancel");
+		cancelBtn.style.cssText = "padding:1px 5px;line-height:1.4;";
+
+		controlWrapper.appendChild(saveBtn);
+		controlWrapper.appendChild(cancelBtn);
+		cell.appendChild(controlWrapper);
+
+		// Build Frappe control
+		const ctrl = frappe.ui.form.make_control({
+			df: { ...df, label: "" },
+			parent: inputHolder,
+			only_input: df.fieldtype !== "Check",
+			render_input: true,
+		});
+		ctrl.refresh();
+		ctrl.set_value(doc[df.fieldname]);
+		if (ctrl.$input) ctrl.$input.focus();
+
+		const cancel = () => {
+			cell.innerHTML = originalContent;
+			delete cell.dataset.editing;
+			// Re-attach listener
+			this.attachEditListener(cell, df, doc, colIndex);
+		};
+
+		cancelBtn.addEventListener("click", (e) => {
+			e.stopPropagation();
+			cancel();
+		});
+
+		saveBtn.addEventListener("click", async (e) => {
+			e.stopPropagation();
+			const newValue = ctrl.get_value();
+			await this.saveValue(df, doc, newValue, cell, colIndex);
+		});
+	},
+
+	/**
+	 * Open a frappe.ui.Dialog for complex field types.
+	 */
+	openEditDialog(df, doc, colIndex) {
+		const dialog = new frappe.ui.Dialog({
+			title: __(df.label),
+			fields: [{ ...df, label: df.label, reqd: 0 }],
+			primary_action_label: __("Save"),
+			primary_action: async ({ [df.fieldname]: newValue }) => {
+				dialog.hide();
+				await this.saveValue(df, doc, newValue, null, colIndex);
+			},
+		});
+		dialog.set_value(df.fieldname, doc[df.fieldname]);
+		dialog.show();
+	},
+
+	/**
+	 * Persist the new value via frappe.db.set_value, then refresh the cell.
+	 *
+	 * @param {Object}      df       — field descriptor
+	 * @param {Object}      doc      — document row object (mutated on success)
+	 * @param {*}           newValue — new value to save
+	 * @param {HTMLElement} cell     — cell to refresh (null when called from dialog)
+	 * @param {number}      colIndex — column index
+	 */
+	async saveValue(df, doc, newValue, cell, colIndex) {
+		// beforeSave hook — returning false cancels the save
+		if (typeof this.events.beforeSave === "function") {
+			const proceed = await this.events.beforeSave(df, doc.name, newValue);
+			if (proceed === false) {
+				if (cell) {
+					delete cell.dataset.editing;
+				}
+				return;
+			}
+		}
+
+		try {
+			await frappe.db.set_value(this.doctype, doc.name, df.fieldname, newValue);
+			doc[df.fieldname] = newValue;
+
+			if (cell) {
+				delete cell.dataset.editing;
+				const formatted = this.formatCellValue(newValue, df, doc, colIndex);
+				cell.innerHTML = formatted;
+				this.attachEditListener(cell, df, doc, colIndex);
+			}
+
+			if (typeof this.events.afterSave === "function") {
+				this.events.afterSave(df, doc.name, newValue);
+			}
+		} catch (err) {
+			frappe.msgprint({
+				title: __("Error"),
+				indicator: "red",
+				message: err.message || __("Could not save value"),
+			});
+			if (cell) {
+				// Restore original display
+				delete cell.dataset.editing;
+				const formatted = this.formatCellValue(doc[df.fieldname], df, doc, colIndex);
+				cell.innerHTML = formatted;
+				this.attachEditListener(cell, df, doc, colIndex);
+			}
+		}
+	},
+};
+
+export default EditMixin;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -1,10 +1,35 @@
+/**
+ * EditMixin — inline editing with Excel-like auto-sync on focus-out
+ *
+ * Behaviour:
+ *   - Clicking an editable cell opens a Frappe control inline (no dialog).
+ *   - For instant-change types (Check, Select): saves on the `change` event.
+ *   - For text-like types: saves automatically when the input loses focus (blur).
+ *   - ESC cancels and reverts the cell to its original content.
+ *   - While saving: cell opacity drops to 0.5 and a spinner appears.
+ *   - On failure: cell reverts to original content and an error banner is shown.
+ *   - On success: error banner is cleared (if any).
+ *
+ * Complex field types (Link, Text, Attach, etc.) still use a frappe.ui.Dialog
+ * with an explicit Save button, since those controls don't fit well inline.
+ */
 const EditMixin = {
 	/**
-	 * Field types that get inline (in-cell) editing.
+	 * Field types rendered inline (blur/change auto-save).
 	 * All others open a dialog.
 	 */
 	getEditableCellTypes() {
-		return ["Data", "Int", "Float", "Currency", "Percent", "Date", "Datetime", "Time", "Check", "Select", "Small Text"];
+		return [
+			"Data", "Int", "Float", "Currency", "Percent",
+			"Date", "Datetime", "Time", "Check", "Select", "Small Text",
+		];
+	},
+
+	/**
+	 * Field types that fire `change` immediately (no need to wait for blur).
+	 */
+	_getInstantSaveTypes() {
+		return ["Check", "Select"];
 	},
 
 	/**
@@ -18,8 +43,9 @@ const EditMixin = {
 	 */
 	attachEditListener(cell, df, doc, colIndex) {
 		if (!this.crud_permissions.includes("write")) return;
-		// Read-only fields
 		if (df.read_only) return;
+		// Also respect dynamic read_only_depends_on
+		if (this.isFieldReadOnly && this.isFieldReadOnly(df, doc)) return;
 
 		cell.style.cursor = "pointer";
 		cell.title = __("Click to edit");
@@ -35,38 +61,27 @@ const EditMixin = {
 	},
 
 	/**
-	 * Replace cell content with a Frappe control + ✓ / ✗ action buttons.
+	 * Replace cell content with a Frappe control.
+	 * Auto-saves on blur (text fields) or change (Check/Select).
+	 * ESC cancels and reverts.
+	 *
+	 * @param {HTMLElement} cell
+	 * @param {Object}      df
+	 * @param {Object}      doc
+	 * @param {number}      colIndex
 	 */
 	renderInlineEditor(cell, df, doc, colIndex) {
 		cell.dataset.editing = "1";
-		const originalContent = cell.innerHTML;
+		// Preserve original HTML so we can revert on failure or ESC
+		cell.dataset.originalContent = cell.innerHTML;
 		cell.innerHTML = "";
+		cell.style.cursor = "default";
+		cell.title = "";
 
-		// Wrapper for the control
-		const controlWrapper = document.createElement("div");
-		controlWrapper.style.cssText = "display:flex;align-items:center;gap:4px;padding:2px;";
-
+		// Control wrapper (fills the cell width)
 		const inputHolder = document.createElement("div");
-		inputHolder.style.cssText = "flex:1;min-width:0;";
-		controlWrapper.appendChild(inputHolder);
-
-		// ✓ save
-		const saveBtn = document.createElement("button");
-		saveBtn.className = "btn btn-xs btn-success";
-		saveBtn.innerHTML = "✓";
-		saveBtn.title = __("Save");
-		saveBtn.style.cssText = "padding:1px 5px;line-height:1.4;";
-
-		// ✗ cancel
-		const cancelBtn = document.createElement("button");
-		cancelBtn.className = "btn btn-xs btn-default";
-		cancelBtn.innerHTML = "✗";
-		cancelBtn.title = __("Cancel");
-		cancelBtn.style.cssText = "padding:1px 5px;line-height:1.4;";
-
-		controlWrapper.appendChild(saveBtn);
-		controlWrapper.appendChild(cancelBtn);
-		cell.appendChild(controlWrapper);
+		inputHolder.style.cssText = "min-width: 0; width: 100%;";
+		cell.appendChild(inputHolder);
 
 		// Build Frappe control
 		const ctrl = frappe.ui.form.make_control({
@@ -79,27 +94,65 @@ const EditMixin = {
 		ctrl.set_value(doc[df.fieldname]);
 		if (ctrl.$input) ctrl.$input.focus();
 
+		// ── cancel: revert cell to its pre-edit state ──────────────────────
 		const cancel = () => {
-			cell.innerHTML = originalContent;
+			const orig = cell.dataset.originalContent || "";
+			cell.innerHTML = orig;
 			delete cell.dataset.editing;
-			// Re-attach listener
+			delete cell.dataset.originalContent;
+			// Re-attach click listener
 			this.attachEditListener(cell, df, doc, colIndex);
 		};
 
-		cancelBtn.addEventListener("click", (e) => {
-			e.stopPropagation();
-			cancel();
-		});
+		// ── triggerSave: validate → show spinner → persist → clean up ──────
+		const triggerSave = async () => {
+			if (cell.dataset.saving === "1") return;
 
-		saveBtn.addEventListener("click", async (e) => {
-			e.stopPropagation();
 			const newValue = ctrl.get_value();
+
+			// Set saving visual state
+			cell.dataset.saving = "1";
+			cell.style.opacity = "0.5";
+			const spinner = document.createElement("span");
+			spinner.className = "sva-vdr-spinner";
+			spinner.textContent = "\u21BB"; // ↻
+			cell.appendChild(spinner);
+
 			await this.saveValue(df, doc, newValue, cell, colIndex);
-		});
+
+			// saveValue has already updated cell.innerHTML (success) or
+			// reverted it (failure). Just clean up the saving state.
+			delete cell.dataset.saving;
+			cell.style.opacity = "";
+			// spinner element was removed when saveValue replaced innerHTML
+		};
+
+		// ── wire events based on field type ───────────────────────────────
+		if (ctrl.$input) {
+			if (this._getInstantSaveTypes().includes(df.fieldtype)) {
+				// Check, Select — save immediately on change
+				ctrl.$input.on("change", triggerSave);
+			} else {
+				// Text-like fields — save when focus leaves the input
+				ctrl.$input.on("blur", triggerSave);
+				// ESC → cancel without saving
+				ctrl.$input.on("keydown", (e) => {
+					if (e.key === "Escape") {
+						e.preventDefault();
+						cancel();
+					}
+				});
+			}
+		}
 	},
 
 	/**
-	 * Open a frappe.ui.Dialog for complex field types.
+	 * Open a frappe.ui.Dialog for complex field types (Link, Text, Attach, etc.).
+	 * Dialog retains an explicit "Save" button — auto-sync doesn't apply here.
+	 *
+	 * @param {Object}  df
+	 * @param {Object}  doc
+	 * @param {number}  colIndex
 	 */
 	openEditDialog(df, doc, colIndex) {
 		const dialog = new frappe.ui.Dialog({
@@ -116,51 +169,96 @@ const EditMixin = {
 	},
 
 	/**
-	 * Persist the new value via frappe.db.set_value, then refresh the cell.
+	 * Validate and persist a new value via frappe.db.set_value.
+	 * On success: updates cell content, clears error banner.
+	 * On failure: reverts cell to original content, shows error banner.
 	 *
-	 * @param {Object}      df       — field descriptor
-	 * @param {Object}      doc      — document row object (mutated on success)
-	 * @param {*}           newValue — new value to save
-	 * @param {HTMLElement} cell     — cell to refresh (null when called from dialog)
-	 * @param {number}      colIndex — column index
+	 * @param {Object}           df       — field descriptor
+	 * @param {Object}           doc      — document row (mutated on success)
+	 * @param {*}                newValue — new value to save
+	 * @param {HTMLElement|null} cell     — cell to update (null when called from dialog)
+	 * @param {number}           colIndex — column index
 	 */
 	async saveValue(df, doc, newValue, cell, colIndex) {
-		// beforeSave hook — returning false cancels the save
-		if (typeof this.events.beforeSave === "function") {
-			const proceed = await this.events.beforeSave(df, doc.name, newValue);
-			if (proceed === false) {
+		// ── client-side mandatory validation ────────────────────────────────
+		if (typeof this.validateBeforeSave === "function") {
+			const errors = this.validateBeforeSave(df, doc, newValue);
+			if (errors.length) {
+				if (typeof this.showErrorBanner === "function") {
+					this.showErrorBanner(errors);
+				}
 				if (cell) {
+					// Revert immediately — don't make the API call
+					const orig = cell.dataset.originalContent;
+					cell.innerHTML = orig !== undefined
+						? orig
+						: this.formatCellValue(doc[df.fieldname], df, doc, colIndex);
 					delete cell.dataset.editing;
+					delete cell.dataset.originalContent;
+					this.attachEditListener(cell, df, doc, colIndex);
 				}
 				return;
 			}
 		}
 
+		// ── beforeSave hook ─────────────────────────────────────────────────
+		if (typeof this.events.beforeSave === "function") {
+			const proceed = await this.events.beforeSave(df, doc.name, newValue);
+			if (proceed === false) {
+				if (cell) {
+					delete cell.dataset.editing;
+					delete cell.dataset.originalContent;
+				}
+				return;
+			}
+		}
+
+		// ── persist ─────────────────────────────────────────────────────────
 		try {
 			await frappe.db.set_value(this.doctype, doc.name, df.fieldname, newValue);
 			doc[df.fieldname] = newValue;
 
 			if (cell) {
 				delete cell.dataset.editing;
+				delete cell.dataset.originalContent;
+				// Update raw-value stamp so link title re-resolution works
+				cell.dataset.rawValue = String(newValue ?? "");
 				const formatted = this.formatCellValue(newValue, df, doc, colIndex);
 				cell.innerHTML = formatted;
 				this.attachEditListener(cell, df, doc, colIndex);
+
+				// Re-resolve link titles if the saved field is a Link
+				if (df.fieldtype === "Link" && typeof this.resolveLinkTitles === "function") {
+					this.resolveLinkTitles();
+				}
+			}
+
+			// Clear any error banner on success
+			if (typeof this.clearErrorBanner === "function") {
+				this.clearErrorBanner();
 			}
 
 			if (typeof this.events.afterSave === "function") {
 				this.events.afterSave(df, doc.name, newValue);
 			}
 		} catch (err) {
-			frappe.msgprint({
-				title: __("Error"),
-				indicator: "red",
-				message: err.message || __("Could not save value"),
-			});
+			// ── failure: revert + show banner ───────────────────────────────
+			const errMsg =
+				(err && (err.message || err.exc_type)) ||
+				__("Could not save value");
+			const label = __(df.label || df.fieldname);
+			if (typeof this.showErrorBanner === "function") {
+				this.showErrorBanner([`${label}: ${errMsg}`]);
+			}
+
 			if (cell) {
-				// Restore original display
+				// Revert to original HTML (preserves resolved link titles etc.)
+				const orig = cell.dataset.originalContent;
+				cell.innerHTML = orig !== undefined
+					? orig
+					: this.formatCellValue(doc[df.fieldname], df, doc, colIndex);
 				delete cell.dataset.editing;
-				const formatted = this.formatCellValue(doc[df.fieldname], df, doc, colIndex);
-				cell.innerHTML = formatted;
+				delete cell.dataset.originalContent;
 				this.attachEditListener(cell, df, doc, colIndex);
 			}
 		}

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -376,7 +376,7 @@ const EditMixin = {
 			}
 
 			if (typeof this.events.afterSave === "function") {
-				this.events.afterSave(df, doc.name, newValue);
+				this.events.afterSave(df, doc.name, newValue, this);
 			}
 		} catch (err) {
 			// ── failure: revert + show banner ───────────────────────────────
@@ -711,7 +711,7 @@ const EditMixin = {
 			frappe.show_alert({ message: __("Saved"), indicator: "green" });
 
 			if (typeof me.events.afterSave === "function") {
-				me.events.afterSave(df, doc.name, doc[df.fieldname]);
+				me.events.afterSave(df, doc.name, doc[df.fieldname], me);
 			}
 		} catch (err) {
 			const errMsg = (err && (err.message || err.exc_type)) || __("Could not save");

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -243,6 +243,26 @@ const EditMixin = {
 				if (df.fieldtype === "Link" && typeof this.resolveLinkTitles === "function") {
 					this.resolveLinkTitles();
 				}
+			} else {
+				// Dialog path (cell === null): find the cell and refresh it
+				const savedCell = this._table?.querySelector(
+					`td.sva-vdr-value-cell[data-fieldname="${CSS.escape(
+						df.fieldname
+					)}"][data-docname="${CSS.escape(doc.name)}"]`
+				);
+				if (savedCell) {
+					savedCell.dataset.rawValue = String(newValue ?? "");
+					// Invalidate cache so resolveLinkTitles re-fetches the new value's display name
+					if (df.fieldtype === "Link" && this._linkTitles?.[df.options]) {
+						delete this._linkTitles[df.options][String(newValue ?? "")];
+					}
+					const formatted = this.formatCellValue(newValue, df, doc, colIndex);
+					savedCell.innerHTML = formatted;
+					this.attachEditListener(savedCell, df, doc, colIndex);
+					if (df.fieldtype === "Link" && typeof this.resolveLinkTitles === "function") {
+						this.resolveLinkTitles();
+					}
+				}
 			}
 
 			// Clear any error banner on success

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -61,7 +61,9 @@ const EditMixin = {
 
 		cell.addEventListener("click", () => {
 			if (cell.dataset.editing === "1") return;
-			if (this.getEditableCellTypes().includes(df.fieldtype)) {
+			if (df.fieldtype === "Table") {
+				this._openTableEditDialog(df, doc, colIndex);
+			} else if (this.getEditableCellTypes().includes(df.fieldtype)) {
 				this.renderInlineEditor(cell, df, doc, colIndex);
 			} else {
 				this.openEditDialog(df, doc, colIndex);
@@ -356,6 +358,320 @@ const EditMixin = {
 				delete cell.dataset.editing;
 				delete cell.dataset.originalContent;
 				this.attachEditListener(cell, df, doc, colIndex);
+			}
+		}
+	},
+
+	// ─── Table fieldtype editing ─────────────────────────────────────────────
+
+	/**
+	 * Entry point for Table field clicks.
+	 * Ensures child DocType meta is loaded, fetches existing rows if not cached,
+	 * then either opens the single-row dialog directly (table_max_rows === 1)
+	 * or the row-listing dialog (multi-row mode).
+	 */
+	_openTableEditDialog(df, doc, colIndex) {
+		const me = this;
+		const childDt = df.options;
+		if (!childDt) return;
+
+		frappe.model.with_doctype(childDt, async () => {
+			const childMeta = frappe.get_meta(childDt);
+			let rows;
+			if (Array.isArray(doc[df.fieldname])) {
+				rows = JSON.parse(JSON.stringify(doc[df.fieldname]));
+			} else {
+				try {
+					const fullDoc = await frappe.db.get_doc(me.doctype, doc.name);
+					rows = fullDoc[df.fieldname] || [];
+					doc[df.fieldname] = rows;
+				} catch (_) {
+					rows = [];
+				}
+			}
+
+			// Single-row mode: skip the listing dialog and open the row editor directly.
+			// The row is re-used on every click — existing data pre-fills; saving replaces it.
+			if (me.table_max_rows === 1) {
+				const rowData = rows[0] ? { ...rows[0] } : {};
+				me._openChildRowDialog(childMeta, rowData, rows[0] ? 0 : null, async (saved) => {
+					const newRows = [saved];
+					doc[df.fieldname] = newRows; // keep cache fresh
+					await me._saveTableValue(df, doc, newRows, colIndex);
+				});
+				return;
+			}
+
+			me._showTableDialog(df, doc, colIndex, childMeta, rows);
+		});
+	},
+
+	/**
+	 * Build and show the row-listing dialog for a Table field.
+	 * Allows adding, editing, and deleting rows before saving.
+	 */
+	_showTableDialog(df, doc, colIndex, childMeta, rows) {
+		const me = this;
+
+		const SYSTEM = new Set([
+			"name",
+			"doctype",
+			"parent",
+			"parentfield",
+			"parenttype",
+			"idx",
+			"docstatus",
+			"creation",
+			"modified",
+			"modified_by",
+			"owner",
+			"__islocal",
+			"__unsaved",
+		]);
+
+		const buildSummary = (row, i) => {
+			const parts = Object.entries(row)
+				.filter(([k, v]) => !SYSTEM.has(k) && v !== null && v !== undefined && v !== "")
+				.slice(0, 3)
+				.map(([k, v]) => {
+					const fdf = (childMeta.fields || []).find((f) => f.fieldname === k);
+					const label = fdf ? __(fdf.label || k) : k;
+					return `<b>${label}:</b> ${String(v).slice(0, 40)}`;
+				});
+			return parts.join(" &nbsp;|&nbsp; ") || `${__("Row")} ${i + 1}`;
+		};
+
+		const buildListHTML = (r) => {
+			if (!r.length) {
+				return `<p style="color:var(--text-muted,#888);font-size:12px;margin:4px 0;">${__(
+					"No rows yet. Click Add Row to begin."
+				)}</p>`;
+			}
+			return r
+				.map(
+					(row, i) => `
+				<div style="display:flex;align-items:center;gap:6px;padding:5px 8px;margin-bottom:3px;
+					background:var(--control-bg,#f8f9fa);border:1px solid var(--border-color,#d1d8dd);border-radius:4px;">
+					<span style="flex:1;font-size:12px;">${buildSummary(row, i)}</span>
+					<button class="btn btn-xs btn-secondary sva-tr-edit" data-idx="${i}" style="padding:1px 8px;">${__(
+						"Edit"
+					)}</button>
+					<button class="btn btn-xs btn-danger sva-tr-del" data-idx="${i}" style="padding:1px 8px;">${__(
+						"Delete"
+					)}</button>
+				</div>`
+				)
+				.join("");
+		};
+
+		const atMax = () => me.table_max_rows && rows.length >= me.table_max_rows;
+
+		const dialogFields = [
+			{
+				fieldname: "row_list",
+				fieldtype: "HTML",
+				options: `<div class="sva-tr-list" style="max-height:320px;overflow-y:auto;padding:2px 0;">${buildListHTML(
+					rows
+				)}</div>`,
+			},
+		];
+		if (!atMax()) {
+			dialogFields.push({
+				fieldname: "add_row_btn",
+				fieldtype: "HTML",
+				options: `<button class="btn btn-xs btn-primary sva-tr-add" style="margin-top:6px;">+ ${__(
+					"Add Row"
+				)}</button>`,
+			});
+		}
+
+		const dialog = new frappe.ui.Dialog({
+			title: __(df.label || df.fieldname),
+			fields: dialogFields,
+			primary_action_label: __("Save"),
+			primary_action: async () => {
+				dialog.hide();
+				await me._saveTableValue(df, doc, rows, colIndex);
+			},
+		});
+
+		dialog.show();
+
+		const refreshList = () => {
+			const listEl = dialog.$wrapper[0].querySelector(".sva-tr-list");
+			if (listEl) listEl.innerHTML = buildListHTML(rows);
+			wireButtons();
+		};
+
+		const wireButtons = () => {
+			const w = dialog.$wrapper[0];
+
+			const addBtn = w.querySelector(".sva-tr-add");
+			if (addBtn) {
+				addBtn.style.display = atMax() ? "none" : "";
+				addBtn.onclick = () =>
+					me._openChildRowDialog(childMeta, {}, null, (newRow) => {
+						rows.push(newRow);
+						refreshList();
+					});
+			}
+
+			w.querySelectorAll(".sva-tr-edit").forEach((btn) => {
+				btn.onclick = () => {
+					const idx = parseInt(btn.dataset.idx);
+					me._openChildRowDialog(childMeta, { ...rows[idx] }, idx, (updated) => {
+						rows[idx] = updated;
+						refreshList();
+					});
+				};
+			});
+
+			w.querySelectorAll(".sva-tr-del").forEach((btn) => {
+				btn.onclick = () => {
+					rows.splice(parseInt(btn.dataset.idx), 1);
+					refreshList();
+				};
+			});
+		};
+
+		wireButtons();
+	},
+
+	/**
+	 * Open a sub-dialog for adding or editing a single child row.
+	 * Includes full Geolocation field support (map picker, draw tools, etc.).
+	 *
+	 * @param {Object}   childMeta — meta of the child DocType
+	 * @param {Object}   rowData   — existing row values (empty {} for new row)
+	 * @param {number|null} rowIdx — null = new row; number = edit existing
+	 * @param {Function} onSave   — called with merged row data on confirm
+	 */
+	_openChildRowDialog(childMeta, rowData, rowIdx, onSave) {
+		const me = this;
+		const SKIP_TYPES = new Set([
+			"Column Break",
+			"Section Break",
+			"Tab Break",
+			"HTML",
+			"Button",
+			"Fold",
+			"Image",
+			"Signature",
+			"Barcode",
+		]);
+		const fields = (childMeta.fields || [])
+			.filter((df) => !SKIP_TYPES.has(df.fieldtype) && !df.hidden)
+			.map((df) => ({ ...df, reqd: 0 }));
+
+		if (!fields.length) return;
+
+		const subDialog = new frappe.ui.Dialog({
+			title: rowIdx === null ? __("Add Row") : __("Edit Row"),
+			fields,
+			primary_action_label: rowIdx === null ? __("Add") : __("Update"),
+			primary_action(values) {
+				subDialog.hide();
+				onSave({ ...rowData, ...values });
+			},
+		});
+
+		// Apply the same Geolocation patches used in openEditDialog
+		fields.forEach((df) => {
+			if (df.fieldtype !== "Geolocation") return;
+			const geoCtrl = subDialog.fields_dict[df.fieldname];
+			if (!geoCtrl) return;
+
+			geoCtrl.doctype = me.doctype;
+			geoCtrl.doc = rowData;
+			geoCtrl.bind_leaflet_draw_control = function () {
+				if (this.df.read_only) return;
+				this.draw_control = this.get_leaflet_controls();
+				this.map.addControl(this.draw_control);
+			};
+			const existingValue = rowData[df.fieldname];
+			let mapReady = false;
+			const protoMakeMap = Object.getPrototypeOf(geoCtrl).make_map;
+			geoCtrl.make_map = (v) => {
+				if (mapReady) return;
+				mapReady = true;
+				protoMakeMap.call(geoCtrl, v !== undefined ? v : existingValue);
+			};
+			subDialog.$wrapper.one("shown.bs.modal", () => {
+				if (geoCtrl.map) {
+					geoCtrl.map.invalidateSize();
+					const layers = geoCtrl.editableLayers?.getLayers() || [];
+					if (layers.length) {
+						try {
+							geoCtrl.map.fitBounds(geoCtrl.editableLayers.getBounds(), {
+								padding: [50, 50],
+							});
+						} catch (_e) {
+							console.warn("Could not fit map bounds:", _e);
+						}
+					}
+				}
+			});
+			subDialog.$wrapper.one("hidden.bs.modal", () => subDialog.$wrapper.remove());
+		});
+
+		// Populate existing values
+		fields.forEach((df) => {
+			if (rowData[df.fieldname] !== undefined) {
+				try {
+					subDialog.set_value(df.fieldname, rowData[df.fieldname]);
+				} catch (_e) {
+					console.warn("Could not set field value:", _e);
+				}
+			}
+		});
+
+		subDialog.show();
+	},
+
+	/**
+	 * Fetch the full parent doc, replace the child table field, save, and
+	 * refresh the VDR cell.
+	 */
+	async _saveTableValue(df, doc, rows, colIndex) {
+		const me = this;
+		const childDt = df.options;
+
+		const processedRows = rows.map((row, i) => ({
+			doctype: childDt,
+			idx: i + 1,
+			...row,
+		}));
+
+		try {
+			const fullDoc = await frappe.db.get_doc(me.doctype, doc.name);
+			fullDoc[df.fieldname] = processedRows;
+			const saved = await frappe.xcall("frappe.client.save", { doc: fullDoc });
+
+			doc[df.fieldname] = saved[df.fieldname] || processedRows;
+
+			const cell = me._table?.querySelector(
+				`td.sva-vdr-value-cell[data-fieldname="${CSS.escape(
+					df.fieldname
+				)}"][data-docname="${CSS.escape(doc.name)}"]`
+			);
+			if (cell) {
+				cell.dataset.rawValue = String(rows.length);
+				cell.innerHTML = me.formatCellValue(doc[df.fieldname], df, doc, colIndex);
+				me.attachEditListener(cell, df, doc, colIndex);
+			}
+
+			if (typeof me.clearErrorBanner === "function") me.clearErrorBanner();
+			frappe.show_alert({ message: __("Saved"), indicator: "green" });
+
+			if (typeof me.events.afterSave === "function") {
+				me.events.afterSave(df, doc.name, doc[df.fieldname]);
+			}
+		} catch (err) {
+			const errMsg = (err && (err.message || err.exc_type)) || __("Could not save");
+			if (typeof me.showErrorBanner === "function") {
+				me.showErrorBanner([`${__(df.label || df.fieldname)}: ${errMsg}`]);
+			} else {
+				frappe.msgprint({ title: __("Save failed"), message: errMsg, indicator: "red" });
 			}
 		}
 	},

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -20,8 +20,17 @@ const EditMixin = {
 	 */
 	getEditableCellTypes() {
 		return [
-			"Data", "Int", "Float", "Currency", "Percent",
-			"Date", "Datetime", "Time", "Check", "Select", "Small Text",
+			"Data",
+			"Int",
+			"Float",
+			"Currency",
+			"Percent",
+			"Date",
+			"Datetime",
+			"Time",
+			"Check",
+			"Select",
+			"Small Text",
 		];
 	},
 
@@ -190,9 +199,10 @@ const EditMixin = {
 				if (cell) {
 					// Revert immediately — don't make the API call
 					const orig = cell.dataset.originalContent;
-					cell.innerHTML = orig !== undefined
-						? orig
-						: this.formatCellValue(doc[df.fieldname], df, doc, colIndex);
+					cell.innerHTML =
+						orig !== undefined
+							? orig
+							: this.formatCellValue(doc[df.fieldname], df, doc, colIndex);
 					delete cell.dataset.editing;
 					delete cell.dataset.originalContent;
 					this.attachEditListener(cell, df, doc, colIndex);
@@ -215,7 +225,9 @@ const EditMixin = {
 
 		// ── persist ─────────────────────────────────────────────────────────
 		try {
-			await frappe.db.set_value(this.doctype, doc.name, df.fieldname, newValue);
+			const dt = doc.doctype || this.doctype;
+			await frappe.db.set_value(dt, doc.name, df.fieldname, newValue);
+			// await frappe.db.set_value(this.doctype, doc.name, df.fieldname, newValue);
 			doc[df.fieldname] = newValue;
 
 			if (cell) {
@@ -243,9 +255,7 @@ const EditMixin = {
 			}
 		} catch (err) {
 			// ── failure: revert + show banner ───────────────────────────────
-			const errMsg =
-				(err && (err.message || err.exc_type)) ||
-				__("Could not save value");
+			const errMsg = (err && (err.message || err.exc_type)) || __("Could not save value");
 			const label = __(df.label || df.fieldname);
 			if (typeof this.showErrorBanner === "function") {
 				this.showErrorBanner([`${label}: ${errMsg}`]);
@@ -254,9 +264,10 @@ const EditMixin = {
 			if (cell) {
 				// Revert to original HTML (preserves resolved link titles etc.)
 				const orig = cell.dataset.originalContent;
-				cell.innerHTML = orig !== undefined
-					? orig
-					: this.formatCellValue(doc[df.fieldname], df, doc, colIndex);
+				cell.innerHTML =
+					orig !== undefined
+						? orig
+						: this.formatCellValue(doc[df.fieldname], df, doc, colIndex);
 				delete cell.dataset.editing;
 				delete cell.dataset.originalContent;
 				this.attachEditListener(cell, df, doc, colIndex);

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -59,7 +59,13 @@ const EditMixin = {
 		cell.style.cursor = "pointer";
 		cell.title = __("Click to edit");
 
-		cell.addEventListener("click", () => {
+		// Remove any previously attached handler before adding a new one so
+		// repeated calls (e.g. after every save) never stack up listeners.
+		if (cell._svaVdrClickHandler) {
+			cell.removeEventListener("click", cell._svaVdrClickHandler);
+		}
+
+		const _handler = () => {
 			if (cell.dataset.editing === "1") return;
 			if (df.fieldtype === "Table") {
 				this._openTableEditDialog(df, doc, colIndex);
@@ -68,7 +74,9 @@ const EditMixin = {
 			} else {
 				this.openEditDialog(df, doc, colIndex);
 			}
-		});
+		};
+		cell._svaVdrClickHandler = _handler;
+		cell.addEventListener("click", _handler);
 	},
 
 	/**
@@ -388,6 +396,15 @@ const EditMixin = {
 				} catch (_) {
 					rows = [];
 				}
+			}
+
+			// Allow vdr_events to intercept with a custom dialog.
+			if (typeof me.events.openTableDialog === "function") {
+				const handled = me.events.openTableDialog(df, doc, rows, async (newRows) => {
+					doc[df.fieldname] = newRows;
+					await me._saveTableValue(df, doc, newRows, colIndex);
+				});
+				if (handled) return;
 			}
 
 			// Single-row mode: skip the listing dialog and open the row editor directly.

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -395,8 +395,14 @@ const EditMixin = {
 			const proceed = await this.events.beforeSave(df, doc.name, newValue);
 			if (proceed === false) {
 				if (cell) {
+					const orig = cell.dataset.originalContent;
+					cell.innerHTML =
+						orig !== undefined
+							? orig
+							: this.formatCellValue(doc[df.fieldname], df, doc, colIndex);
 					delete cell.dataset.editing;
 					delete cell.dataset.originalContent;
+					this.attachEditListener(cell, df, doc, colIndex);
 				}
 				return;
 			}

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -115,9 +115,16 @@ const EditMixin = {
 			ctrl.$input.focus();
 			// air-datepicker doesn't always open on programmatic focus when a value is
 			// already set — call show() explicitly for date/time types.
+			// Deferred so the opening click event finishes propagating before show() runs;
+			// otherwise air-datepicker's outside-click handler fires during the same tick
+			// and immediately closes the picker (visible on second+ clicks on a dated cell).
 			if (["Date", "Datetime", "Time"].includes(df.fieldtype)) {
 				const dp = ctrl.datepicker || ctrl.$input.data("datepicker");
-				if (dp && typeof dp.show === "function") dp.show();
+				if (dp && typeof dp.show === "function") {
+					setTimeout(() => {
+						if (cell.dataset.editing === "1") dp.show();
+					}, 0);
+				}
 			}
 		}
 
@@ -278,13 +285,17 @@ const EditMixin = {
 			dialog.$wrapper.one("hidden.bs.modal", () => dialog.$wrapper.remove());
 		}
 
-		// getLinkQuery hook — apply get_query filter on the Link control inside the dialog
+		// getLinkQuery hook — apply get_query filter on the Link control inside the dialog.
+		// Must patch ctrl.df too: dialog.show() triggers refresh_fields() → ctrl.refresh()
+		// which resets ctrl.get_query from ctrl.df.get_query, overwriting a ctrl-only patch.
 		if (df.fieldtype === "Link" && typeof this.events.getLinkQuery === "function") {
 			const query = this.events.getLinkQuery(df, doc, this);
 			if (query != null) {
+				const getQueryFn = typeof query === "function" ? query : () => query;
 				const ctrl = dialog.fields_dict[df.fieldname];
 				if (ctrl) {
-					ctrl.get_query = typeof query === "function" ? query : () => query;
+					ctrl.get_query = getQueryFn;
+					ctrl.df = { ...ctrl.df, get_query: getQueryFn };
 				}
 			}
 		}

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -173,6 +173,71 @@ const EditMixin = {
 				await this.saveValue(df, doc, newValue, null, colIndex);
 			},
 		});
+
+		if (df.fieldtype === "Geolocation") {
+			const geoCtrl = dialog.fields_dict[df.fieldname];
+			if (geoCtrl) {
+				geoCtrl.doctype = this.doctype;
+				geoCtrl.doc = doc;
+
+				// bind_leaflet_draw_control() gates draw tools on
+				// frappe.perm.has_perm(this.doctype, this.df.permlevel, "write", this.doc).
+				// This silently fails for connected/child doctypes that lack an explicit
+				// Frappe write-permission role entry, even when VDR crud_permissions
+				// includes "write". We already verified write permission in attachEditListener,
+				// so bypass the Frappe perm check and respect only df.read_only.
+				geoCtrl.bind_leaflet_draw_control = function () {
+					if (this.df.read_only) return;
+					this.draw_control = this.get_leaflet_controls();
+					this.map.addControl(this.draw_control);
+				};
+
+				// Frappe's dialog path registers a frappe.ui.Dialog:shown handler every
+				// time set_disp_area() is called (dialog init + set_value both call it).
+				// Multiple handlers → multiple make_map() calls → Leaflet "Map container
+				// already initialized". Also, make_map() is called without value in that
+				// path, so existing geo data never renders.
+				// Fix: gate make_map() to run once and supply the existing value.
+				// Always call the prototype method directly so chained instance patches
+				// (if geoCtrl is ever reused across dialog opens) don't no-op the call.
+				const existingValue = doc[df.fieldname];
+				let mapReady = false;
+				const protoMakeMap = Object.getPrototypeOf(geoCtrl).make_map;
+				geoCtrl.make_map = (v) => {
+					if (mapReady) return;
+					mapReady = true;
+					protoMakeMap.call(geoCtrl, v !== undefined ? v : existingValue);
+				};
+
+				// After Bootstrap's show animation completes, re-invalidate map size.
+				// Without this, fitBounds() (called during make_map with existingValue)
+				// runs while the container is still animating → Leaflet calculates a 0px
+				// viewport → tiles never load → blank white map on reopen after a save.
+				dialog.$wrapper.one("shown.bs.modal", () => {
+					if (geoCtrl.map) {
+						geoCtrl.map.invalidateSize();
+						const layers = geoCtrl.editableLayers?.getLayers() || [];
+						if (layers.length) {
+							try {
+								geoCtrl.map.fitBounds(geoCtrl.editableLayers.getBounds(), {
+									padding: [50, 50],
+								});
+							} catch (e) {
+								console.warn("Could not fit map bounds:", e);
+							}
+						}
+					}
+				});
+			}
+
+			// Remove the wrapper only after Bootstrap finishes its hide animation
+			// (hidden.bs.modal fires after animation; onhide fires before it).
+			// Removing mid-animation corrupts Bootstrap's modal stack so
+			// $(document).trigger("frappe.ui.Dialog:shown") never fires for the next
+			// dialog, leaving the map container blank on every reopen after a save.
+			dialog.$wrapper.one("hidden.bs.modal", () => dialog.$wrapper.remove());
+		}
+
 		dialog.set_value(df.fieldname, doc[df.fieldname]);
 		dialog.show();
 	},

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -110,7 +110,14 @@ const EditMixin = {
 			render_input: true,
 		});
 		ctrl.refresh();
-		ctrl.set_value(doc[df.fieldname]);
+		const _rawVal = doc[df.fieldname];
+		const _numericTypes = ["Int", "Float", "Currency", "Percent"];
+		ctrl.set_value(
+			_numericTypes.includes(df.fieldtype) && (_rawVal === 0 || _rawVal === null)
+				? ""
+				: _rawVal
+		);
+		// ctrl.set_value(_rawVal);
 		if (ctrl.$input) {
 			// Frappe's Int/Float/Currency/Percent controls use type="text" internally.
 			// Switch to type="number" so the browser rejects non-numeric input and

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -130,7 +130,22 @@ const EditMixin = {
 				const dp = ctrl.datepicker || ctrl.$input.data("datepicker");
 				if (dp && typeof dp.show === "function") {
 					setTimeout(() => {
-						if (cell.dataset.editing === "1") dp.show();
+						if (cell.dataset.editing !== "1") return;
+						// Apply Disable Future / Past Dates from df.options
+						if (
+							df.fieldtype === "Date" &&
+							df.options &&
+							typeof dp.update === "function"
+						) {
+							const today = new Date();
+							today.setHours(0, 0, 0, 0);
+							if (df.options === "Disable Future Dates") {
+								dp.update({ maxDate: today });
+							} else if (df.options === "Disable Past Dates") {
+								dp.update({ minDate: today });
+							}
+						}
+						dp.show();
 					}, 0);
 				}
 			}
@@ -158,6 +173,36 @@ const EditMixin = {
 			if (df.fieldtype === "Date") {
 				const raw = ctrl.$input.val();
 				newValue = raw ? frappe.datetime.user_to_str(raw) : "";
+				// Validate Disable Future / Past Dates constraint
+				if (newValue && df.options) {
+					const today = frappe.datetime.get_today();
+					if (df.options === "Disable Future Dates" && newValue > today) {
+						frappe.show_alert(
+							{
+								message: __("{0}: future dates are not allowed.", [
+									__(df.label || df.fieldname),
+								]),
+								indicator: "orange",
+							},
+							4
+						);
+						cancel();
+						return;
+					}
+					if (df.options === "Disable Past Dates" && newValue < today) {
+						frappe.show_alert(
+							{
+								message: __("{0}: past dates are not allowed.", [
+									__(df.label || df.fieldname),
+								]),
+								indicator: "orange",
+							},
+							4
+						);
+						cancel();
+						return;
+					}
+				}
 			} else if (df.fieldtype === "Datetime") {
 				const raw = ctrl.$input.val();
 				newValue = raw ? frappe.datetime.user_to_str(raw, true) : "";

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -604,6 +604,14 @@ const EditMixin = {
 
 		const atMax = () => me.table_max_rows && rows.length >= me.table_max_rows;
 
+		// Resolve per-field "Add Row" label.
+		// Priority: child_add_row_labels config (from Property Setter) → getAddRowLabel event → default.
+		const addRowLabel =
+			(me.child_add_row_labels && me.child_add_row_labels[df.fieldname]) ||
+			(typeof me.events.getAddRowLabel === "function" &&
+				me.events.getAddRowLabel(df, doc, me)) ||
+			__("Add Row");
+
 		const dialogFields = [
 			{
 				fieldname: "row_list",
@@ -618,7 +626,7 @@ const EditMixin = {
 				fieldname: "add_row_btn",
 				fieldtype: "HTML",
 				options: `<button class="btn btn-xs btn-primary sva-tr-add" style="margin-top:6px;">+ ${__(
-					"Add Row"
+					addRowLabel
 				)}</button>`,
 			});
 		}

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -112,6 +112,14 @@ const EditMixin = {
 		ctrl.refresh();
 		ctrl.set_value(doc[df.fieldname]);
 		if (ctrl.$input) {
+			// Frappe's Int/Float/Currency/Percent controls use type="text" internally.
+			// Switch to type="number" so the browser rejects non-numeric input and
+			// shows a numeric keyboard on mobile.
+			if (["Int", "Float", "Currency", "Percent"].includes(df.fieldtype)) {
+				ctrl.$input.attr("type", "number");
+				ctrl.$input.attr("step", df.fieldtype === "Int" ? "1" : "any");
+				if (df.non_negative) ctrl.$input.attr("min", "0");
+			}
 			ctrl.$input.focus();
 			// air-datepicker doesn't always open on programmatic focus when a value is
 			// already set — call show() explicitly for date/time types.
@@ -159,6 +167,41 @@ const EditMixin = {
 				newValue = ctrl.get_value();
 			}
 
+			// For numeric fields, reject non-numeric or invalid values.
+			if (["Int", "Float", "Currency", "Percent"].includes(df.fieldtype)) {
+				const raw = ctrl.$input ? ctrl.$input.val() : String(newValue ?? "");
+				if (raw !== "" && raw !== null) {
+					const parsed = df.fieldtype === "Int" ? parseInt(raw, 10) : parseFloat(raw);
+					if (isNaN(parsed)) {
+						frappe.show_alert(
+							{
+								message: __("{0}: only numeric values are allowed.", [
+									__(df.label || df.fieldname),
+								]),
+								indicator: "orange",
+							},
+							4
+						);
+						cancel();
+						return;
+					}
+					if (df.non_negative && parsed < 0) {
+						frappe.show_alert(
+							{
+								message: __("{0}: value cannot be negative.", [
+									__(df.label || df.fieldname),
+								]),
+								indicator: "orange",
+							},
+							4
+						);
+						cancel();
+						return;
+					}
+					newValue = parsed;
+				}
+			}
+
 			// Set saving visual state
 			cell.dataset.saving = "1";
 			cell.style.opacity = "0.5";
@@ -187,7 +230,10 @@ const EditMixin = {
 				// one tick so ctrl.get_value() reliably returns the new ISO date string.
 				ctrl.$input.on("change", () => setTimeout(triggerSave, 0));
 				ctrl.$input.on("keydown", (e) => {
-					if (e.key === "Escape") { e.preventDefault(); cancel(); }
+					if (e.key === "Escape") {
+						e.preventDefault();
+						cancel();
+					}
 				});
 			} else {
 				// Text-like fields — save when focus leaves the input
@@ -275,9 +321,9 @@ const EditMixin = {
 						} else {
 							// No existing location — auto-locate current GPS position and zoom in
 							geoCtrl.map.once("locationfound", (e) => {
-	geoCtrl.map.setView(e.latlng, 19);
-});
-geoCtrl.map.locate({ enableHighAccuracy: true });
+								geoCtrl.map.setView(e.latlng, 19);
+							});
+							geoCtrl.map.locate({ enableHighAccuracy: true });
 						}
 					}
 				});
@@ -469,11 +515,18 @@ geoCtrl.map.locate({ enableHighAccuracy: true });
 			// The row is re-used on every click — existing data pre-fills; saving replaces it.
 			if (me.table_max_rows === 1) {
 				const rowData = rows[0] ? { ...rows[0] } : {};
-				me._openChildRowDialog(df, doc, childMeta, rowData, rows[0] ? 0 : null, async (saved) => {
-					const newRows = [saved];
-					doc[df.fieldname] = newRows; // keep cache fresh
-					await me._saveTableValue(df, doc, newRows, colIndex);
-				});
+				me._openChildRowDialog(
+					df,
+					doc,
+					childMeta,
+					rowData,
+					rows[0] ? 0 : null,
+					async (saved) => {
+						const newRows = [saved];
+						doc[df.fieldname] = newRows; // keep cache fresh
+						await me._saveTableValue(df, doc, newRows, colIndex);
+					}
+				);
 				return;
 			}
 
@@ -594,10 +647,17 @@ geoCtrl.map.locate({ enableHighAccuracy: true });
 			w.querySelectorAll(".sva-tr-edit").forEach((btn) => {
 				btn.onclick = () => {
 					const idx = parseInt(btn.dataset.idx);
-					me._openChildRowDialog(df, doc, childMeta, { ...rows[idx] }, idx, (updated) => {
-						rows[idx] = updated;
-						refreshList();
-					});
+					me._openChildRowDialog(
+						df,
+						doc,
+						childMeta,
+						{ ...rows[idx] },
+						idx,
+						(updated) => {
+							rows[idx] = updated;
+							refreshList();
+						}
+					);
 				};
 			});
 
@@ -649,7 +709,9 @@ geoCtrl.map.locate({ enableHighAccuracy: true });
 
 		// getTableFields: allowlist approach — return fieldname[] or null (show all)
 		if (typeof me.events.getTableFields === "function") {
-			const allowed = await Promise.resolve(me.events.getTableFields(tableDf, parentDoc, me));
+			const allowed = await Promise.resolve(
+				me.events.getTableFields(tableDf, parentDoc, me)
+			);
 			if (Array.isArray(allowed) && allowed.length) {
 				const allowedSet = new Set(allowed);
 				fields = fields.filter((f) => allowedSet.has(f.fieldname));
@@ -659,7 +721,9 @@ geoCtrl.map.locate({ enableHighAccuracy: true });
 		// filterTableField: per-field conditional — return false to hide a field
 		if (typeof me.events.filterTableField === "function") {
 			const results = await Promise.all(
-				fields.map((f) => Promise.resolve(me.events.filterTableField(tableDf, f, parentDoc, me)))
+				fields.map((f) =>
+					Promise.resolve(me.events.filterTableField(tableDf, f, parentDoc, me))
+				)
 			);
 			fields = fields.filter((_, i) => results[i] !== false);
 		}

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -272,6 +272,12 @@ const EditMixin = {
 							} catch (e) {
 								console.warn("Could not fit map bounds:", e);
 							}
+						} else {
+							// No existing location — auto-locate current GPS position and zoom in
+							geoCtrl.map.once("locationfound", (e) => {
+	geoCtrl.map.setView(e.latlng, 19);
+});
+geoCtrl.map.locate({ enableHighAccuracy: true });
 						}
 					}
 				});
@@ -690,9 +696,9 @@ const EditMixin = {
 				if (mapReady) return;
 				mapReady = true;
 				protoMakeMap.call(geoCtrl, v !== undefined ? v : existingValue);
-			};
-			subDialog.$wrapper.one("shown.bs.modal", () => {
-				if (geoCtrl.map) {
+				// Delay so Bootstrap animation finishes and container has real dimensions
+				setTimeout(() => {
+					if (!geoCtrl.map) return;
 					geoCtrl.map.invalidateSize();
 					const layers = geoCtrl.editableLayers?.getLayers() || [];
 					if (layers.length) {
@@ -703,9 +709,14 @@ const EditMixin = {
 						} catch (_e) {
 							console.warn("Could not fit map bounds:", _e);
 						}
+					} else {
+						geoCtrl.map.once("locationfound", (e) => {
+							geoCtrl.map.setView(e.latlng, 19);
+						});
+						geoCtrl.map.locate({ enableHighAccuracy: true });
 					}
-				}
-			});
+				}, 350);
+			};
 			subDialog.$wrapper.one("hidden.bs.modal", () => subDialog.$wrapper.remove());
 		});
 

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -162,7 +162,8 @@ const EditMixin = {
 				const raw = ctrl.$input.val();
 				newValue = raw ? frappe.datetime.user_to_str(raw, true) : "";
 			} else if (df.fieldtype === "Time") {
-				newValue = ctrl.$input.val() || "";
+				// Strip microseconds — Frappe only accepts HH:mm:ss
+				newValue = (ctrl.$input.val() || "").slice(0, 8);
 			} else {
 				newValue = ctrl.get_value();
 			}

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -525,6 +525,10 @@ const EditMixin = {
 						const newRows = [saved];
 						doc[df.fieldname] = newRows; // keep cache fresh
 						await me._saveTableValue(df, doc, newRows, colIndex);
+					},
+					{
+						title: __(df.label || df.fieldname),
+						primary_action_label: __("Save"),
 					}
 				);
 				return;
@@ -690,7 +694,15 @@ const EditMixin = {
 	 * @param {number|null} rowIdx    — null = new row; number = edit existing
 	 * @param {Function}    onSave    — called with merged row data on confirm
 	 */
-	async _openChildRowDialog(tableDf, parentDoc, childMeta, rowData, rowIdx, onSave) {
+	async _openChildRowDialog(
+		tableDf,
+		parentDoc,
+		childMeta,
+		rowData,
+		rowIdx,
+		onSave,
+		options = {}
+	) {
 		const me = this;
 		const SKIP_TYPES = new Set([
 			"Column Break",
@@ -731,9 +743,10 @@ const EditMixin = {
 		if (!fields.length) return;
 
 		const subDialog = new frappe.ui.Dialog({
-			title: rowIdx === null ? __("Add Row") : __("Edit Row"),
+			title: options.title || (rowIdx === null ? __("Add Row") : __("Edit Row")),
 			fields,
-			primary_action_label: rowIdx === null ? __("Add") : __("Update"),
+			primary_action_label:
+				options.primary_action_label || (rowIdx === null ? __("Add") : __("Update")),
 			primary_action(values) {
 				subDialog.hide();
 				onSave({ ...rowData, ...values });

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -441,7 +441,7 @@ const EditMixin = {
 			// The row is re-used on every click — existing data pre-fills; saving replaces it.
 			if (me.table_max_rows === 1) {
 				const rowData = rows[0] ? { ...rows[0] } : {};
-				me._openChildRowDialog(childMeta, rowData, rows[0] ? 0 : null, async (saved) => {
+				me._openChildRowDialog(df, doc, childMeta, rowData, rows[0] ? 0 : null, async (saved) => {
 					const newRows = [saved];
 					doc[df.fieldname] = newRows; // keep cache fresh
 					await me._saveTableValue(df, doc, newRows, colIndex);
@@ -557,7 +557,7 @@ const EditMixin = {
 			if (addBtn) {
 				addBtn.style.display = atMax() ? "none" : "";
 				addBtn.onclick = () =>
-					me._openChildRowDialog(childMeta, {}, null, (newRow) => {
+					me._openChildRowDialog(df, doc, childMeta, {}, null, (newRow) => {
 						rows.push(newRow);
 						refreshList();
 					});
@@ -566,7 +566,7 @@ const EditMixin = {
 			w.querySelectorAll(".sva-tr-edit").forEach((btn) => {
 				btn.onclick = () => {
 					const idx = parseInt(btn.dataset.idx);
-					me._openChildRowDialog(childMeta, { ...rows[idx] }, idx, (updated) => {
+					me._openChildRowDialog(df, doc, childMeta, { ...rows[idx] }, idx, (updated) => {
 						rows[idx] = updated;
 						refreshList();
 					});
@@ -588,12 +588,21 @@ const EditMixin = {
 	 * Open a sub-dialog for adding or editing a single child row.
 	 * Includes full Geolocation field support (map picker, draw tools, etc.).
 	 *
-	 * @param {Object}   childMeta — meta of the child DocType
-	 * @param {Object}   rowData   — existing row values (empty {} for new row)
-	 * @param {number|null} rowIdx — null = new row; number = edit existing
-	 * @param {Function} onSave   — called with merged row data on confirm
+	 * Supports two optional vdr_events hooks for field filtering:
+	 *   getTableFields(tableDf, parentDoc, vdrInstance) → string[] | null
+	 *     Return an allowlist of fieldnames to show; null = show all.
+	 *   filterTableField(tableDf, childFieldDf, parentDoc, vdrInstance) → boolean
+	 *     Called per-field; return false to hide that field.
+	 * Both hooks support async. filterTableField runs after getTableFields.
+	 *
+	 * @param {Object}      tableDf   — Table field descriptor from parent meta
+	 * @param {Object}      parentDoc — parent VDR document row
+	 * @param {Object}      childMeta — meta of the child DocType
+	 * @param {Object}      rowData   — existing row values (empty {} for new row)
+	 * @param {number|null} rowIdx    — null = new row; number = edit existing
+	 * @param {Function}    onSave    — called with merged row data on confirm
 	 */
-	_openChildRowDialog(childMeta, rowData, rowIdx, onSave) {
+	async _openChildRowDialog(tableDf, parentDoc, childMeta, rowData, rowIdx, onSave) {
 		const me = this;
 		const SKIP_TYPES = new Set([
 			"Column Break",
@@ -606,9 +615,26 @@ const EditMixin = {
 			"Signature",
 			"Barcode",
 		]);
-		const fields = (childMeta.fields || [])
+		let fields = (childMeta.fields || [])
 			.filter((df) => !SKIP_TYPES.has(df.fieldtype) && !df.hidden)
 			.map((df) => ({ ...df, reqd: 0 }));
+
+		// getTableFields: allowlist approach — return fieldname[] or null (show all)
+		if (typeof me.events.getTableFields === "function") {
+			const allowed = await Promise.resolve(me.events.getTableFields(tableDf, parentDoc, me));
+			if (Array.isArray(allowed) && allowed.length) {
+				const allowedSet = new Set(allowed);
+				fields = fields.filter((f) => allowedSet.has(f.fieldname));
+			}
+		}
+
+		// filterTableField: per-field conditional — return false to hide a field
+		if (typeof me.events.filterTableField === "function") {
+			const results = await Promise.all(
+				fields.map((f) => Promise.resolve(me.events.filterTableField(tableDf, f, parentDoc, me)))
+			);
+			fields = fields.filter((_, i) => results[i] !== false);
+		}
 
 		if (!fields.length) return;
 

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -111,7 +111,15 @@ const EditMixin = {
 		});
 		ctrl.refresh();
 		ctrl.set_value(doc[df.fieldname]);
-		if (ctrl.$input) ctrl.$input.focus();
+		if (ctrl.$input) {
+			ctrl.$input.focus();
+			// air-datepicker doesn't always open on programmatic focus when a value is
+			// already set — call show() explicitly for date/time types.
+			if (["Date", "Datetime", "Time"].includes(df.fieldtype)) {
+				const dp = ctrl.datepicker || ctrl.$input.data("datepicker");
+				if (dp && typeof dp.show === "function") dp.show();
+			}
+		}
 
 		// ── cancel: revert cell to its pre-edit state ──────────────────────
 		const cancel = () => {
@@ -127,7 +135,22 @@ const EditMixin = {
 		const triggerSave = async () => {
 			if (cell.dataset.saving === "1") return;
 
-			const newValue = ctrl.get_value();
+			// For Date/Datetime/Time: ctrl.get_value() returns the stale initial value
+			// because the standalone control's this.value is never updated by air-datepicker
+			// (set_model_value requires a frm/doctype context). Read $input.val() directly
+			// and convert from locale display format to ISO using Frappe's datetime util.
+			let newValue;
+			if (df.fieldtype === "Date") {
+				const raw = ctrl.$input.val();
+				newValue = raw ? frappe.datetime.user_to_str(raw) : "";
+			} else if (df.fieldtype === "Datetime") {
+				const raw = ctrl.$input.val();
+				newValue = raw ? frappe.datetime.user_to_str(raw, true) : "";
+			} else if (df.fieldtype === "Time") {
+				newValue = ctrl.$input.val() || "";
+			} else {
+				newValue = ctrl.get_value();
+			}
 
 			// Set saving visual state
 			cell.dataset.saving = "1";
@@ -151,10 +174,17 @@ const EditMixin = {
 			if (this._getInstantSaveTypes().includes(df.fieldtype)) {
 				// Check, Select — save immediately on change
 				ctrl.$input.on("change", triggerSave);
+			} else if (["Date", "Datetime", "Time"].includes(df.fieldtype)) {
+				// Date picker types: flatpickr fires a native change event after selecting
+				// a date, but Frappe's ctrl.value may not be fully settled yet. Defer by
+				// one tick so ctrl.get_value() reliably returns the new ISO date string.
+				ctrl.$input.on("change", () => setTimeout(triggerSave, 0));
+				ctrl.$input.on("keydown", (e) => {
+					if (e.key === "Escape") { e.preventDefault(); cancel(); }
+				});
 			} else {
 				// Text-like fields — save when focus leaves the input
 				ctrl.$input.on("blur", triggerSave);
-				// ESC → cancel without saving
 				ctrl.$input.on("keydown", (e) => {
 					if (e.key === "Escape") {
 						e.preventDefault();

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/edit.js
@@ -278,6 +278,17 @@ const EditMixin = {
 			dialog.$wrapper.one("hidden.bs.modal", () => dialog.$wrapper.remove());
 		}
 
+		// getLinkQuery hook — apply get_query filter on the Link control inside the dialog
+		if (df.fieldtype === "Link" && typeof this.events.getLinkQuery === "function") {
+			const query = this.events.getLinkQuery(df, doc, this);
+			if (query != null) {
+				const ctrl = dialog.fields_dict[df.fieldname];
+				if (ctrl) {
+					ctrl.get_query = typeof query === "function" ? query : () => query;
+				}
+			}
+		}
+
 		dialog.set_value(df.fieldname, doc[df.fieldname]);
 		dialog.show();
 	},

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/fields.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/fields.js
@@ -1,0 +1,35 @@
+const FieldsMixin = {
+	/**
+	 * Format a cell value for display.
+	 * Checks vdr_events.formatCell first; falls back to frappe.format().
+	 *
+	 * @param {*}      value    — raw value from the document
+	 * @param {Object} df       — field descriptor from meta
+	 * @param {Object} doc      — full document row
+	 * @param {number} colIndex — 0-based index of this doc column
+	 * @returns {string} HTML or text to place into the cell
+	 */
+	formatCellValue(value, df, doc, colIndex) {
+		// Developer override — return null to fall through to default
+		if (typeof this.events.formatCell === "function") {
+			const override = this.events.formatCell(value, df, doc, colIndex);
+			if (override !== null && override !== undefined) {
+				return override;
+			}
+		}
+
+		if (value === null || value === undefined || value === "") {
+			return "";
+		}
+
+		// Use Frappe's built-in formatter when available
+		try {
+			const formatted = frappe.format(value, df, { inline: true }, doc);
+			return formatted !== null && formatted !== undefined ? formatted : String(value);
+		} catch (_) {
+			return String(value);
+		}
+	},
+};
+
+export default FieldsMixin;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/fields.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/fields.js
@@ -18,6 +18,11 @@ const FieldsMixin = {
 			}
 		}
 
+		// Table: always route here — handles null/empty with 📋 placeholder
+		if (df.fieldtype === "Table") {
+			return this._formatTable(value, df);
+		}
+
 		if (value === null || value === undefined || value === "") {
 			return "";
 		}
@@ -47,6 +52,101 @@ const FieldsMixin = {
 	 * @param {string|object} value — raw field value (GeoJSON string or object)
 	 * @returns {string} safe HTML string
 	 */
+	/**
+	 * Format a Table (child table) field value as "FieldLabel(value), ..." per field.
+	 *
+	 * For each non-empty field in each row shows "Label(formatted_value)":
+	 *   - Geolocation  → "P1(🗺 Polygon)" using geometry type
+	 *   - Other fields → "FieldName(raw_value)"
+	 *
+	 * Uses child DocType meta from Frappe's in-memory cache (frappe.get_meta).
+	 * Falls back to "(row1), (row2)..." when meta is not yet cached.
+	 * Returns 📋 when value is null / not yet loaded.
+	 *
+	 * @param {*}      value — raw field value (array of row objects, or null)
+	 * @param {Object} df    — Table field descriptor (df.options = child DocType name)
+	 */
+	_formatTable(value, df) {
+		if (!Array.isArray(value) || !value.length) {
+			return `<span style="color:var(--text-muted,#aaa);font-size:13px;" title="${__(
+				"Child table — click to view/edit"
+			)}">📋</span>`;
+		}
+
+		const SYSTEM = new Set([
+			"name",
+			"doctype",
+			"parent",
+			"parentfield",
+			"parenttype",
+			"idx",
+			"docstatus",
+			"creation",
+			"modified",
+			"modified_by",
+			"owner",
+			"__islocal",
+			"__unsaved",
+		]);
+
+		// Use cached child meta when available
+		const childMeta = df && df.options ? frappe.get_meta(df.options) : null;
+		const childFields = childMeta ? childMeta.fields || [] : null;
+
+		const parts = [];
+
+		value.forEach((row) => {
+			Object.entries(row)
+				.filter(
+					([k, v]) =>
+						!SYSTEM.has(k) && v !== null && v !== undefined && v !== "" && v !== 0
+				)
+				.forEach(([k, v]) => {
+					const fdf = childFields && childFields.find((f) => f.fieldname === k);
+					const label = fdf ? __(fdf.label || k) : k;
+
+					let displayVal;
+					if (fdf && fdf.fieldtype === "Geolocation") {
+						displayVal = this._getGeoTypeSummary(v);
+					} else if (childFields) {
+						displayVal = String(v).slice(0, 30);
+					} else {
+						// Meta not loaded yet — show raw value truncated
+						displayVal = String(v).slice(0, 20);
+					}
+
+					if (displayVal) {
+						parts.push(
+							`<span style="white-space:nowrap;">${label}(${displayVal})</span>`
+						);
+					}
+				});
+		});
+
+		if (!parts.length) {
+			return `<span style="color:var(--text-muted,#aaa);font-size:13px;">📋</span>`;
+		}
+
+		return parts.join(",&nbsp;");
+	},
+
+	/**
+	 * Extract the geometry type label from a GeoJSON value — used for compact
+	 * child-table Geolocation summaries, e.g. "🗺 Polygon", "📍 Point".
+	 */
+	_getGeoTypeSummary(value) {
+		try {
+			const geo = typeof value === "string" ? JSON.parse(value) : value;
+			if (!geo || !Array.isArray(geo.features) || !geo.features.length) return "";
+			const types = [...new Set(geo.features.map((f) => f.geometry?.type).filter(Boolean))];
+			if (!types.length) return "";
+			const icon = types.includes("Point") && types.length === 1 ? "📍" : "🗺";
+			return `${icon} ${types.join("/")}`;
+		} catch (_) {
+			return "";
+		}
+	},
+
 	_formatGeolocation(value) {
 		try {
 			const geo = typeof value === "string" ? JSON.parse(value) : value;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/fields.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/fields.js
@@ -79,7 +79,8 @@ const FieldsMixin = {
 	 * @param {Object} df    — Table field descriptor (df.options = child DocType name)
 	 */
 	_formatTable(value, df) {
-		const TABLE_PLUS_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12.5 21h-7.5a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v7.5"/><path d="M3 10h18"/><path d="M10 3v18"/><path d="M16 19h6"/><path d="M19 16v6"/></svg>';
+		const TABLE_PLUS_SVG =
+			'<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12.5 21h-7.5a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v7.5"/><path d="M3 10h18"/><path d="M10 3v18"/><path d="M16 19h6"/><path d="M19 16v6"/></svg>';
 		// frappe.db.get_list may return a numeric row count for Table fields instead of
 		// the actual rows — show a count badge so the cell isn't misleadingly empty.
 		if (typeof value === "number" && value > 0) {

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/fields.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/fields.js
@@ -22,10 +22,63 @@ const FieldsMixin = {
 			return "";
 		}
 
+		// Geolocation: parse GeoJSON and show human-readable coordinates / type summary
+		if (df.fieldtype === "Geolocation") {
+			return this._formatGeolocation(value);
+		}
+
 		// Use Frappe's built-in formatter when available
 		try {
 			const formatted = frappe.format(value, df, { inline: true }, doc);
 			return formatted !== null && formatted !== undefined ? formatted : String(value);
+		} catch (_) {
+			return String(value);
+		}
+	},
+
+	/**
+	 * Render a Geolocation field value compactly for the comparison table.
+	 *
+	 * - Single Point  → "📍 lat, lng" as a Google Maps link
+	 * - Polygon/Line/mixed → "🗺 <type> (<n> features)" label
+	 *
+	 * GeoJSON coordinates are stored as [longitude, latitude]; display is lat, lng.
+	 *
+	 * @param {string|object} value — raw field value (GeoJSON string or object)
+	 * @returns {string} safe HTML string
+	 */
+	_formatGeolocation(value) {
+		try {
+			const geo = typeof value === "string" ? JSON.parse(value) : value;
+			if (!geo || !Array.isArray(geo.features) || !geo.features.length) return "";
+
+			const geomTypes = [
+				...new Set(geo.features.map((f) => f.geometry?.type).filter(Boolean)),
+			];
+			if (!geomTypes.length) return "";
+
+			// Single Point — show coordinates and link to Google Maps
+			if (geomTypes.length === 1 && geomTypes[0] === "Point") {
+				const [lng, lat] = geo.features[0].geometry.coordinates;
+				const latF = parseFloat(lat).toFixed(6);
+				const lngF = parseFloat(lng).toFixed(6);
+				return (
+					`<a href="https://www.google.com/maps?q=${latF},${lngF}" ` +
+					`target="_blank" rel="noopener" title="${latF}, ${lngF}" ` +
+					`style="white-space:nowrap;text-decoration:none;font-size:12px;">` +
+					`📍 ${latF}, ${lngF}</a>`
+				);
+			}
+
+			// Polygon, LineString, or mixed — show a compact label
+			const count = geo.features.length;
+			const typeLabel = geomTypes.join(" / ");
+			return (
+				`<span title="Geolocation: ${typeLabel}" ` +
+				`style="white-space:nowrap;color:var(--text-muted,#888);font-size:12px;">` +
+				`🗺 ${typeLabel}${count > 1 ? ` (${count})` : ""}` +
+				`</span>`
+			);
 		} catch (_) {
 			return String(value);
 		}

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/fields.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/fields.js
@@ -39,6 +39,11 @@ const FieldsMixin = {
 			return frappe.utils.escape_html(String(value));
 		}
 
+		// Check fields: show table-plus SVG icon instead of disabled checkbox
+		if (df.fieldtype === "Check") {
+			return '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12.5 21h-7.5a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v7.5"/><path d="M3 10h18"/><path d="M10 3v18"/><path d="M16 19h6"/><path d="M19 16v6"/></svg>';
+		}
+
 		// Use Frappe's built-in formatter when available
 		try {
 			const formatted = frappe.format(value, df, { inline: true }, doc);
@@ -74,17 +79,18 @@ const FieldsMixin = {
 	 * @param {Object} df    — Table field descriptor (df.options = child DocType name)
 	 */
 	_formatTable(value, df) {
+		const TABLE_PLUS_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12.5 21h-7.5a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v7.5"/><path d="M3 10h18"/><path d="M10 3v18"/><path d="M16 19h6"/><path d="M19 16v6"/></svg>';
 		// frappe.db.get_list may return a numeric row count for Table fields instead of
 		// the actual rows — show a count badge so the cell isn't misleadingly empty.
 		if (typeof value === "number" && value > 0) {
 			return `<span style="color:var(--text-muted,#aaa);font-size:13px;" title="${__(
 				"Child table — click to view/edit"
-			)}">📋 ${value}</span>`;
+			)}">${TABLE_PLUS_SVG} ${value}</span>`;
 		}
 		if (!Array.isArray(value) || !value.length) {
 			return `<span style="color:var(--text-muted,#aaa);font-size:13px;" title="${__(
-				"Child table — click to view/edit"
-			)}">📋</span>`;
+				"Table — click to view/edit"
+			)}">${TABLE_PLUS_SVG}</span>`;
 		}
 
 		const SYSTEM = new Set([
@@ -138,7 +144,7 @@ const FieldsMixin = {
 		});
 
 		if (!parts.length) {
-			return `<span style="color:var(--text-muted,#aaa);font-size:13px;">📋</span>`;
+			return `<span style="color:var(--text-muted,#aaa);font-size:13px;">${TABLE_PLUS_SVG}</span>`;
 		}
 
 		return parts.join(",&nbsp;");

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/fields.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/fields.js
@@ -67,6 +67,13 @@ const FieldsMixin = {
 	 * @param {Object} df    — Table field descriptor (df.options = child DocType name)
 	 */
 	_formatTable(value, df) {
+		// frappe.db.get_list may return a numeric row count for Table fields instead of
+		// the actual rows — show a count badge so the cell isn't misleadingly empty.
+		if (typeof value === "number" && value > 0) {
+			return `<span style="color:var(--text-muted,#aaa);font-size:13px;" title="${__(
+				"Child table — click to view/edit"
+			)}">📋 ${value}</span>`;
+		}
 		if (!Array.isArray(value) || !value.length) {
 			return `<span style="color:var(--text-muted,#aaa);font-size:13px;" title="${__(
 				"Child table — click to view/edit"

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/fields.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/fields.js
@@ -27,6 +27,18 @@ const FieldsMixin = {
 			return "";
 		}
 
+		// Frappe's API converts null int/float values to 0 via Python's cint().
+		// Treat 0 as empty for these types when the raw DB value was null.
+		if (
+			(df.fieldtype === "Int" ||
+				df.fieldtype === "Float" ||
+				df.fieldtype === "Currency" ||
+				df.fieldtype === "Percent") &&
+			(value === 0 || value === "0")
+		) {
+			return "";
+		}
+
 		// Geolocation: parse GeoJSON and show human-readable coordinates / type summary
 		if (df.fieldtype === "Geolocation") {
 			return this._formatGeolocation(value);

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/fields.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/fields.js
@@ -32,6 +32,13 @@ const FieldsMixin = {
 			return this._formatGeolocation(value);
 		}
 
+		// Link fields: frappe.format() returns <a href="..."> which causes page navigation
+		// when the cell is clicked for editing. Return plain text — link titles are resolved
+		// separately by _applyLinkTitles() after render.
+		if (df.fieldtype === "Link") {
+			return frappe.utils.escape_html(String(value));
+		}
+
 		// Use Frappe's built-in formatter when available
 		try {
 			const formatted = frappe.format(value, df, { inline: true }, doc);

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
@@ -1,0 +1,104 @@
+const HelpersMixin = {
+	/**
+	 * Total column count: label col + optional unit col + one col per doc.
+	 */
+	getColumnCount() {
+		return 1 + (this.show_unit ? 1 : 0) + this.docs.length;
+	},
+
+	/**
+	 * Re-order fetched doc records to match the order of this.docs.
+	 * @param {Array} data — array of objects returned by frappe.db.get_list
+	 * @returns {Array} sorted array aligned with this.docs
+	 */
+	sortDataByDocs(data) {
+		const map = {};
+		data.forEach((d) => (map[d.name] = d));
+		return this.docs.map((name) => map[name] || { name });
+	},
+
+	/**
+	 * Returns true when every document has a null/empty value for the given field.
+	 * Used to skip rows when hide_empty_rows is enabled.
+	 * @param {Object} df — field descriptor from meta
+	 */
+	isEmptyRow(df) {
+		return this.data.every((doc) => {
+			const v = doc[df.fieldname];
+			return v === null || v === undefined || v === "" || v === 0;
+		});
+	},
+
+	/**
+	 * Parse a short unit string from a field's description.
+	 * Supports patterns like "in acre", "in year", "(ac)", "(yr)" etc.
+	 * Returns empty string if no unit found.
+	 * @param {Object} df — field descriptor
+	 * @returns {string}
+	 */
+	getFieldUnit(df) {
+		if (!df.description) return "";
+		const desc = df.description.trim();
+
+		// "in <unit>" pattern — take the word after "in"
+		const inMatch = desc.match(/\bin\s+(\S+)/i);
+		if (inMatch) {
+			return this._abbreviateUnit(inMatch[1]);
+		}
+
+		// "(unit)" pattern — text inside first parentheses
+		const parenMatch = desc.match(/\(([^)]+)\)/);
+		if (parenMatch) {
+			return parenMatch[1].trim();
+		}
+
+		return "";
+	},
+
+	/**
+	 * Map common full unit names to short abbreviations.
+	 * @param {string} unit
+	 * @returns {string}
+	 */
+	_abbreviateUnit(unit) {
+		const MAP = {
+			acre: "ac",
+			acres: "ac",
+			year: "yr",
+			years: "yr",
+			hectare: "ha",
+			hectares: "ha",
+			kilogram: "kg",
+			kilograms: "kg",
+			meter: "m",
+			meters: "m",
+			kilometer: "km",
+			kilometers: "km",
+			litre: "L",
+			litres: "L",
+			liter: "L",
+			liters: "L",
+		};
+		return MAP[unit.toLowerCase()] || unit;
+	},
+
+	/**
+	 * Return the list of field descriptors that should be rendered as data rows,
+	 * respecting fields_to_show / fields_to_hide and skipping layout fields.
+	 * Section Break and Tab Break are NOT filtered here — rendering.js handles those separately.
+	 * @returns {Array}
+	 */
+	getVisibleFields() {
+		const SKIP_TYPES = new Set(["Column Break", "HTML", "Button", "Fold", "Image", "Signature", "Geolocation", "Barcode"]);
+		return (this.meta.fields || []).filter((df) => {
+			if (SKIP_TYPES.has(df.fieldtype)) return false;
+			if (df.fieldtype === "Tab Break" || df.fieldtype === "Section Break") return false;
+			if (df.hidden) return false;
+			if (this.fields_to_hide && this.fields_to_hide.includes(df.fieldname)) return false;
+			if (this.fields_to_show && !this.fields_to_show.includes(df.fieldname)) return false;
+			return true;
+		});
+	},
+};
+
+export default HelpersMixin;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
@@ -120,7 +120,6 @@ const HelpersMixin = {
 			"Fold",
 			"Image",
 			"Signature",
-			"Geolocation",
 			"Barcode",
 			"Tab Break",
 			"Section Break",

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
@@ -214,6 +214,55 @@ const HelpersMixin = {
 	},
 
 	/**
+	 * Re-sort all already-rendered columns by column_order_rules.
+	 * Called after each lazy-loaded batch so cross-batch ordering is correct.
+	 * Reorders this.data, this.docs, this.column_configs, and all DOM columns.
+	 */
+	_reorderColumnsByRules() {
+		if (!this.column_order_rules || !this.column_order_rules.length) return;
+		if (!this.data || !this.data.length) return;
+
+		const labelField = this.column_label_field;
+		const configs = this.column_configs || [];
+
+		const entries = this.data.map((doc, i) => {
+			const label = (labelField && doc[labelField]) || configs[i]?.label || doc.name || "";
+			const rule = this._matchOrderRule(label);
+			return { doc, conf: configs[i] || {}, order: rule ? (rule.order ?? Infinity) : Infinity, origIndex: i };
+		});
+		entries.sort((a, b) => a.order - b.order || a.origIndex - b.origIndex);
+
+		this.data = entries.map((e) => e.doc);
+		this.docs = this.data.map((d) => d.name);
+		this.column_configs = entries.map((e) => e.conf);
+
+		// Reorder header <th>s — insertBefore sentinel/create keeps them before the controls
+		const insertBefore = this._createTh || this._sentinel || null;
+		this.data.forEach((doc) => {
+			const th = this._theadRow.querySelector(`th[data-docname="${doc.name}"]`);
+			if (!th) return;
+			if (insertBefore) this._theadRow.insertBefore(th, insertBefore);
+			else this._theadRow.appendChild(th);
+		});
+
+		// Reorder value <td>s in each field row
+		this._table.querySelectorAll("tr.sva-vdr-field-row").forEach((tr) => {
+			this.data.forEach((doc) => {
+				const td = tr.querySelector(`td[data-docname="${doc.name}"]`);
+				if (td) tr.appendChild(td);
+			});
+		});
+
+		// Reorder delete cells (if delete row exists)
+		if (this._deleteRow) {
+			this.data.forEach((doc) => {
+				const td = this._deleteRow.querySelector(`td[data-docname="${doc.name}"]`);
+				if (td) this._deleteRow.appendChild(td);
+			});
+		}
+	},
+
+	/**
 	 * Resolve the section_configs entry for a given Section/Tab Break field.
 	 * Looks up by fieldname first, then by label (case-sensitive).
 	 * Returns null when no config exists for this section.

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
@@ -95,6 +95,7 @@ const HelpersMixin = {
 		return (
 			this.section_configs[df.fieldname] ||
 			(df.label ? this.section_configs[df.label] : null) ||
+			this.section_configs["*"] ||
 			null
 		);
 	},

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
@@ -260,18 +260,28 @@ const HelpersMixin = {
 			(df) => !SKIP_TYPES.has(df.fieldtype) && !df.hidden
 		);
 
+		let visible;
 		if (this.fields_config && this.fields_config.length > 0) {
 			// fields_config is authoritative: defines both order and visibility
 			const map = new Map(all.map((df) => [df.fieldname, df]));
-			return this.fields_config.map((fn) => map.get(fn)).filter(Boolean);
+			visible = this.fields_config.map((fn) => map.get(fn)).filter(Boolean);
+		} else {
+			// Default: apply fields_to_show / fields_to_hide in meta order
+			visible = all.filter((df) => {
+				if (this.fields_to_hide && this.fields_to_hide.includes(df.fieldname)) return false;
+				if (this.fields_to_show && !this.fields_to_show.includes(df.fieldname)) return false;
+				return true;
+			});
 		}
 
-		// Default: apply fields_to_show / fields_to_hide in meta order
-		return all.filter((df) => {
-			if (this.fields_to_hide && this.fields_to_hide.includes(df.fieldname)) return false;
-			if (this.fields_to_show && !this.fields_to_show.includes(df.fieldname)) return false;
-			return true;
-		});
+		// filterRow hook: sync per-field gate; return false to hide a row.
+		// Use this to conditionally show/hide VDR rows based on doc values or config.
+		// Note: must be synchronous — called inside the rendering loop.
+		if (typeof this.events.filterRow === "function") {
+			visible = visible.filter((df) => this.events.filterRow(df, this) !== false);
+		}
+
+		return visible;
 	},
 };
 

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
@@ -25,7 +25,13 @@ const HelpersMixin = {
 	isEmptyRow(df) {
 		return this.data.every((doc) => {
 			const v = doc[df.fieldname];
-			return v === null || v === undefined || v === "" || v === 0;
+			return (
+				v === null ||
+				v === undefined ||
+				v === "" ||
+				v === 0 ||
+				(Array.isArray(v) && !v.length)
+			);
 		});
 	},
 
@@ -80,6 +86,131 @@ const HelpersMixin = {
 			liters: "L",
 		};
 		return MAP[unit.toLowerCase()] || unit;
+	},
+
+	/**
+	 * Match a column header label against this.column_color_rules.
+	 * Each rule: { key, bg_color, text_color, priority }
+	 *   - key       — case-insensitive substring to match against the label
+	 *   - priority  — higher number wins when multiple keys match (default 0)
+	 *
+	 * Returns the winning rule object, or null when no rule matches.
+	 *
+	 * @param {string} label — column header label (doc name or column_label_field value)
+	 * @returns {object|null}
+	 */
+	_matchColorRule(label) {
+		if (!this.column_color_rules || !this.column_color_rules.length) return null;
+		const haystack = String(label || "").toLowerCase();
+		let best = null;
+		for (const rule of this.column_color_rules) {
+			const key = String(rule.key || "").toLowerCase();
+			if (key && haystack.includes(key)) {
+				if (!best) {
+					best = rule;
+				} else {
+					const bp = best.priority ?? 0;
+					const rp = rule.priority ?? 0;
+					const bestKey = String(best.key || "").toLowerCase();
+					// Higher priority wins; on tie prefer longer key (more specific match)
+					if (rp > bp || (rp === bp && key.length > bestKey.length)) {
+						best = rule;
+					}
+				}
+			}
+		}
+		return best;
+	},
+
+	/**
+	 * Match a column header label against this.column_order_rules.
+	 * Each rule: { key, order, priority }
+	 *   - key       — case-insensitive substring to match against the label
+	 *   - order     — numeric sort position (lower = rendered first)
+	 *   - priority  — higher number wins when multiple keys match (default 0)
+	 *
+	 * Returns the winning rule object, or null when no rule matches.
+	 *
+	 * @param {string} label
+	 * @returns {object|null}
+	 */
+	_matchOrderRule(label) {
+		if (!this.column_order_rules || !this.column_order_rules.length) return null;
+		const haystack = String(label || "").toLowerCase();
+		let best = null;
+		for (const rule of this.column_order_rules) {
+			const key = String(rule.key || "").toLowerCase();
+			if (key && haystack.includes(key)) {
+				if (!best) {
+					best = rule;
+				} else {
+					const bp = best.priority ?? 0;
+					const rp = rule.priority ?? 0;
+					const bestKey = String(best.key || "").toLowerCase();
+					// Higher priority wins; on tie prefer longer key (more specific match)
+					if (rp > bp || (rp === bp && key.length > bestKey.length)) {
+						best = rule;
+					}
+				}
+			}
+		}
+		return best;
+	},
+
+	/**
+	 * Sort this.data (and this.column_configs) according to column_order_rules.
+	 * Called once after fetchDocs(), before render().
+	 *
+	 * For object[] input mode: also sorts this._all_inputs so viewport lazy-loaded
+	 * batches maintain the same order.
+	 * For string[]/null modes: only the already-fetched data is sorted (known limitation).
+	 *
+	 * Columns that match no rule are placed at the end (order = Infinity).
+	 */
+	_sortDataByOrderRules() {
+		if (!this.column_order_rules || !this.column_order_rules.length) return;
+		if (!this.data || !this.data.length) return;
+
+		const labelField = this.column_label_field;
+		const configs = this.column_configs || [];
+
+		const getOrder = (doc, i) => {
+			const label = (labelField && doc[labelField]) || configs[i]?.label || doc.name || "";
+			const rule = this._matchOrderRule(label);
+			return rule ? rule.order ?? Infinity : Infinity;
+		};
+
+		// object[] mode — sort full _all_inputs so viewport batches are also ordered
+		if (
+			this._all_inputs !== null &&
+			Array.isArray(this._all_inputs) &&
+			this._all_inputs.length > 0 &&
+			typeof this._all_inputs[0] === "object"
+		) {
+			const entries = this._all_inputs.map((doc, i) => ({
+				doc,
+				conf: configs[i] || {},
+				order: getOrder(doc, i),
+			}));
+			entries.sort((a, b) => a.order - b.order);
+			this._all_inputs = entries.map((e) => e.doc);
+			this.column_configs = entries.map((e) => e.conf);
+			const batchSize = this.data.length;
+			this.data = this._all_inputs.slice(0, batchSize);
+			this.docs = this.data.map((d) => d.name);
+			return;
+		}
+
+		// string[] / null mode — sort only the fetched first batch
+		const entries = this.data.map((doc, i) => ({
+			doc,
+			conf: configs[i] || {},
+			order: getOrder(doc, i),
+		}));
+		entries.sort((a, b) => a.order - b.order);
+		this.data = entries.map((e) => e.doc);
+		this.column_configs = entries.map((e) => e.conf);
+		this.docs = this.data.map((d) => d.name);
 	},
 
 	/**

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
@@ -83,17 +83,43 @@ const HelpersMixin = {
 	},
 
 	/**
-	 * Return the list of field descriptors that should be rendered as data rows,
-	 * respecting fields_to_show / fields_to_hide and skipping layout fields.
-	 * Section Break and Tab Break are NOT filtered here — rendering.js handles those separately.
+	 * Return the list of field descriptors that should be rendered as data rows.
+	 *
+	 * When this.fields_config is set (row settings saved by user or admin), it is
+	 * the authoritative ordered+visible field list and overrides fields_to_show /
+	 * fields_to_hide. When null, the default meta order + fields_to_show/hide
+	 * applies.
+	 *
+	 * Section Break and Tab Break are NOT filtered here — rendering.js handles
+	 * those separately.
 	 * @returns {Array}
 	 */
 	getVisibleFields() {
-		const SKIP_TYPES = new Set(["Column Break", "HTML", "Button", "Fold", "Image", "Signature", "Geolocation", "Barcode"]);
-		return (this.meta.fields || []).filter((df) => {
-			if (SKIP_TYPES.has(df.fieldtype)) return false;
-			if (df.fieldtype === "Tab Break" || df.fieldtype === "Section Break") return false;
-			if (df.hidden) return false;
+		const SKIP_TYPES = new Set([
+			"Column Break",
+			"HTML",
+			"Button",
+			"Fold",
+			"Image",
+			"Signature",
+			"Geolocation",
+			"Barcode",
+			"Tab Break",
+			"Section Break",
+		]);
+
+		const all = (this.meta.fields || []).filter(
+			(df) => !SKIP_TYPES.has(df.fieldtype) && !df.hidden
+		);
+
+		if (this.fields_config && this.fields_config.length > 0) {
+			// fields_config is authoritative: defines both order and visibility
+			const map = new Map(all.map((df) => [df.fieldname, df]));
+			return this.fields_config.map((fn) => map.get(fn)).filter(Boolean);
+		}
+
+		// Default: apply fields_to_show / fields_to_hide in meta order
+		return all.filter((df) => {
 			if (this.fields_to_hide && this.fields_to_hide.includes(df.fieldname)) return false;
 			if (this.fields_to_show && !this.fields_to_show.includes(df.fieldname)) return false;
 			return true;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
@@ -228,7 +228,12 @@ const HelpersMixin = {
 		const entries = this.data.map((doc, i) => {
 			const label = (labelField && doc[labelField]) || configs[i]?.label || doc.name || "";
 			const rule = this._matchOrderRule(label);
-			return { doc, conf: configs[i] || {}, order: rule ? (rule.order ?? Infinity) : Infinity, origIndex: i };
+			return {
+				doc,
+				conf: configs[i] || {},
+				order: rule ? rule.order ?? Infinity : Infinity,
+				origIndex: i,
+			};
 		});
 		entries.sort((a, b) => a.order - b.order || a.origIndex - b.origIndex);
 
@@ -317,8 +322,10 @@ const HelpersMixin = {
 		} else {
 			// Default: apply fields_to_show / fields_to_hide in meta order
 			visible = all.filter((df) => {
-				if (this.fields_to_hide && this.fields_to_hide.includes(df.fieldname)) return false;
-				if (this.fields_to_show && !this.fields_to_show.includes(df.fieldname)) return false;
+				if (this.fields_to_hide && this.fields_to_hide.includes(df.fieldname))
+					return false;
+				if (this.fields_to_show && !this.fields_to_show.includes(df.fieldname))
+					return false;
 				return true;
 			});
 		}

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/helpers.js
@@ -83,6 +83,23 @@ const HelpersMixin = {
 	},
 
 	/**
+	 * Resolve the section_configs entry for a given Section/Tab Break field.
+	 * Looks up by fieldname first, then by label (case-sensitive).
+	 * Returns null when no config exists for this section.
+	 *
+	 * @param {Object} df — Section Break or Tab Break field descriptor
+	 * @returns {Object|null}
+	 */
+	_getSectionConfig(df) {
+		if (!this.section_configs || typeof this.section_configs !== "object") return null;
+		return (
+			this.section_configs[df.fieldname] ||
+			(df.label ? this.section_configs[df.label] : null) ||
+			null
+		);
+	},
+
+	/**
 	 * Return the list of field descriptors that should be rendered as data rows.
 	 *
 	 * When this.fields_config is set (row settings saved by user or admin), it is

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/link_titles.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/link_titles.js
@@ -1,0 +1,145 @@
+/**
+ * LinkTitlesMixin — batch-fetch display titles for Link fields
+ *
+ * After the first render (and after each lazy-loaded viewport batch), this
+ * mixin collects all unique Link field values grouped by linked DocType, then
+ * issues ONE frappe.db.get_list per DocType — never one call per cell.
+ *
+ * Title discovery uses frappe.boot.link_title_doctypes, which Frappe populates
+ * at boot time (e.g. { "Customer": "customer_name", "Item": "item_name" }).
+ * If a DocType is not listed there, the raw "name" is used as display text.
+ *
+ * Results are cached in this._linkTitles so subsequent calls (from viewport
+ * batches) only fetch newly-uncached values.
+ *
+ * Cell update:
+ *   - cell.textContent  → resolved display title
+ *   - cell.title attr   → raw document name (shown as tooltip)
+ *   - cell.dataset.rawValue (set by rendering.js) is the lookup key
+ */
+const LinkTitlesMixin = {
+	/**
+	 * Batch-fetch and apply link titles for all currently loaded docs.
+	 * Safe to call multiple times — subsequent calls only fetch new values.
+	 */
+	async resolveLinkTitles() {
+		if (!this._table || !this.meta) return;
+
+		if (!this._linkTitles) this._linkTitles = {};
+
+		const linkFields = (this.meta.fields || []).filter(
+			(df) => df.fieldtype === "Link" && df.options
+		);
+		if (!linkFields.length) return;
+
+		const linkTitleMap = (frappe.boot && frappe.boot.link_title_doctypes) || {};
+		const toFetch = {}; // { linkedDoctype: Set<rawName> } — only uncached
+
+		linkFields.forEach((df) => {
+			const ldt = df.options;
+			if (!this._linkTitles[ldt]) this._linkTitles[ldt] = {};
+
+			this.data.forEach((doc) => {
+				const val = doc[df.fieldname];
+				if (val && this._linkTitles[ldt][val] === undefined) {
+					if (!toFetch[ldt]) toFetch[ldt] = new Set();
+					toFetch[ldt].add(val);
+				}
+			});
+		});
+
+		if (!Object.keys(toFetch).length) {
+			// Everything already cached — just repaint cells
+			this._applyLinkTitles();
+			return;
+		}
+
+		// One frappe.db.get_list per linked DocType
+		await Promise.all(
+			Object.entries(toFetch).map(async ([ldt, namesSet]) => {
+				// Primary: frappe.boot.link_title_doctypes (set when show_title_field_in_link = 1)
+				// Fallback: frappe.get_meta() in-memory cache (available if meta was loaded this session)
+				let titleField = linkTitleMap[ldt];
+				if (!titleField) {
+					try {
+						const cachedMeta = frappe.get_meta(ldt);
+						if (cachedMeta && cachedMeta.title_field) {
+							titleField = cachedMeta.title_field;
+						}
+					} catch (_) {
+						// meta not cached — no title field known
+					}
+				}
+				const fields = titleField ? ["name", titleField] : ["name"];
+				const names = [...namesSet];
+
+				try {
+					const records = await frappe.db.get_list(ldt, {
+						filters: [["name", "in", names]],
+						fields,
+						limit: names.length + 1,
+					});
+
+					records.forEach((r) => {
+						this._linkTitles[ldt][r.name] =
+							(titleField && r[titleField]) || r.name;
+					});
+
+					// Mark any names the server didn't return (deleted/permissioned out)
+					names.forEach((n) => {
+						if (this._linkTitles[ldt][n] === undefined) {
+							this._linkTitles[ldt][n] = n; // fall back to raw name
+						}
+					});
+				} catch (e) {
+					console.error(
+						"SVAVerticalDocRenderer: link title fetch failed for",
+						ldt,
+						e
+					);
+					// Fall back: use raw names so cells aren't left blank
+					names.forEach((n) => {
+						this._linkTitles[ldt][n] = n;
+					});
+				}
+			})
+		);
+
+		this._applyLinkTitles();
+	},
+
+	/**
+	 * Update every rendered Link-field cell with its resolved display title.
+	 * Reads data-raw-value (stamped by rendering.js _buildValueCell) as the
+	 * cache lookup key. Sets textContent to title and title attribute to raw name.
+	 */
+	_applyLinkTitles() {
+		if (!this._table || !this._linkTitles) return;
+
+		const linkFields = (this.meta.fields || []).filter(
+			(df) => df.fieldtype === "Link" && df.options
+		);
+
+		linkFields.forEach((df) => {
+			const ldt = df.options;
+			const cache = this._linkTitles[ldt];
+			if (!cache) return;
+
+			this._table
+				.querySelectorAll(
+					`td.sva-vdr-value-cell[data-fieldname="${df.fieldname}"]`
+				)
+				.forEach((td) => {
+					const rawName = td.dataset.rawValue;
+					if (!rawName) return;
+					const title = cache[rawName];
+					if (title && title !== rawName) {
+						td.setAttribute("title", rawName); // tooltip shows raw doc name
+						td.textContent = title;
+					}
+				});
+		});
+	},
+};
+
+export default LinkTitlesMixin;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/link_titles.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/link_titles.js
@@ -59,7 +59,8 @@ const LinkTitlesMixin = {
 			Object.entries(toFetch).map(async ([ldt, namesSet]) => {
 				// Primary: frappe.boot.link_title_doctypes (set when show_title_field_in_link = 1)
 				// Fallback: frappe.get_meta() in-memory cache (available if meta was loaded this session)
-				let titleField = linkTitleMap[ldt];
+				let titleField =
+					(this.link_title_fields && this.link_title_fields[ldt]) || linkTitleMap[ldt];
 				if (!titleField) {
 					try {
 						const cachedMeta = frappe.get_meta(ldt);
@@ -81,8 +82,7 @@ const LinkTitlesMixin = {
 					});
 
 					records.forEach((r) => {
-						this._linkTitles[ldt][r.name] =
-							(titleField && r[titleField]) || r.name;
+						this._linkTitles[ldt][r.name] = (titleField && r[titleField]) || r.name;
 					});
 
 					// Mark any names the server didn't return (deleted/permissioned out)
@@ -92,11 +92,7 @@ const LinkTitlesMixin = {
 						}
 					});
 				} catch (e) {
-					console.error(
-						"SVAVerticalDocRenderer: link title fetch failed for",
-						ldt,
-						e
-					);
+					console.error("SVAVerticalDocRenderer: link title fetch failed for", ldt, e);
 					// Fall back: use raw names so cells aren't left blank
 					names.forEach((n) => {
 						this._linkTitles[ldt][n] = n;
@@ -126,9 +122,7 @@ const LinkTitlesMixin = {
 			if (!cache) return;
 
 			this._table
-				.querySelectorAll(
-					`td.sva-vdr-value-cell[data-fieldname="${df.fieldname}"]`
-				)
+				.querySelectorAll(`td.sva-vdr-value-cell[data-fieldname="${df.fieldname}"]`)
 				.forEach((td) => {
 					const rawName = td.dataset.rawValue;
 					if (!rawName) return;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
@@ -39,15 +39,15 @@ const RenderingMixin = {
 	_buildThead() {
 		const thead = document.createElement("thead");
 		const tr = document.createElement("tr");
-		this._theadRow = tr; // stored so viewport mixin can append new columns
+		this._theadRow = tr; // stored so viewport + delete mixins can append columns
 
-		// "Parameters" sticky label column
+		// "Parameters" sticky label column — highest z-index (corner cell)
 		const paramTh = document.createElement("th");
 		paramTh.textContent = __("Parameters");
 		paramTh.className = "sva-vdr-header-cell sva-vdr-sticky-col";
 		this._styleHeaderCell(paramTh);
 		paramTh.style.left = "0";
-		paramTh.style.zIndex = "3";
+		paramTh.style.zIndex = "3"; // corner: above both sticky-top and sticky-left
 		tr.appendChild(paramTh);
 
 		// Optional "Unit" column
@@ -59,13 +59,13 @@ const RenderingMixin = {
 			tr.appendChild(unitTh);
 		}
 
-		// One column per doc — first batch only; viewport mixin appends the rest
+		// One column per doc — first batch; viewport mixin appends the rest
 		this.data.forEach((doc, i) => {
 			const conf = (this.column_configs && this.column_configs[i]) || {};
 			tr.appendChild(this._buildDocHeaderCell(doc, i, conf));
 		});
 
-		// "+" create column — always stays at the far right (viewport mixin inserts before it)
+		// "+" create column — always at the far right (viewport inserts before it)
 		if (this.allow_create) {
 			this._createTh = this._buildCreateHeaderCell();
 			tr.appendChild(this._createTh);
@@ -75,6 +75,13 @@ const RenderingMixin = {
 		return thead;
 	},
 
+	/**
+	 * Shared style for all header <th> cells.
+	 * z-index is intentionally NOT set here — callers set it per their role:
+	 *   paramTh corner  → z-index 3
+	 *   doc headers     → z-index 2  (set in _buildDocHeaderCell)
+	 *   unit header     → inherits from sticky-top, no extra z-index needed
+	 */
 	_styleHeaderCell(th) {
 		th.style.cssText = `
 			background: var(--sva-vdr-header-bg, #1a3a5c);
@@ -93,10 +100,19 @@ const RenderingMixin = {
 
 	_buildTbody() {
 		const tbody = document.createElement("tbody");
+
+		// Delete row — prepended as first row when delete permission is granted
+		if (this._canDelete && this._canDelete()) {
+			tbody.appendChild(this._buildDeleteRow());
+		}
+
 		const fields = this.meta.fields || [];
 		const visibleFieldNames = new Set(this.getVisibleFields().map((df) => df.fieldname));
 
-		const SKIP_TYPES = new Set(["Column Break", "HTML", "Button", "Fold", "Image", "Signature", "Geolocation", "Barcode"]);
+		const SKIP_TYPES = new Set([
+			"Column Break", "HTML", "Button", "Fold", "Image",
+			"Signature", "Geolocation", "Barcode",
+		]);
 
 		fields.forEach((df) => {
 			if (SKIP_TYPES.has(df.fieldtype)) return;
@@ -149,7 +165,6 @@ const RenderingMixin = {
 		// Developer override
 		if (typeof this.events.renderSectionHeader === "function") {
 			const result = this.events.renderSectionHeader(label, colCount, tr);
-			// If override returns true, skip default td
 			if (result === true) return tr;
 		}
 
@@ -170,7 +185,6 @@ const RenderingMixin = {
 			if (result === true) return tr; // fully custom row
 		}
 
-		// Zebra stripes via CSS classes (applied externally); alternating rows
 		tr.style.cssText = "transition: background .1s;";
 		tr.addEventListener("mouseenter", () => {
 			tr.style.background = "var(--sva-vdr-row-hover, #f0f4ff)";
@@ -179,13 +193,13 @@ const RenderingMixin = {
 			tr.style.background = "";
 		});
 
-		// Label (sticky)
+		// Label cell — sticky left, highest z-index among tbody cells
 		const labelTd = document.createElement("td");
 		labelTd.className = "sva-vdr-label-cell sva-vdr-sticky-col";
 		labelTd.style.cssText = `
 			position: sticky;
 			left: 0;
-			z-index: 2;
+			z-index: 1;
 			background: var(--sva-vdr-label-bg, #dce6f1);
 			color: var(--sva-vdr-label-text, #1a3a5c);
 			font-weight: 500;
@@ -221,10 +235,12 @@ const RenderingMixin = {
 		return tr;
 	},
 
-	// ─── Reusable column/cell builders (also called by ViewportMixin) ───────
+	// ─── Reusable column/cell builders (also called by ViewportMixin) ────────
 
 	/**
 	 * Build a single <th> for one document column header.
+	 * Adds hover listeners for the delete icon when delete is permitted.
+	 *
 	 * @param {object} doc      — document data object (must have .name)
 	 * @param {number} colIndex — 0-based absolute column index
 	 * @param {object} conf     — column config {label, bg_color, text_color}
@@ -247,6 +263,9 @@ const RenderingMixin = {
 			white-space: nowrap;
 			border: 1px solid rgba(0,0,0,.08);
 			min-width: 120px;
+			position: sticky;
+			top: 0;
+			z-index: 2;
 		`;
 		th.textContent = label;
 
@@ -254,11 +273,21 @@ const RenderingMixin = {
 			this.events.renderColumnHeader(doc, colIndex, th);
 		}
 
+		// Wire hover listeners for delete icon reveal (keyed by doc.name, not index,
+		// so they remain correct after other columns are deleted)
+		if (this._canDelete && this._canDelete()) {
+			th.addEventListener("mouseenter", () => this._showDeleteIcon(doc.name));
+			th.addEventListener("mouseleave", () => this._hideDeleteIcon(doc.name));
+		}
+
 		return th;
 	},
 
 	/**
 	 * Build a single <td> for one document's value in a field row.
+	 * Applies per-cell validation state (hidden / read-only).
+	 * Stamps data-raw-value for link title resolution.
+	 *
 	 * @param {object} df       — field descriptor from meta
 	 * @param {object} doc      — document data object
 	 * @param {number} colIndex — 0-based absolute column index
@@ -269,6 +298,22 @@ const RenderingMixin = {
 		td.className = "sva-vdr-value-cell";
 		td.dataset.fieldname = df.fieldname;
 		td.dataset.docname = doc.name;
+		// Store raw value as data attribute for link title lookup
+		td.dataset.rawValue = String(doc[df.fieldname] ?? "");
+
+		// Per-cell visibility (depends_on evaluated for this specific doc)
+		if (this.isFieldHidden && this.isFieldHidden(df, doc)) {
+			td.style.cssText = `
+				padding: 4px 10px;
+				border: 1px solid rgba(0,0,0,.06);
+				visibility: hidden;
+			`;
+			return td; // no content, no edit listener
+		}
+
+		// Per-cell read-only state
+		const readOnly = this.isFieldReadOnly && this.isFieldReadOnly(df, doc);
+
 		td.style.cssText = `
 			padding: 4px 10px;
 			border: 1px solid rgba(0,0,0,.06);
@@ -279,12 +324,19 @@ const RenderingMixin = {
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
+			${readOnly
+				? "background: var(--sva-vdr-readonly-bg, #f5f5f5); color: var(--sva-vdr-readonly-text, #999);"
+				: ""
+			}
 		`;
 
 		const formatted = this.formatCellValue(doc[df.fieldname], df, doc, colIndex);
 		td.innerHTML = formatted;
 
-		this.attachEditListener(td, df, doc, colIndex);
+		// Only attach edit listener when the cell is writable
+		if (!readOnly) {
+			this.attachEditListener(td, df, doc, colIndex);
+		}
 
 		return td;
 	},

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
@@ -65,6 +65,12 @@ const RenderingMixin = {
 			tr.appendChild(this._buildDocHeaderCell(doc, i, conf));
 		});
 
+		// "+" create column — always stays at the far right (viewport mixin inserts before it)
+		if (this.allow_create) {
+			this._createTh = this._buildCreateHeaderCell();
+			tr.appendChild(this._createTh);
+		}
+
 		thead.appendChild(tr);
 		return thead;
 	},

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
@@ -1,0 +1,305 @@
+const RenderingMixin = {
+	/**
+	 * Top-level render: build table, optional legend, fire afterRender hook.
+	 */
+	render() {
+		if (!this.meta) return;
+
+		this._buildTable();
+		if (this.show_legend && this.legend_items && this.legend_items.length) {
+			this._buildLegend();
+		}
+
+		if (typeof this.events.afterRender === "function") {
+			this.events.afterRender(this);
+		}
+	},
+
+	// ─── Table ──────────────────────────────────────────────────────────────
+
+	_buildTable() {
+		const table = document.createElement("table");
+		table.className = "sva-vdr-table";
+		table.style.cssText = `
+			border-collapse: collapse;
+			width: 100%;
+			min-width: 300px;
+			table-layout: auto;
+		`;
+		this._table = table;
+
+		table.appendChild(this._buildThead());
+		table.appendChild(this._buildTbody());
+
+		this.scrollBox.appendChild(table);
+	},
+
+	// ─── Header ─────────────────────────────────────────────────────────────
+
+	_buildThead() {
+		const thead = document.createElement("thead");
+		const tr = document.createElement("tr");
+
+		// "Parameters" sticky label column
+		const paramTh = document.createElement("th");
+		paramTh.textContent = __("Parameters");
+		paramTh.className = "sva-vdr-header-cell sva-vdr-sticky-col";
+		this._styleHeaderCell(paramTh);
+		paramTh.style.left = "0";
+		paramTh.style.zIndex = "3";
+		tr.appendChild(paramTh);
+
+		// Optional "Unit" column
+		if (this.show_unit) {
+			const unitTh = document.createElement("th");
+			unitTh.textContent = __("Unit");
+			unitTh.className = "sva-vdr-header-cell";
+			this._styleHeaderCell(unitTh);
+			tr.appendChild(unitTh);
+		}
+
+		// One column per doc
+		this.docs.forEach((docName, i) => {
+			const doc = this.data[i] || { name: docName };
+			const conf = (this.column_configs && this.column_configs[i]) || {};
+			const bgColor = conf.bg_color || "#4472C4";
+			const textColor = conf.text_color || "#fff";
+			const label = conf.label || doc.name;
+
+			const th = document.createElement("th");
+			th.className = "sva-vdr-header-cell sva-vdr-doc-header";
+			th.dataset.docname = doc.name;
+			th.style.cssText = `
+				background: ${bgColor};
+				color: ${textColor};
+				font-weight: 600;
+				padding: 6px 10px;
+				text-align: center;
+				white-space: nowrap;
+				border: 1px solid rgba(0,0,0,.08);
+				min-width: 120px;
+			`;
+			th.textContent = label;
+
+			// Developer override
+			if (typeof this.events.renderColumnHeader === "function") {
+				this.events.renderColumnHeader(doc, i, th);
+			}
+
+			tr.appendChild(th);
+		});
+
+		thead.appendChild(tr);
+		return thead;
+	},
+
+	_styleHeaderCell(th) {
+		th.style.cssText = `
+			background: var(--sva-vdr-header-bg, #1a3a5c);
+			color: var(--sva-vdr-header-text, #fff);
+			font-weight: 600;
+			padding: 6px 10px;
+			text-align: left;
+			white-space: nowrap;
+			border: 1px solid rgba(0,0,0,.08);
+			position: sticky;
+			top: 0;
+		`;
+	},
+
+	// ─── Body ────────────────────────────────────────────────────────────────
+
+	_buildTbody() {
+		const tbody = document.createElement("tbody");
+		const fields = this.meta.fields || [];
+		const visibleFieldNames = new Set(this.getVisibleFields().map((df) => df.fieldname));
+
+		const SKIP_TYPES = new Set(["Column Break", "HTML", "Button", "Fold", "Image", "Signature", "Geolocation", "Barcode"]);
+
+		fields.forEach((df) => {
+			if (SKIP_TYPES.has(df.fieldtype)) return;
+
+			if (df.fieldtype === "Section Break") {
+				if (this.show_section_headers && df.label) {
+					tbody.appendChild(this._buildSectionRow(df.label));
+				}
+				return;
+			}
+
+			if (df.fieldtype === "Tab Break") {
+				if (this.show_section_headers && df.label) {
+					tbody.appendChild(this._buildSectionRow(df.label));
+				}
+				return;
+			}
+
+			// Regular field row — only if it passes visibility filters
+			if (!visibleFieldNames.has(df.fieldname)) return;
+
+			// Skip empty rows when requested
+			if (this.hide_empty_rows && this.isEmptyRow(df)) return;
+
+			tbody.appendChild(this._buildFieldRow(df));
+		});
+
+		return tbody;
+	},
+
+	// ─── Section header row ──────────────────────────────────────────────────
+
+	_buildSectionRow(label) {
+		const tr = document.createElement("tr");
+		tr.className = "sva-vdr-section-row";
+		const colCount = this.getColumnCount();
+
+		const td = document.createElement("td");
+		td.colSpan = colCount;
+		td.style.cssText = `
+			background: var(--sva-vdr-section-bg, #1a3a5c);
+			color: var(--sva-vdr-section-text, #fff);
+			font-weight: 600;
+			padding: 5px 10px;
+			font-size: 13px;
+			letter-spacing: 0.3px;
+		`;
+		td.textContent = label;
+
+		// Developer override
+		if (typeof this.events.renderSectionHeader === "function") {
+			const result = this.events.renderSectionHeader(label, colCount, tr);
+			// If override returns true, skip default td
+			if (result === true) return tr;
+		}
+
+		tr.appendChild(td);
+		return tr;
+	},
+
+	// ─── Field data row ──────────────────────────────────────────────────────
+
+	_buildFieldRow(df) {
+		const tr = document.createElement("tr");
+		tr.className = "sva-vdr-field-row";
+		tr.dataset.fieldname = df.fieldname;
+
+		// Developer override for entire row
+		if (typeof this.events.renderRow === "function") {
+			const result = this.events.renderRow(df, this.data, tr);
+			if (result === true) return tr; // fully custom row
+		}
+
+		// Zebra stripes via CSS classes (applied externally); alternating rows
+		tr.style.cssText = "transition: background .1s;";
+		tr.addEventListener("mouseenter", () => {
+			tr.style.background = "var(--sva-vdr-row-hover, #f0f4ff)";
+		});
+		tr.addEventListener("mouseleave", () => {
+			tr.style.background = "";
+		});
+
+		// Label (sticky)
+		const labelTd = document.createElement("td");
+		labelTd.className = "sva-vdr-label-cell sva-vdr-sticky-col";
+		labelTd.style.cssText = `
+			position: sticky;
+			left: 0;
+			z-index: 2;
+			background: var(--sva-vdr-label-bg, #dce6f1);
+			color: var(--sva-vdr-label-text, #1a3a5c);
+			font-weight: 500;
+			padding: 4px 10px;
+			white-space: nowrap;
+			border: 1px solid rgba(0,0,0,.06);
+			min-width: 140px;
+		`;
+		labelTd.textContent = __(df.label || df.fieldname);
+		tr.appendChild(labelTd);
+
+		// Unit column
+		if (this.show_unit) {
+			const unitTd = document.createElement("td");
+			unitTd.className = "sva-vdr-unit-cell";
+			unitTd.style.cssText = `
+				padding: 4px 8px;
+				text-align: center;
+				color: var(--text-muted, #888);
+				font-size: 11px;
+				border: 1px solid rgba(0,0,0,.06);
+				white-space: nowrap;
+			`;
+			unitTd.textContent = this.getFieldUnit(df);
+			tr.appendChild(unitTd);
+		}
+
+		// One value cell per document
+		this.data.forEach((doc, colIndex) => {
+			const td = document.createElement("td");
+			td.className = "sva-vdr-value-cell";
+			td.dataset.fieldname = df.fieldname;
+			td.dataset.docname = doc.name;
+			td.style.cssText = `
+				padding: 4px 10px;
+				border: 1px solid rgba(0,0,0,.06);
+				text-align: left;
+				vertical-align: middle;
+				min-width: 100px;
+				max-width: 280px;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			`;
+
+			const formatted = this.formatCellValue(doc[df.fieldname], df, doc, colIndex);
+			td.innerHTML = formatted;
+
+			// Wire up editing
+			this.attachEditListener(td, df, doc, colIndex);
+
+			tr.appendChild(td);
+		});
+
+		return tr;
+	},
+
+	// ─── Legend ─────────────────────────────────────────────────────────────
+
+	_buildLegend() {
+		const legend = document.createElement("div");
+		legend.className = "sva-vdr-legend";
+		legend.style.cssText = `
+			margin-top: 8px;
+			font-size: 11px;
+			color: var(--text-muted, #666);
+			display: flex;
+			flex-wrap: wrap;
+			gap: 4px 12px;
+		`;
+
+		this.legend_items.forEach((item) => {
+			const span = document.createElement("span");
+			span.style.cssText = `display:inline-flex;align-items:center;gap:4px;`;
+
+			const dot = document.createElement("span");
+			dot.style.cssText = `
+				display: inline-block;
+				width: 10px;
+				height: 10px;
+				border-radius: 2px;
+				background: ${item.bg_color || "#4472C4"};
+				flex-shrink: 0;
+			`;
+
+			const text = document.createElement("span");
+			text.style.color = item.text_color || "inherit";
+			text.textContent = `${item.label}: ${item.description || ""}`;
+
+			span.appendChild(dot);
+			span.appendChild(text);
+			legend.appendChild(span);
+		});
+
+		this.container.appendChild(legend);
+	},
+};
+
+export default RenderingMixin;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
@@ -39,6 +39,7 @@ const RenderingMixin = {
 	_buildThead() {
 		const thead = document.createElement("thead");
 		const tr = document.createElement("tr");
+		this._theadRow = tr; // stored so viewport mixin can append new columns
 
 		// "Parameters" sticky label column
 		const paramTh = document.createElement("th");
@@ -58,35 +59,10 @@ const RenderingMixin = {
 			tr.appendChild(unitTh);
 		}
 
-		// One column per doc
-		this.docs.forEach((docName, i) => {
-			const doc = this.data[i] || { name: docName };
+		// One column per doc — first batch only; viewport mixin appends the rest
+		this.data.forEach((doc, i) => {
 			const conf = (this.column_configs && this.column_configs[i]) || {};
-			const bgColor = conf.bg_color || "#4472C4";
-			const textColor = conf.text_color || "#fff";
-			const label = conf.label || doc.name;
-
-			const th = document.createElement("th");
-			th.className = "sva-vdr-header-cell sva-vdr-doc-header";
-			th.dataset.docname = doc.name;
-			th.style.cssText = `
-				background: ${bgColor};
-				color: ${textColor};
-				font-weight: 600;
-				padding: 6px 10px;
-				text-align: center;
-				white-space: nowrap;
-				border: 1px solid rgba(0,0,0,.08);
-				min-width: 120px;
-			`;
-			th.textContent = label;
-
-			// Developer override
-			if (typeof this.events.renderColumnHeader === "function") {
-				this.events.renderColumnHeader(doc, i, th);
-			}
-
-			tr.appendChild(th);
+			tr.appendChild(this._buildDocHeaderCell(doc, i, conf));
 		});
 
 		thead.appendChild(tr);
@@ -231,34 +207,80 @@ const RenderingMixin = {
 			tr.appendChild(unitTd);
 		}
 
-		// One value cell per document
+		// One value cell per document — first batch only; viewport mixin appends the rest
 		this.data.forEach((doc, colIndex) => {
-			const td = document.createElement("td");
-			td.className = "sva-vdr-value-cell";
-			td.dataset.fieldname = df.fieldname;
-			td.dataset.docname = doc.name;
-			td.style.cssText = `
-				padding: 4px 10px;
-				border: 1px solid rgba(0,0,0,.06);
-				text-align: left;
-				vertical-align: middle;
-				min-width: 100px;
-				max-width: 280px;
-				overflow: hidden;
-				text-overflow: ellipsis;
-				white-space: nowrap;
-			`;
-
-			const formatted = this.formatCellValue(doc[df.fieldname], df, doc, colIndex);
-			td.innerHTML = formatted;
-
-			// Wire up editing
-			this.attachEditListener(td, df, doc, colIndex);
-
-			tr.appendChild(td);
+			tr.appendChild(this._buildValueCell(df, doc, colIndex));
 		});
 
 		return tr;
+	},
+
+	// ─── Reusable column/cell builders (also called by ViewportMixin) ───────
+
+	/**
+	 * Build a single <th> for one document column header.
+	 * @param {object} doc      — document data object (must have .name)
+	 * @param {number} colIndex — 0-based absolute column index
+	 * @param {object} conf     — column config {label, bg_color, text_color}
+	 * @returns {HTMLElement}
+	 */
+	_buildDocHeaderCell(doc, colIndex, conf) {
+		const bgColor = conf.bg_color || "#4472C4";
+		const textColor = conf.text_color || "#fff";
+		const label = conf.label || doc.name;
+
+		const th = document.createElement("th");
+		th.className = "sva-vdr-header-cell sva-vdr-doc-header";
+		th.dataset.docname = doc.name;
+		th.style.cssText = `
+			background: ${bgColor};
+			color: ${textColor};
+			font-weight: 600;
+			padding: 6px 10px;
+			text-align: center;
+			white-space: nowrap;
+			border: 1px solid rgba(0,0,0,.08);
+			min-width: 120px;
+		`;
+		th.textContent = label;
+
+		if (typeof this.events.renderColumnHeader === "function") {
+			this.events.renderColumnHeader(doc, colIndex, th);
+		}
+
+		return th;
+	},
+
+	/**
+	 * Build a single <td> for one document's value in a field row.
+	 * @param {object} df       — field descriptor from meta
+	 * @param {object} doc      — document data object
+	 * @param {number} colIndex — 0-based absolute column index
+	 * @returns {HTMLElement}
+	 */
+	_buildValueCell(df, doc, colIndex) {
+		const td = document.createElement("td");
+		td.className = "sva-vdr-value-cell";
+		td.dataset.fieldname = df.fieldname;
+		td.dataset.docname = doc.name;
+		td.style.cssText = `
+			padding: 4px 10px;
+			border: 1px solid rgba(0,0,0,.06);
+			text-align: left;
+			vertical-align: middle;
+			min-width: 100px;
+			max-width: 280px;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		`;
+
+		const formatted = this.formatCellValue(doc[df.fieldname], df, doc, colIndex);
+		td.innerHTML = formatted;
+
+		this.attachEditListener(td, df, doc, colIndex);
+
+		return td;
 	},
 
 	// ─── Legend ─────────────────────────────────────────────────────────────

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
@@ -24,7 +24,7 @@ const RenderingMixin = {
 			border-collapse: collapse;
 			width: 100%;
 			min-width: 100%;
-			table-layout: auto;
+			table-layout: fixed;
 		`;
 		this._table = table;
 
@@ -321,10 +321,13 @@ const RenderingMixin = {
 			color: var(--sva-vdr-label-text, #1a3a5c);
 			font-weight: 500;
 			padding: 4px 10px;
-			white-space: nowrap;
+			white-space: normal;
+			word-break: break-word;
+			overflow-wrap: break-word;
 			border: 1px solid rgba(0,0,0,.06);
 			min-width: ${this.label_width || 160}px;
-		width: ${this.label_width || 160}px;
+			width: ${this.label_width || 160}px;
+			max-width: ${this.label_width || 160}px;
 		`;
 		labelTd.textContent = __(df.label || df.fieldname);
 		tr.appendChild(labelTd);
@@ -365,15 +368,19 @@ const RenderingMixin = {
 	 * @returns {HTMLElement}
 	 */
 	_buildDocHeaderCell(doc, colIndex, conf) {
-		const bgColor = conf.bg_color || this.column_default_bg || "#4472C4";
-		const textColor = conf.text_color || this.column_default_text || "#fff";
 		const label =
 			(this.column_label_field && doc[this.column_label_field]) || conf.label || doc.name;
+
+		// Priority: explicit column_configs[i] > color_rules match > column_default > fallback
+		const rule = !conf.bg_color && this._matchColorRule ? this._matchColorRule(label) : null;
+		const bgColor =
+			conf.bg_color || (rule && rule.bg_color) || this.column_default_bg || "#4472C4";
+		const textColor =
+			conf.text_color || (rule && rule.text_color) || this.column_default_text || "#fff";
 
 		const th = document.createElement("th");
 		th.className = "sva-vdr-header-cell sva-vdr-doc-header";
 		th.dataset.docname = doc.name;
-		const colW = this.column_width || 150;
 		th.style.cssText = `
 			background: ${bgColor};
 			color: ${textColor};
@@ -382,8 +389,6 @@ const RenderingMixin = {
 			text-align: center;
 			white-space: nowrap;
 			border: 1px solid rgba(0,0,0,.08);
-			min-width: ${colW}px;
-			width: ${colW}px;
 			position: sticky;
 			top: 0;
 			z-index: 2;
@@ -435,15 +440,11 @@ const RenderingMixin = {
 		// Per-cell read-only state
 		const readOnly = this.isFieldReadOnly && this.isFieldReadOnly(df, doc);
 
-		const _colW = this.column_width || 150;
 		td.style.cssText = `
 			padding: 4px 10px;
 			border: 1px solid rgba(0,0,0,.06);
 			text-align: left;
 			vertical-align: middle;
-			min-width: ${_colW}px;
-			max-width: ${_colW}px;
-			width: ${_colW}px;
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
@@ -1,5 +1,18 @@
 const RenderingMixin = {
 	/**
+	 * Return label column width capped for narrow viewports so the params column
+	 * never pushes all data columns off-screen on mobile.
+	 * On screens wider than 768 px the configured value is returned unchanged.
+	 */
+	_responsiveLabelWidth() {
+		const raw = this.label_width || 160;
+		const vw = window.innerWidth || 375;
+		if (vw >= 768) return raw;
+		// Cap at 42 % of viewport, min 100 px, so at least one data column peeks in.
+		return Math.min(raw, Math.max(100, Math.floor(vw * 0.42)));
+	},
+
+	/**
 	 * Top-level render: build table, optional legend, fire afterRender hook.
 	 */
 	render() {
@@ -49,7 +62,7 @@ const RenderingMixin = {
 		this._theadRow = tr; // stored so viewport + delete mixins can append columns
 
 		// "Parameters" sticky label column — highest z-index (corner cell)
-		const labelW = this.label_width || 160;
+		const labelW = this._responsiveLabelWidth();
 		const paramTh = document.createElement("th");
 		paramTh.textContent = __("Parameters");
 		paramTh.className = "sva-vdr-header-cell sva-vdr-sticky-col";
@@ -332,9 +345,9 @@ const RenderingMixin = {
 			word-break: break-word;
 			overflow-wrap: break-word;
 			border: 1px solid rgba(0,0,0,.06);
-			min-width: ${this.label_width || 160}px;
-			width: ${this.label_width || 160}px;
-			max-width: ${this.label_width || 160}px;
+			min-width: ${this._responsiveLabelWidth()}px;
+			width: ${this._responsiveLabelWidth()}px;
+			max-width: ${this._responsiveLabelWidth()}px;
 		`;
 		labelTd.textContent = __(df.label || df.fieldname);
 		tr.appendChild(labelTd);
@@ -484,7 +497,7 @@ const RenderingMixin = {
 	 * @returns {number}
 	 */
 	_calcTableMinWidth(colCount) {
-		const labelW = this.label_width || 160;
+		const labelW = this._responsiveLabelWidth();
 		const colW = this.column_width || 150;
 		const unitW = this.show_unit ? 60 : 0;
 		return labelW + unitW + colCount * colW;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
@@ -98,13 +98,13 @@ const RenderingMixin = {
 	_buildTbody() {
 		const tbody = document.createElement("tbody");
 
-		// Delete row — prepended as first row when delete permission is granted
 		if (this._canDelete && this._canDelete()) {
 			tbody.appendChild(this._buildDeleteRow());
 		}
 
-		const fields = this.meta.fields || [];
-		const visibleFieldNames = new Set(this.getVisibleFields().map((df) => df.fieldname));
+		const allMetaFields = this.meta.fields || [];
+		const visibleFields = this.getVisibleFields();
+		const visibleFieldNames = new Set(visibleFields.map((df) => df.fieldname));
 
 		const SKIP_TYPES = new Set([
 			"Column Break",
@@ -117,41 +117,77 @@ const RenderingMixin = {
 			"Barcode",
 		]);
 
-		// Section-level config state — reset at each Section/Tab Break
+		if (this.fields_config && this.fields_config.length > 0) {
+			// fields_config is active — render in user-defined order.
+			// Build a map of fieldname → owning section break from meta so we can
+			// still emit section headers in the right place.
+			const fieldToSection = new Map();
+			let curSection = null;
+			allMetaFields.forEach((df) => {
+				if (df.fieldtype === "Section Break" || df.fieldtype === "Tab Break") {
+					curSection = df;
+				} else if (!SKIP_TYPES.has(df.fieldtype)) {
+					fieldToSection.set(df.fieldname, curSection);
+				}
+			});
+
+			let lastSectionDf = undefined; // undefined = "not yet seen any section"
+			visibleFields.forEach((df) => {
+				if (this.hide_empty_rows && this.isEmptyRow(df)) return;
+
+				const sectionDf = fieldToSection.get(df.fieldname) || null;
+
+				// Emit a section header when we cross into a new section
+				if (sectionDf !== lastSectionDf) {
+					lastSectionDf = sectionDf;
+					if (sectionDf) {
+						const sconf = this._getSectionConfig(sectionDf);
+						if (
+							!(sconf && sconf.hidden) &&
+							this.show_section_headers &&
+							sectionDf.label
+						) {
+							tbody.appendChild(this._buildSectionRow(sectionDf.label, sconf));
+						}
+					}
+				}
+
+				const sectionConf = sectionDf ? this._getSectionConfig(sectionDf) : null;
+				if (sectionConf && sectionConf.hidden) return;
+
+				const fieldRow = this._buildFieldRow(df);
+				if (sectionConf && sectionConf.collapsed) fieldRow.style.display = "none";
+				tbody.appendChild(fieldRow);
+			});
+
+			return tbody;
+		}
+
+		// Default path: meta order with section tracking
 		let sectionHidden = false;
 		let currentSectionConfig = null;
 
-		fields.forEach((df) => {
+		allMetaFields.forEach((df) => {
 			if (SKIP_TYPES.has(df.fieldtype)) return;
 
 			if (df.fieldtype === "Section Break" || df.fieldtype === "Tab Break") {
-				// Resolve config for this section (by fieldname, then by label)
 				currentSectionConfig = this._getSectionConfig(df);
 				sectionHidden = !!(currentSectionConfig && currentSectionConfig.hidden);
 
-				// Render section header only when not hidden
 				if (this.show_section_headers && df.label && !sectionHidden) {
 					tbody.appendChild(this._buildSectionRow(df.label, currentSectionConfig));
 				}
 				return;
 			}
 
-			// Skip fields that belong to a hidden section
 			if (sectionHidden) return;
-
-			// Regular field row — only if it passes visibility filters
 			if (!visibleFieldNames.has(df.fieldname)) return;
-
-			// Skip empty rows when requested
 			if (this.hide_empty_rows && this.isEmptyRow(df)) return;
 
 			const fieldRow = this._buildFieldRow(df);
-
-			// Start collapsed when the current section has collapsed: true
 			if (currentSectionConfig && currentSectionConfig.collapsed) {
 				fieldRow.style.display = "none";
 			}
-
 			tbody.appendChild(fieldRow);
 		});
 
@@ -326,9 +362,10 @@ const RenderingMixin = {
 	 * @returns {HTMLElement}
 	 */
 	_buildDocHeaderCell(doc, colIndex, conf) {
-		const bgColor = conf.bg_color || "#4472C4";
-		const textColor = conf.text_color || "#fff";
-		const label = conf.label || doc.name;
+		const bgColor = conf.bg_color || this.column_default_bg || "#4472C4";
+		const textColor = conf.text_color || this.column_default_text || "#fff";
+		const label =
+			(this.column_label_field && doc[this.column_label_field]) || conf.label || doc.name;
 
 		const th = document.createElement("th");
 		th.className = "sva-vdr-header-cell sva-vdr-doc-header";

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
@@ -42,12 +42,15 @@ const RenderingMixin = {
 		this._theadRow = tr; // stored so viewport + delete mixins can append columns
 
 		// "Parameters" sticky label column — highest z-index (corner cell)
+		const labelW = this.label_width || 160;
 		const paramTh = document.createElement("th");
 		paramTh.textContent = __("Parameters");
 		paramTh.className = "sva-vdr-header-cell sva-vdr-sticky-col";
 		this._styleHeaderCell(paramTh);
 		paramTh.style.left = "0";
 		paramTh.style.zIndex = "3"; // corner: above both sticky-top and sticky-left
+		paramTh.style.minWidth = `${labelW}px`;
+		paramTh.style.width = `${labelW}px`;
 		tr.appendChild(paramTh);
 
 		// Optional "Unit" column
@@ -113,7 +116,6 @@ const RenderingMixin = {
 			"Fold",
 			"Image",
 			"Signature",
-			"Geolocation",
 			"Barcode",
 		]);
 
@@ -321,7 +323,8 @@ const RenderingMixin = {
 			padding: 4px 10px;
 			white-space: nowrap;
 			border: 1px solid rgba(0,0,0,.06);
-			min-width: 140px;
+			min-width: ${this.label_width || 160}px;
+		width: ${this.label_width || 160}px;
 		`;
 		labelTd.textContent = __(df.label || df.fieldname);
 		tr.appendChild(labelTd);
@@ -370,6 +373,7 @@ const RenderingMixin = {
 		const th = document.createElement("th");
 		th.className = "sva-vdr-header-cell sva-vdr-doc-header";
 		th.dataset.docname = doc.name;
+		const colW = this.column_width || 150;
 		th.style.cssText = `
 			background: ${bgColor};
 			color: ${textColor};
@@ -378,7 +382,8 @@ const RenderingMixin = {
 			text-align: center;
 			white-space: nowrap;
 			border: 1px solid rgba(0,0,0,.08);
-			min-width: 120px;
+			min-width: ${colW}px;
+			width: ${colW}px;
 			position: sticky;
 			top: 0;
 			z-index: 2;
@@ -430,13 +435,15 @@ const RenderingMixin = {
 		// Per-cell read-only state
 		const readOnly = this.isFieldReadOnly && this.isFieldReadOnly(df, doc);
 
+		const _colW = this.column_width || 150;
 		td.style.cssText = `
 			padding: 4px 10px;
 			border: 1px solid rgba(0,0,0,.06);
 			text-align: left;
 			vertical-align: middle;
-			min-width: 100px;
-			max-width: 280px;
+			min-width: ${_colW}px;
+			max-width: ${_colW}px;
+			width: ${_colW}px;
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
@@ -478,6 +478,19 @@ const RenderingMixin = {
 		const formatted = this.formatCellValue(doc[df.fieldname], df, doc, colIndex);
 		td.innerHTML = formatted;
 
+		// Empty Link cell + write permission → show a subtle dropdown hint
+		if (
+			!formatted &&
+			!readOnly &&
+			df.fieldtype === "Link" &&
+			this.crud_permissions &&
+			this.crud_permissions.includes("write")
+		) {
+			td.innerHTML = `<span style="color:#bbb;font-size:12px;user-select:none;" title="${__(
+				"Click to select"
+			)}">▾</span>`;
+		}
+
 		// Only attach edit listener when the cell is writable
 		if (!readOnly) {
 			this.attachEditListener(td, df, doc, colIndex);

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
@@ -18,6 +18,14 @@ const RenderingMixin = {
 	render() {
 		if (!this.meta) return;
 
+		if (!this.data || this.data.length === 0) {
+			this._buildEmptyState();
+			if (typeof this.events.afterRender === "function") {
+				this.events.afterRender(this);
+			}
+			return;
+		}
+
 		this._buildTable();
 		if (this.show_legend && this.legend_items && this.legend_items.length) {
 			this._buildLegend();
@@ -26,6 +34,47 @@ const RenderingMixin = {
 		if (typeof this.events.afterRender === "function") {
 			this.events.afterRender(this);
 		}
+	},
+
+	/**
+	 * Render a clean "No records found" empty state into the scrollBox.
+	 */
+	_buildEmptyState() {
+		const wrapper = document.createElement("div");
+		wrapper.className = "sva-vdr-empty-state";
+		wrapper.style.cssText = `
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			justify-content: center;
+			padding: 48px 24px;
+			border: 1px solid rgba(0,0,0,.08);
+			border-radius: 6px;
+			background: var(--card-bg, #fff);
+			color: var(--text-muted, #8d99a6);
+			text-align: center;
+		`;
+
+		const icon = document.createElement("div");
+		icon.style.cssText = `
+			font-size: 40px;
+			margin-bottom: 12px;
+			opacity: 0.45;
+			line-height: 1;
+		`;
+		icon.textContent = "🗂";
+
+		const msg = document.createElement("div");
+		msg.style.cssText = `
+			font-size: 14px;
+			font-weight: 500;
+			color: var(--text-muted, #8d99a6);
+		`;
+		msg.textContent = __("No records found");
+
+		wrapper.appendChild(icon);
+		wrapper.appendChild(msg);
+		this.scrollBox.appendChild(wrapper);
 	},
 
 	// ─── Table ──────────────────────────────────────────────────────────────

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
@@ -117,22 +117,27 @@ const RenderingMixin = {
 			"Barcode",
 		]);
 
+		// Section-level config state — reset at each Section/Tab Break
+		let sectionHidden = false;
+		let currentSectionConfig = null;
+
 		fields.forEach((df) => {
 			if (SKIP_TYPES.has(df.fieldtype)) return;
 
-			if (df.fieldtype === "Section Break") {
-				if (this.show_section_headers && df.label) {
-					tbody.appendChild(this._buildSectionRow(df.label));
+			if (df.fieldtype === "Section Break" || df.fieldtype === "Tab Break") {
+				// Resolve config for this section (by fieldname, then by label)
+				currentSectionConfig = this._getSectionConfig(df);
+				sectionHidden = !!(currentSectionConfig && currentSectionConfig.hidden);
+
+				// Render section header only when not hidden
+				if (this.show_section_headers && df.label && !sectionHidden) {
+					tbody.appendChild(this._buildSectionRow(df.label, currentSectionConfig));
 				}
 				return;
 			}
 
-			if (df.fieldtype === "Tab Break") {
-				if (this.show_section_headers && df.label) {
-					tbody.appendChild(this._buildSectionRow(df.label));
-				}
-				return;
-			}
+			// Skip fields that belong to a hidden section
+			if (sectionHidden) return;
 
 			// Regular field row — only if it passes visibility filters
 			if (!visibleFieldNames.has(df.fieldname)) return;
@@ -140,7 +145,14 @@ const RenderingMixin = {
 			// Skip empty rows when requested
 			if (this.hide_empty_rows && this.isEmptyRow(df)) return;
 
-			tbody.appendChild(this._buildFieldRow(df));
+			const fieldRow = this._buildFieldRow(df);
+
+			// Start collapsed when the current section has collapsed: true
+			if (currentSectionConfig && currentSectionConfig.collapsed) {
+				fieldRow.style.display = "none";
+			}
+
+			tbody.appendChild(fieldRow);
 		});
 
 		return tbody;
@@ -148,31 +160,95 @@ const RenderingMixin = {
 
 	// ─── Section header row ──────────────────────────────────────────────────
 
-	_buildSectionRow(label) {
+	/**
+	 * Build a section header <tr>.
+	 *
+	 * @param {string} label        — field label from meta
+	 * @param {object|null} conf    — section_configs entry (may contain label, bg_color,
+	 *                                text_color, collapsed, hidden)
+	 */
+	_buildSectionRow(label, conf = null) {
 		const tr = document.createElement("tr");
 		tr.className = "sva-vdr-section-row";
 		const colCount = this.getColumnCount();
 
+		const isCollapsible = conf !== null && conf.collapsed !== undefined;
+		const initiallyCollapsed = !!(conf && conf.collapsed);
+
+		// Track collapsed state on the element for _toggleSection
+		tr.dataset.collapsed = initiallyCollapsed ? "true" : "false";
+
+		// Developer override — fires first so the hook can replace the entire row.
+		// Collapse toggling is still wired below even when the hook takes over.
+		if (typeof this.events.renderSectionHeader === "function") {
+			const result = this.events.renderSectionHeader(label, colCount, tr);
+			if (result === true) {
+				if (isCollapsible) {
+					tr.style.cursor = "pointer";
+					tr.addEventListener("click", () => this._toggleSection(tr));
+				}
+				return tr;
+			}
+		}
+
+		// Default rendering
+		const displayLabel = (conf && conf.label) || label;
+		const bgColor = conf && conf.bg_color;
+		const textColor = conf && conf.text_color;
+
 		const td = document.createElement("td");
 		td.colSpan = colCount;
 		td.style.cssText = `
-			background: var(--sva-vdr-section-bg, #1a3a5c);
-			color: var(--sva-vdr-section-text, #fff);
+			background: ${bgColor || "var(--sva-vdr-section-bg, #1a3a5c)"};
+			color: ${textColor || "var(--sva-vdr-section-text, #fff)"};
 			font-weight: 600;
 			padding: 5px 10px;
 			font-size: 13px;
 			letter-spacing: 0.3px;
+			${isCollapsible ? "cursor: pointer; user-select: none;" : ""}
 		`;
-		td.textContent = label;
 
-		// Developer override
-		if (typeof this.events.renderSectionHeader === "function") {
-			const result = this.events.renderSectionHeader(label, colCount, tr);
-			if (result === true) return tr;
+		if (isCollapsible) {
+			// Toggle arrow prefix
+			const arrow = document.createElement("span");
+			arrow.className = "sva-vdr-section-arrow";
+			arrow.style.cssText =
+				"display:inline-block;margin-right:6px;font-size:10px;vertical-align:middle;";
+			arrow.textContent = initiallyCollapsed ? "▶" : "▼";
+			td.appendChild(arrow);
+			td.appendChild(document.createTextNode(displayLabel));
+			tr.addEventListener("click", () => this._toggleSection(tr));
+		} else {
+			td.textContent = displayLabel;
 		}
 
 		tr.appendChild(td);
 		return tr;
+	},
+
+	/**
+	 * Toggle the collapsed state of a section header row.
+	 * Shows/hides all sibling field rows until the next section row.
+	 *
+	 * @param {HTMLElement} sectionTr — the section header <tr>
+	 */
+	_toggleSection(sectionTr) {
+		const nowCollapsed = sectionTr.dataset.collapsed === "true";
+		const willCollapse = !nowCollapsed;
+		sectionTr.dataset.collapsed = willCollapse ? "true" : "false";
+
+		// Update the arrow indicator (if present)
+		const arrow = sectionTr.querySelector(".sva-vdr-section-arrow");
+		if (arrow) arrow.textContent = willCollapse ? "▶" : "▼";
+
+		// Walk subsequent siblings — toggle field rows; stop at next section row
+		let next = sectionTr.nextElementSibling;
+		while (next && !next.classList.contains("sva-vdr-section-row")) {
+			if (next.classList.contains("sva-vdr-field-row")) {
+				next.style.display = willCollapse ? "none" : "";
+			}
+			next = next.nextElementSibling;
+		}
 	},
 
 	// ─── Field data row ──────────────────────────────────────────────────────

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
@@ -23,7 +23,7 @@ const RenderingMixin = {
 		table.style.cssText = `
 			border-collapse: collapse;
 			width: 100%;
-			min-width: 300px;
+			min-width: 100%;
 			table-layout: auto;
 		`;
 		this._table = table;
@@ -65,11 +65,8 @@ const RenderingMixin = {
 			tr.appendChild(this._buildDocHeaderCell(doc, i, conf));
 		});
 
-		// "+" create column — always at the far right (viewport inserts before it)
-		if (this.allow_create) {
-			this._createTh = this._buildCreateHeaderCell();
-			tr.appendChild(this._createTh);
-		}
+		// "+" is rendered as a floating button outside the table (see ui_setup._buildToolbar)
+		this._createTh = null;
 
 		thead.appendChild(tr);
 		return thead;
@@ -110,8 +107,14 @@ const RenderingMixin = {
 		const visibleFieldNames = new Set(this.getVisibleFields().map((df) => df.fieldname));
 
 		const SKIP_TYPES = new Set([
-			"Column Break", "HTML", "Button", "Fold", "Image",
-			"Signature", "Geolocation", "Barcode",
+			"Column Break",
+			"HTML",
+			"Button",
+			"Fold",
+			"Image",
+			"Signature",
+			"Geolocation",
+			"Barcode",
 		]);
 
 		fields.forEach((df) => {
@@ -324,9 +327,10 @@ const RenderingMixin = {
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
-			${readOnly
-				? "background: var(--sva-vdr-readonly-bg, #f5f5f5); color: var(--sva-vdr-readonly-text, #999);"
-				: ""
+			${
+				readOnly
+					? "background: var(--sva-vdr-readonly-bg, #f5f5f5); color: var(--sva-vdr-readonly-text, #999);"
+					: ""
 			}
 		`;
 

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/rendering.js
@@ -20,10 +20,17 @@ const RenderingMixin = {
 	_buildTable() {
 		const table = document.createElement("table");
 		table.className = "sva-vdr-table";
+
+		// Calculate minimum pixel width so the table overflows the scroll container
+		// on narrow screens instead of squishing columns. CSS min-width overrides
+		// width:100% when the calculated minimum is larger (e.g. on mobile).
+		// Updated incrementally in _appendDocColumn() as viewport loads more batches.
+		const minTableW = this._calcTableMinWidth(this.data.length || 0);
+
 		table.style.cssText = `
 			border-collapse: collapse;
 			width: 100%;
-			min-width: 100%;
+			min-width: ${minTableW}px;
 			table-layout: fixed;
 		`;
 		this._table = table;
@@ -464,6 +471,23 @@ const RenderingMixin = {
 		}
 
 		return td;
+	},
+
+	// ─── Helpers ────────────────────────────────────────────────────────────
+
+	/**
+	 * Minimum table width in pixels for a given column count.
+	 * Used to set/update table min-width so the table scrolls horizontally on
+	 * narrow viewports instead of squishing columns.
+	 *
+	 * @param {number} colCount — number of document columns currently rendered
+	 * @returns {number}
+	 */
+	_calcTableMinWidth(colCount) {
+		const labelW = this.label_width || 160;
+		const colW = this.column_width || 150;
+		const unitW = this.show_unit ? 60 : 0;
+		return labelW + unitW + colCount * colW;
 	},
 
 	// ─── Legend ─────────────────────────────────────────────────────────────

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/row_settings.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/row_settings.js
@@ -1,0 +1,325 @@
+/**
+ * RowSettingsMixin — gear button + dialog to configure which field rows are
+ * visible and in what order (listview-settings equivalent for VDR rows).
+ *
+ * Activated when `vdr_field_name` is passed to the constructor (i.e. the VDR
+ * was configured via the no-code Custom Property Setter dialog). Without it,
+ * the toolbar button is not rendered and settings are session-only.
+ *
+ * Persistence:
+ *   Administrator  → frappe_theme.dt_api.update_sva_ft_property
+ *                    (updates "vdr_fields_config" key inside the sva_ft JSON)
+ *   Other users    → frappe_theme.dt_api.setup_user_list_settings
+ *                    (stored in SVADT User Listview Settings)
+ *
+ * this.fields_config — string[] of fieldnames in display order, or null
+ *   null  → use default meta order + fields_to_show/hide
+ *   set   → authoritative ordered+visible field list (replaces fields_to_show/hide)
+ */
+const RowSettingsMixin = {
+	/**
+	 * Build and return the gear settings button for the toolbar.
+	 * @returns {HTMLElement}
+	 */
+	_buildSettingsButton() {
+		const btn = document.createElement("button");
+		btn.className = "btn btn-secondary btn-xs sva-vdr-settings-btn";
+		btn.title = __("Configure row settings");
+		btn.style.cssText = `
+			display: inline-flex;
+			align-items: center;
+			gap: 4px;
+			padding: 2px 8px;
+			font-size: 12px;
+			${this._has_user_settings ? "color: var(--primary, #4285f4);" : ""}
+		`;
+		btn.innerHTML = `
+			<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 16 16" fill="currentColor">
+				<path d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492zM5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0z"/>
+				<path d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 0 1-1.255.52l-.292-.16c-1.64-.892-3.433.902-2.54 2.541l.159.292a.873.873 0 0 1-.52 1.255l-.319.094c-1.79.527-1.79 3.065 0 3.592l.319.094a.873.873 0 0 1 .52 1.255l-.16.292c-.892 1.64.901 3.434 2.541 2.54l.292-.159a.873.873 0 0 1 1.255.52l.094.319c.527 1.79 3.065 1.79 3.592 0l.094-.319a.873.873 0 0 1 1.255-.52l.292.16c1.64.892 3.433-.902 2.54-2.541l-.159-.292a.873.873 0 0 1 .52-1.255l.319-.094c1.79-.527 1.79-3.065 0-3.592l-.319-.094a.873.873 0 0 1-.52-1.255l.16-.292c.892-1.64-.901-3.433-2.541-2.54l-.292.159a.873.873 0 0 1-1.255-.52l-.094-.319zm-2.633.283c.246-.835 1.428-.835 1.674 0l.094.319a1.873 1.873 0 0 0 2.693 1.115l.291-.16c.764-.415 1.6.42 1.184 1.185l-.159.292a1.873 1.873 0 0 0 1.116 2.692l.318.094c.835.246.835 1.428 0 1.674l-.319.094a1.873 1.873 0 0 0-1.115 2.693l.16.291c.415.764-.42 1.6-1.185 1.184l-.291-.159a1.873 1.873 0 0 0-2.693 1.116l-.094.318c-.246.835-1.428.835-1.674 0l-.094-.319a1.873 1.873 0 0 0-2.692-1.115l-.292.16c-.764.415-1.6-.42-1.184-1.185l.159-.291A1.873 1.873 0 0 0 1.945 8.93l-.319-.094c-.835-.246-.835-1.428 0-1.674l.319-.094A1.873 1.873 0 0 0 3.06 4.474l-.16-.292c-.415-.764.42-1.6 1.185-1.184l.292.159a1.873 1.873 0 0 0 2.692-1.115l.094-.319z"/>
+			</svg>
+			${__("Settings")}
+		`;
+
+		btn.addEventListener("click", () => {
+			if (btn.disabled) return;
+			this.openRowSettingsDialog();
+		});
+
+		this._settingsBtn = btn;
+		return btn;
+	},
+
+	/**
+	 * Open a dialog listing all non-layout, non-hidden meta fields with
+	 * drag-to-reorder and check/uncheck for visibility.
+	 */
+	openRowSettingsDialog() {
+		const me = this;
+
+		// Build the candidate field list (all non-layout, non-hidden fields)
+		const SKIP_TYPES = new Set([
+			"Column Break",
+			"HTML",
+			"Button",
+			"Fold",
+			"Image",
+			"Signature",
+			"Geolocation",
+			"Barcode",
+			"Tab Break",
+			"Section Break",
+		]);
+		const allFields = (this.meta.fields || []).filter(
+			(df) => !SKIP_TYPES.has(df.fieldtype) && !df.hidden
+		);
+
+		// Determine initial ordered+visible set
+		let orderedFields;
+		if (this.fields_config && this.fields_config.length > 0) {
+			const map = new Map(allFields.map((df) => [df.fieldname, df]));
+			// Fields in config (visible), then remaining (hidden)
+			const configSet = new Set(this.fields_config);
+			orderedFields = [
+				...this.fields_config
+					.map((fn) => map.get(fn))
+					.filter(Boolean)
+					.map((df) => ({ df, checked: true })),
+				...allFields
+					.filter((df) => !configSet.has(df.fieldname))
+					.map((df) => ({ df, checked: false })),
+			];
+		} else {
+			// No config — use meta order, all visible
+			const hiddenSet = new Set(this.fields_to_hide || []);
+			const showSet = this.fields_to_show ? new Set(this.fields_to_show) : null;
+			orderedFields = allFields.map((df) => ({
+				df,
+				checked: !hiddenSet.has(df.fieldname) && (!showSet || showSet.has(df.fieldname)),
+			}));
+		}
+
+		// Build dialog HTML
+		const listHtml = orderedFields
+			.map(
+				({ df, checked }) => `
+				<div class="sva-vdr-field-item sortable" data-fieldname="${df.fieldname}" style="
+					display: flex;
+					align-items: center;
+					gap: 8px;
+					padding: 6px 8px;
+					margin-bottom: 2px;
+					background: var(--control-bg, #f8f9fa);
+					border: 1px solid var(--border-color, #d1d8dd);
+					border-radius: 4px;
+					cursor: grab;
+					user-select: none;
+				">
+					<span class="sva-vdr-sort-handle" style="color: var(--text-muted, #888); font-size: 14px; cursor: grab;">≡</span>
+					<input type="checkbox" class="sva-vdr-field-check" ${checked ? "checked" : ""}
+						style="margin: 0; cursor: pointer; width: 14px; height: 14px; flex-shrink: 0;"
+					/>
+					<span style="font-size: 13px; color: var(--text-color, #333);">${__(
+						df.label || df.fieldname
+					)}</span>
+					<span style="font-size: 11px; color: var(--text-muted, #888); margin-left: auto;">${
+						df.fieldtype
+					}</span>
+				</div>`
+			)
+			.join("");
+
+		const dialog = new frappe.ui.Dialog({
+			title: __("Configure Field Rows"),
+			fields: [
+				{
+					fieldname: "hint",
+					fieldtype: "HTML",
+					options: `<p style="color:var(--text-muted,#888);font-size:12px;margin:0 0 8px;">
+						${__("Drag ≡ to reorder. Uncheck to hide a field row.")}
+					</p>`,
+				},
+				{
+					fieldname: "field_list",
+					fieldtype: "HTML",
+					options: `<div class="sva-vdr-field-list" style="max-height:420px;overflow-y:auto;padding:2px 0;">${listHtml}</div>`,
+				},
+			],
+			primary_action_label: __("Save Settings"),
+			primary_action() {
+				me._saveRowSettings(dialog);
+			},
+			secondary_action_label: __("Reset to Default"),
+			secondary_action() {
+				me._resetRowSettings(dialog);
+			},
+		});
+
+		dialog.show();
+
+		// Initialize Sortable.js on the list container
+		const listEl = dialog.$wrapper[0].querySelector(".sva-vdr-field-list");
+		if (listEl && typeof Sortable !== "undefined") {
+			new Sortable(listEl, {
+				handle: ".sva-vdr-sort-handle",
+				draggable: ".sortable",
+				animation: 120,
+			});
+		}
+	},
+
+	/**
+	 * Read the dialog's current field order and checked state, persist to
+	 * server, update this.fields_config, rebuild tbody.
+	 *
+	 * @param {frappe.ui.Dialog} dialog
+	 */
+	async _saveRowSettings(dialog) {
+		const listEl = dialog.$wrapper[0].querySelector(".sva-vdr-field-list");
+		if (!listEl) return;
+
+		// Collect checked fieldnames in current DOM order
+		const newConfig = [];
+		listEl.querySelectorAll(".sva-vdr-field-item").forEach((row) => {
+			const cb = row.querySelector(".sva-vdr-field-check");
+			if (cb && cb.checked) {
+				newConfig.push(row.dataset.fieldname);
+			}
+		});
+
+		if (newConfig.length === 0) {
+			frappe.msgprint({
+				message: __("Select at least one field to display."),
+				indicator: "red",
+			});
+			return;
+		}
+
+		// Disable primary button while saving
+		const primaryBtn = dialog.$wrapper[0].querySelector(".btn-primary");
+		if (primaryBtn) primaryBtn.disabled = true;
+
+		try {
+			await this._persistRowSettings(newConfig);
+		} catch (e) {
+			if (primaryBtn) primaryBtn.disabled = false;
+			frappe.msgprint({
+				title: __("Save failed"),
+				message: String(e?.message || e),
+				indicator: "red",
+			});
+			return;
+		}
+
+		this.fields_config = newConfig;
+		this._has_user_settings = frappe.session.user !== "Administrator";
+
+		// Refresh settings button tint
+		if (this._settingsBtn) {
+			this._settingsBtn.style.color = this._has_user_settings
+				? "var(--primary, #4285f4)"
+				: "";
+		}
+
+		dialog.hide();
+		this._rebuildRows();
+
+		frappe.show_alert({ message: __("Row settings saved"), indicator: "green" });
+	},
+
+	/**
+	 * Delete user-specific settings and revert to the initial config
+	 * (the value passed at construction time, reflecting the admin config).
+	 *
+	 * @param {frappe.ui.Dialog} dialog
+	 */
+	async _resetRowSettings(dialog) {
+		if (this.frm && this.vdr_field_name && frappe.session.user !== "Administrator") {
+			try {
+				await frappe.xcall("frappe_theme.dt_api.delete_user_list_settings", {
+					parent_id: `${this.frm.doctype}-${this.vdr_field_name}`,
+					child_dt: this.doctype,
+				});
+			} catch (_) {
+				// Ignore — might not exist
+			}
+		}
+
+		this.fields_config = this._initial_fields_config ? [...this._initial_fields_config] : null;
+		this._has_user_settings = false;
+
+		if (this._settingsBtn) {
+			this._settingsBtn.style.color = "";
+		}
+
+		dialog.hide();
+		this._rebuildRows();
+
+		frappe.show_alert({ message: __("Row settings reset to default"), indicator: "blue" });
+	},
+
+	/**
+	 * Call the appropriate server API to persist the new fields config.
+	 * Administrator → update_sva_ft_property (updates the sva_ft JSON on the Property Setter)
+	 * Others        → setup_user_list_settings (per-user override in SVADT User Listview Settings)
+	 *
+	 * If frm / vdr_field_name are not available, settings are session-only (no server call).
+	 *
+	 * @param {string[]} newConfig — ordered fieldname array
+	 */
+	async _persistRowSettings(newConfig) {
+		if (!this.frm || !this.vdr_field_name) return; // standalone usage — session only
+
+		if (frappe.session.user === "Administrator") {
+			await frappe.xcall("frappe_theme.dt_api.update_sva_ft_property", {
+				doctype: this.frm.doctype,
+				fieldname: this.vdr_field_name,
+				key: "vdr_fields_config",
+				value: JSON.stringify(newConfig),
+			});
+		} else {
+			await frappe.xcall("frappe_theme.dt_api.setup_user_list_settings", {
+				parent_id: `${this.frm.doctype}-${this.vdr_field_name}`,
+				child_dt: this.doctype,
+				listview_settings: JSON.stringify(newConfig),
+			});
+		}
+	},
+
+	/**
+	 * Check for a non-admin user's saved row settings override.
+	 * Called once during _initialize(), after fetchMeta() and before render().
+	 * No-op for Administrator (always uses the sva_ft value passed at construction).
+	 */
+	async _loadUserRowSettings() {
+		if (!this.frm || !this.vdr_field_name) return;
+		if (frappe.session.user === "Administrator") return;
+
+		try {
+			const result = await frappe.xcall("frappe_theme.dt_api.get_user_list_settings", {
+				parent_id: `${this.frm.doctype}-${this.vdr_field_name}`,
+				child_dt: this.doctype,
+			});
+			if (result) {
+				this.fields_config = JSON.parse(result);
+				this._has_user_settings = true;
+			}
+		} catch (_) {
+			// If the API call fails, fall back to the constructor-supplied config
+		}
+	},
+
+	/**
+	 * Rebuild just the <tbody> after fields_config changes.
+	 * The <thead> (doc columns) is unchanged.
+	 * Works correctly because _buildTbody() iterates this.data (all loaded docs).
+	 */
+	_rebuildRows() {
+		if (!this._table) return;
+		const oldTbody = this._table.getElementsByTagName("tbody")[0];
+		if (!oldTbody) return;
+		oldTbody.replaceWith(this._buildTbody());
+	},
+};
+
+export default RowSettingsMixin;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/row_settings.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/row_settings.js
@@ -65,7 +65,6 @@ const RowSettingsMixin = {
 			"Fold",
 			"Image",
 			"Signature",
-			"Geolocation",
 			"Barcode",
 			"Tab Break",
 			"Section Break",

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
@@ -2,18 +2,25 @@ const UISetupMixin = {
 	/**
 	 * Build the root container inside this.wrapper.
 	 * Creates:
-	 *   this.container  — outer div (relative, overflow-hidden)
-	 *   this.scrollBox  — horizontally scrollable inner div
+	 *   this.container  — outer div (overflow:visible so sticky children work)
+	 *   this.scrollBox  — both-axis scrollable inner div (scroll anchor for sticky)
+	 *
+	 * Vertical sticky (header row) requires the scrollBox to have overflow:auto
+	 * and a bounded max-height; horizontal sticky (params column) requires
+	 * overflow:auto on the X axis. Both are set here.
 	 */
 	setupWrapper() {
 		this.wrapper.innerHTML = "";
 		this.wrapper.style.position = "relative";
 
+		// Inject shared CSS once per page load (spinner keyframes, etc.)
+		this._ensureStyles();
+
 		const container = document.createElement("div");
 		container.className = "sva-vdr-container";
 		container.style.cssText = `
 			width: 100%;
-			overflow: hidden;
+			overflow: visible;
 			font-size: 13px;
 		`;
 		this.container = container;
@@ -34,10 +41,13 @@ const UISetupMixin = {
 
 		const scrollBox = document.createElement("div");
 		scrollBox.className = "sva-vdr-scroll-box";
-		scrollBox.style.cssText = `
-			width: 100%;
-			overflow-x: auto;
-		`;
+		scrollBox.style.cssText = [
+			"width: 100%;",
+			"overflow: auto;",
+			this.max_height > 0 ? `max-height: ${this.max_height}px;` : "",
+		]
+			.filter(Boolean)
+			.join(" ");
 		this.scrollBox = scrollBox;
 		container.appendChild(scrollBox);
 
@@ -45,7 +55,7 @@ const UISetupMixin = {
 	},
 
 	/**
-	 * Show a lightweight skeleton / loading overlay inside the scroll box.
+	 * Show a lightweight loading indicator inside the scroll box.
 	 */
 	showLoading() {
 		if (this.scrollBox.querySelector(".sva-vdr-skeleton")) return;
@@ -57,12 +67,12 @@ const UISetupMixin = {
 			font-size: 13px;
 			text-align: center;
 		`;
-		sk.textContent = __("Loading…");
+		sk.textContent = __("Loading\u2026");
 		this.scrollBox.appendChild(sk);
 	},
 
 	/**
-	 * Remove the loading skeleton.
+	 * Remove the loading indicator.
 	 */
 	hideLoading() {
 		const sk = this.scrollBox.querySelector(".sva-vdr-skeleton");
@@ -77,6 +87,28 @@ const UISetupMixin = {
 		this.signal.addEventListener("abort", () => {
 			this.wrapper.innerHTML = "";
 		});
+	},
+
+	/**
+	 * Inject a <style id="sva-vdr-styles"> tag into document.head with CSS
+	 * that cannot be expressed inline (keyframe animations, class selectors).
+	 * Idempotent — no-op if the tag already exists.
+	 */
+	_ensureStyles() {
+		if (document.getElementById("sva-vdr-styles")) return;
+		const style = document.createElement("style");
+		style.id = "sva-vdr-styles";
+		style.textContent = `
+			@keyframes sva-vdr-spin {
+				to { transform: rotate(360deg); }
+			}
+			.sva-vdr-spinner {
+				display: inline-block;
+				animation: sva-vdr-spin 0.8s linear infinite;
+				margin-left: 4px;
+			}
+		`;
+		document.head.appendChild(style);
 	},
 };
 

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
@@ -1,0 +1,83 @@
+const UISetupMixin = {
+	/**
+	 * Build the root container inside this.wrapper.
+	 * Creates:
+	 *   this.container  — outer div (relative, overflow-hidden)
+	 *   this.scrollBox  — horizontally scrollable inner div
+	 */
+	setupWrapper() {
+		this.wrapper.innerHTML = "";
+		this.wrapper.style.position = "relative";
+
+		const container = document.createElement("div");
+		container.className = "sva-vdr-container";
+		container.style.cssText = `
+			width: 100%;
+			overflow: hidden;
+			font-size: 13px;
+		`;
+		this.container = container;
+
+		if (this.title) {
+			const titleEl = document.createElement("div");
+			titleEl.className = "sva-vdr-title";
+			titleEl.textContent = this.title;
+			titleEl.style.cssText = `
+				font-weight: 600;
+				font-size: 15px;
+				margin-bottom: 8px;
+				text-align: center;
+				color: var(--text-color, #333);
+			`;
+			container.appendChild(titleEl);
+		}
+
+		const scrollBox = document.createElement("div");
+		scrollBox.className = "sva-vdr-scroll-box";
+		scrollBox.style.cssText = `
+			width: 100%;
+			overflow-x: auto;
+		`;
+		this.scrollBox = scrollBox;
+		container.appendChild(scrollBox);
+
+		this.wrapper.appendChild(container);
+	},
+
+	/**
+	 * Show a lightweight skeleton / loading overlay inside the scroll box.
+	 */
+	showLoading() {
+		if (this.scrollBox.querySelector(".sva-vdr-skeleton")) return;
+		const sk = document.createElement("div");
+		sk.className = "sva-vdr-skeleton";
+		sk.style.cssText = `
+			padding: 16px;
+			color: var(--text-muted, #888);
+			font-size: 13px;
+			text-align: center;
+		`;
+		sk.textContent = __("Loading…");
+		this.scrollBox.appendChild(sk);
+	},
+
+	/**
+	 * Remove the loading skeleton.
+	 */
+	hideLoading() {
+		const sk = this.scrollBox.querySelector(".sva-vdr-skeleton");
+		if (sk) sk.remove();
+	},
+
+	/**
+	 * Wire up AbortSignal: clear wrapper content when signal fires.
+	 */
+	setupAbortHandler() {
+		if (!this.signal) return;
+		this.signal.addEventListener("abort", () => {
+			this.wrapper.innerHTML = "";
+		});
+	},
+};
+
+export default UISetupMixin;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
@@ -215,19 +215,81 @@ const UISetupMixin = {
 	},
 
 	/**
-	 * Show a lightweight loading indicator inside the scroll box.
+	 * Show a skeleton loading table inside the scroll box.
 	 */
 	showLoading() {
 		if (this.scrollBox.querySelector(".sva-vdr-skeleton")) return;
+
+		// _docs_input holds the raw constructor arg (string[] | object[] | null);
+		// this.docs is always [] at load time, so use _docs_input for accurate count.
+		const inputDocs = this._docs_input;
+		const colCount =
+			Array.isArray(inputDocs) && inputDocs.length ? Math.min(inputDocs.length, 6) : 4;
+		const ROW_COUNT = 7;
+
+		// Bar widths per column to look natural (label col + doc cols)
+		const labelWidths = ["75%", "90%", "60%", "85%", "70%", "80%", "65%"];
+		const cellWidths = ["55%", "70%", "45%", "60%", "50%", "65%", "40%"];
+
 		const sk = document.createElement("div");
 		sk.className = "sva-vdr-skeleton";
 		sk.style.cssText = `
-			padding: 16px;
-			color: var(--text-muted, #888);
-			font-size: 13px;
-			text-align: center;
+			width: 100%;
+			border-radius: 6px;
+			overflow: hidden;
+			border: 1px solid rgba(0,0,0,.06);
 		`;
-		sk.textContent = __("Loading\u2026");
+
+		const table = document.createElement("table");
+		table.style.cssText = "width:100%;border-collapse:collapse;table-layout:fixed;";
+
+		// \u2500\u2500 Header row \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+		const thead = document.createElement("thead");
+		const htr = document.createElement("tr");
+
+		const mkTh = (widthPct) => {
+			const th = document.createElement("th");
+			th.style.cssText =
+				"padding:10px 12px;background:#e9ecef;border:1px solid rgba(0,0,0,.06);";
+			th.innerHTML = `<div class="sva-vdr-skel-bar" style="width:${widthPct};height:14px;border-radius:20px;"></div>`;
+			return th;
+		};
+
+		htr.appendChild(mkTh("65%")); // label column header
+		for (let c = 0; c < colCount; c++) {
+			const th = mkTh("55%");
+			th.querySelector(".sva-vdr-skel-bar").style.margin = "0 auto";
+			htr.appendChild(th);
+		}
+		thead.appendChild(htr);
+		table.appendChild(thead);
+
+		// \u2500\u2500 Body rows \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+		const tbody = document.createElement("tbody");
+		for (let r = 0; r < ROW_COUNT; r++) {
+			const tr = document.createElement("tr");
+			const bg = r % 2 === 0 ? "#f8f9fa" : "#fff";
+
+			const mkTd = (widthPct, centered = false) => {
+				const td = document.createElement("td");
+				td.style.cssText = `padding:9px 12px;background:${bg};border:1px solid rgba(0,0,0,.06);`;
+				const bar = document.createElement("div");
+				bar.className = "sva-vdr-skel-bar";
+				bar.style.cssText = `width:${widthPct};height:12px;border-radius:20px;${
+					centered ? "margin:0 auto;" : ""
+				}`;
+				td.appendChild(bar);
+				return td;
+			};
+
+			tr.appendChild(mkTd(labelWidths[r % labelWidths.length]));
+			for (let c = 0; c < colCount; c++) {
+				tr.appendChild(mkTd(cellWidths[(r + c) % cellWidths.length], true));
+			}
+			tbody.appendChild(tr);
+		}
+		table.appendChild(tbody);
+		sk.appendChild(table);
 		this.scrollBox.appendChild(sk);
 	},
 
@@ -266,6 +328,15 @@ const UISetupMixin = {
 				display: inline-block;
 				animation: sva-vdr-spin 0.8s linear infinite;
 				margin-left: 4px;
+			}
+			@keyframes sva-vdr-shimmer {
+				0%   { background-position: -400px 0; }
+				100% { background-position:  400px 0; }
+			}
+			.sva-vdr-skel-bar {
+				background: linear-gradient(90deg, #e0e0e0 25%, #ececec 50%, #e0e0e0 75%);
+				background-size: 800px 100%;
+				animation: sva-vdr-shimmer 1.4s ease-in-out infinite;
 			}
 		`;
 		document.head.appendChild(style);

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
@@ -101,16 +101,17 @@ const UISetupMixin = {
 
 	/**
 	 * Build the toolbar row placed between the title and the scrollBox.
-	 * Left side: "+" create button (when allow_create is true).
 	 * Right side: gear settings button (when vdr_field_name is set).
-	 * Returns null when neither button is needed (pure read-only standalone usage).
+	 * Returns null when neither the settings button nor Add More is needed.
+	 * Stores reference in this._toolbar so _renderAddMoreButton() can append to it.
 	 *
 	 * @returns {HTMLElement|null}
 	 */
 	_buildToolbar() {
-		// Toolbar only contains the settings gear button.
-		// The "+" create button is an overlay on _scrollWrapper (see setupWrapper).
-		if (!this.vdr_field_name) return null;
+		const hasSettings = !!this.vdr_field_name;
+		const hasAddMore = !!(this.add_more_config && this.add_more_config.allow_add_more_table);
+
+		if (!hasSettings && !hasAddMore) return null;
 
 		const toolbar = document.createElement("div");
 		toolbar.className = "sva-vdr-toolbar";
@@ -118,14 +119,99 @@ const UISetupMixin = {
 			display: flex;
 			justify-content: flex-end;
 			align-items: center;
+			gap: 6px;
 			margin-bottom: 4px;
 		`;
 
-		if (typeof this._buildSettingsButton === "function") {
+		this._toolbar = toolbar; // stored so _renderAddMoreButton() can append to it
+
+		if (hasSettings && typeof this._buildSettingsButton === "function") {
 			toolbar.appendChild(this._buildSettingsButton());
 		}
 
 		return toolbar;
+	},
+
+	/**
+	 * Append the "Add More" button to the toolbar (top-right) after the table renders.
+	 * Called from _initialize() after render() so data is already visible.
+	 * Idempotent — removes any stale button before appending a new one.
+	 * No-op when add_more_config is absent or allow_add_more_table is false.
+	 */
+	_renderAddMoreButton() {
+		// Normalise: accept both a pre-parsed object and a JSON string
+		let cfg = this.add_more_config;
+		if (typeof cfg === "string") {
+			try {
+				cfg = JSON.parse(cfg);
+				this.add_more_config = cfg; // update in place so callers see the object
+				console.log("[VDR] _renderAddMoreButton: parsed add_more_config from string", cfg);
+			} catch (e) {
+				console.warn(
+					"[VDR] _renderAddMoreButton: failed to parse add_more_config string",
+					e
+				);
+				cfg = null;
+			}
+		}
+		console.log("[VDR] _renderAddMoreButton called — add_more_config:", cfg);
+		if (!cfg || !cfg.allow_add_more_table) {
+			console.log(
+				"[VDR] _renderAddMoreButton: no-op (add_more_config missing or allow_add_more_table false)"
+			);
+			return;
+		}
+
+		// Remove stale button (safety for future reloadTable() callers that re-invoke this)
+		if (this._addMoreBtnEl && this._addMoreBtnEl.parentNode) {
+			this._addMoreBtnEl.parentNode.removeChild(this._addMoreBtnEl);
+		}
+
+		const label = cfg.add_more_button_label || "Add More";
+
+		const btn = document.createElement("button");
+		btn.className = "btn btn-default btn-sm sva-vdr-add-more-btn";
+		btn.title = __("Create a new batch of records for each existing column");
+		btn.style.cssText = "font-size:12px;display:flex;align-items:center;gap:4px;";
+		btn.innerHTML = `<span style="font-size:14px;font-weight:700;line-height:1;">+</span> ${__(
+			label
+		)}`;
+
+		btn.addEventListener("click", () => {
+			if (typeof this._onAddMoreClick === "function") {
+				this._onAddMoreClick(cfg);
+			} else {
+				console.warn("[VDR] _onAddMoreClick not implemented. Batch config:", cfg);
+				frappe.show_alert({
+					message: __(
+						"Add More clicked. Implement _onAddMoreClick() to handle batch creation."
+					),
+					indicator: "blue",
+				});
+			}
+		});
+
+		this._addMoreBtnEl = btn;
+
+		// Prefer toolbar (top-right) when available; fall back to a footer bar below table
+		if (this._toolbar) {
+			// Insert before the settings gear so Add More is left of gear: [+ Add More][⚙]
+			this._toolbar.insertBefore(btn, this._toolbar.firstChild);
+			console.log("[VDR] Add More button added to toolbar");
+		} else if (this.container) {
+			// No toolbar (no vdr_field_name) — create a minimal footer bar
+			let footer = this.container.querySelector(".sva-vdr-add-more-footer");
+			if (!footer) {
+				footer = document.createElement("div");
+				footer.className = "sva-vdr-add-more-footer";
+				footer.style.cssText = "display:flex;justify-content:flex-end;margin-top:8px;";
+				this.container.appendChild(footer);
+			}
+			footer.appendChild(btn);
+			console.log("[VDR] Add More button added to footer (no toolbar available)");
+		} else {
+			console.warn("[VDR] _renderAddMoreButton: neither _toolbar nor container is ready");
+		}
 	},
 
 	/**

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
@@ -77,6 +77,7 @@ const UISetupMixin = {
 		scrollBox.style.cssText = [
 			"width: 100%;",
 			"overflow: auto;",
+			"-webkit-overflow-scrolling: touch;", // iOS momentum scroll
 			this.max_height > 0 ? `max-height: ${this.max_height}px;` : "",
 		]
 			.filter(Boolean)

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
@@ -26,23 +26,39 @@ const UISetupMixin = {
 		`;
 		this.container = container;
 
-		if (this.title) {
-			const titleEl = document.createElement("div");
-			titleEl.className = "sva-vdr-title";
-			titleEl.textContent = this.title;
-			titleEl.style.cssText = `
-				font-weight: 600;
-				font-size: 15px;
-				margin-bottom: 8px;
-				text-align: center;
-				color: var(--text-color, #333);
-			`;
-			container.appendChild(titleEl);
-		}
-
-		// Toolbar (gear settings button only) — only when vdr_field_name is set
+		// Header row: title on the left, toolbar (settings/add-more) on the right
 		const toolbar = this._buildToolbar();
-		if (toolbar) container.appendChild(toolbar);
+		if (this.title || toolbar) {
+			const headerRow = document.createElement("div");
+			headerRow.style.cssText = `
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				gap: 8px;
+				margin-bottom: 6px;
+			`;
+
+			if (this.title) {
+				const titleEl = document.createElement("div");
+				titleEl.className = "sva-vdr-title";
+				titleEl.textContent = this.title;
+				titleEl.style.cssText = `
+					font-weight: 600;
+					font-size: 15px;
+					color: var(--text-color, #333);
+					flex: 1;
+				`;
+				headerRow.appendChild(titleEl);
+			}
+
+			if (toolbar) {
+				// Remove the toolbar's own bottom margin — headerRow handles spacing
+				toolbar.style.marginBottom = "0";
+				headerRow.appendChild(toolbar);
+			}
+
+			container.appendChild(headerRow);
+		}
 
 		// scrollWrapper shrinks to the table's natural width but never exceeds
 		// the container (max-width:100%). position:relative anchors the "+" overlay

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
@@ -22,6 +22,7 @@ const UISetupMixin = {
 			width: 100%;
 			overflow: visible;
 			font-size: 13px;
+			margin-bottom: 24px;
 		`;
 		this.container = container;
 

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
@@ -181,20 +181,11 @@ const UISetupMixin = {
 			try {
 				cfg = JSON.parse(cfg);
 				this.add_more_config = cfg; // update in place so callers see the object
-				console.log("[VDR] _renderAddMoreButton: parsed add_more_config from string", cfg);
 			} catch (e) {
-				console.warn(
-					"[VDR] _renderAddMoreButton: failed to parse add_more_config string",
-					e
-				);
 				cfg = null;
 			}
 		}
-		console.log("[VDR] _renderAddMoreButton called — add_more_config:", cfg);
 		if (!cfg || !cfg.allow_add_more_table) {
-			console.log(
-				"[VDR] _renderAddMoreButton: no-op (add_more_config missing or allow_add_more_table false)"
-			);
 			return;
 		}
 
@@ -217,7 +208,6 @@ const UISetupMixin = {
 			if (typeof this._onAddMoreClick === "function") {
 				this._onAddMoreClick(cfg);
 			} else {
-				console.warn("[VDR] _onAddMoreClick not implemented. Batch config:", cfg);
 				frappe.show_alert({
 					message: __(
 						"Add More clicked. Implement _onAddMoreClick() to handle batch creation."
@@ -233,7 +223,6 @@ const UISetupMixin = {
 		if (this._toolbar) {
 			// Insert before the settings gear so Add More is left of gear: [+ Add More][⚙]
 			this._toolbar.insertBefore(btn, this._toolbar.firstChild);
-			console.log("[VDR] Add More button added to toolbar");
 		} else if (this.container) {
 			// No toolbar (no vdr_field_name) — create a minimal footer bar
 			let footer = this.container.querySelector(".sva-vdr-add-more-footer");
@@ -244,7 +233,6 @@ const UISetupMixin = {
 				this.container.appendChild(footer);
 			}
 			footer.appendChild(btn);
-			console.log("[VDR] Add More button added to footer (no toolbar available)");
 		} else {
 			console.warn("[VDR] _renderAddMoreButton: neither _toolbar nor container is ready");
 		}

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
@@ -39,6 +39,22 @@ const UISetupMixin = {
 			container.appendChild(titleEl);
 		}
 
+		// Toolbar (gear settings button only) — only when vdr_field_name is set
+		const toolbar = this._buildToolbar();
+		if (toolbar) container.appendChild(toolbar);
+
+		// scrollWrapper shrinks to the table's natural width but never exceeds
+		// the container (max-width:100%). position:relative anchors the "+" overlay
+		// so its right:0 stays exactly at the table's right edge.
+		// When the table is wider than the container, scrollWrapper is capped at
+		// 100% and scrollBox (width:100%) provides horizontal overflow scrolling.
+		const scrollWrapper = document.createElement("div");
+		scrollWrapper.style.cssText = `
+			position: relative;
+			width: 100%;
+		`;
+		this._scrollWrapper = scrollWrapper;
+
 		const scrollBox = document.createElement("div");
 		scrollBox.className = "sva-vdr-scroll-box";
 		scrollBox.style.cssText = [
@@ -49,9 +65,66 @@ const UISetupMixin = {
 			.filter(Boolean)
 			.join(" ");
 		this.scrollBox = scrollBox;
-		container.appendChild(scrollBox);
+		scrollWrapper.appendChild(scrollBox);
+
+		// "+" overlay button — top-right corner of the table border
+		if (this.allow_create) {
+			const createBtn = document.createElement("button");
+			createBtn.className = "btn btn-primary btn-xs sva-vdr-create-btn";
+			createBtn.title = __("Add new record");
+			createBtn.style.cssText = `
+				position: absolute;
+				top: 0;
+				right: 0;
+				z-index: 20;
+				font-size: 15px;
+				font-weight: 700;
+				line-height: 1;
+				padding: 2px 8px 3px;
+				border-radius: 0 0 0 4px;
+				border-top: none;
+				border-right: none;
+			`;
+			createBtn.textContent = "+";
+			createBtn.addEventListener("click", () => {
+				if (!createBtn.disabled) this.openCreateDialog();
+			});
+			this._createToolbarBtn = createBtn;
+			scrollWrapper.appendChild(createBtn);
+		}
+
+		container.appendChild(scrollWrapper);
 
 		this.wrapper.appendChild(container);
+	},
+
+	/**
+	 * Build the toolbar row placed between the title and the scrollBox.
+	 * Left side: "+" create button (when allow_create is true).
+	 * Right side: gear settings button (when vdr_field_name is set).
+	 * Returns null when neither button is needed (pure read-only standalone usage).
+	 *
+	 * @returns {HTMLElement|null}
+	 */
+	_buildToolbar() {
+		// Toolbar only contains the settings gear button.
+		// The "+" create button is an overlay on _scrollWrapper (see setupWrapper).
+		if (!this.vdr_field_name) return null;
+
+		const toolbar = document.createElement("div");
+		toolbar.className = "sva-vdr-toolbar";
+		toolbar.style.cssText = `
+			display: flex;
+			justify-content: flex-end;
+			align-items: center;
+			margin-bottom: 4px;
+		`;
+
+		if (typeof this._buildSettingsButton === "function") {
+			toolbar.appendChild(this._buildSettingsButton());
+		}
+
+		return toolbar;
 	},
 
 	/**

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/ui_setup.js
@@ -117,17 +117,17 @@ const UISetupMixin = {
 
 	/**
 	 * Build the toolbar row placed between the title and the scrollBox.
-	 * Right side: gear settings button (when vdr_field_name is set).
-	 * Returns null when neither the settings button nor Add More is needed.
+	 * Right side: reload button (always), gear settings (when vdr_field_name is set).
 	 * Stores reference in this._toolbar so _renderAddMoreButton() can append to it.
 	 *
-	 * @returns {HTMLElement|null}
+	 * @returns {HTMLElement}
 	 */
 	_buildToolbar() {
 		const hasSettings = !!this.vdr_field_name;
 		const hasAddMore = !!(this.add_more_config && this.add_more_config.allow_add_more_table);
+		const hasReload = !this._is_sub_vdr;
 
-		if (!hasSettings && !hasAddMore) return null;
+		if (!hasSettings && !hasAddMore && !hasReload) return null;
 
 		const toolbar = document.createElement("div");
 		toolbar.className = "sva-vdr-toolbar";
@@ -143,6 +143,25 @@ const UISetupMixin = {
 
 		if (hasSettings && typeof this._buildSettingsButton === "function") {
 			toolbar.appendChild(this._buildSettingsButton());
+		}
+
+		if (hasReload) {
+			const reloadBtn = document.createElement("button");
+			reloadBtn.className = "btn btn-default btn-xs sva-vdr-reload-btn";
+			reloadBtn.title = __("Reload");
+			reloadBtn.style.cssText = `
+				font-size: 14px;
+				line-height: 1;
+				padding: 3px 7px;
+				display: flex;
+				align-items: center;
+			`;
+			reloadBtn.innerHTML = `<span class="sva-vdr-reload-icon" style="display:inline-block;">↺</span>`;
+			reloadBtn.addEventListener("click", () => {
+				if (!reloadBtn.disabled) this.reloadTable();
+			});
+			this._reloadBtn = reloadBtn;
+			toolbar.appendChild(reloadBtn);
 		}
 
 		return toolbar;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/validation.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/validation.js
@@ -1,0 +1,167 @@
+/**
+ * ValidationMixin — per-cell depends_on evaluation + error banner
+ *
+ * Evaluates Frappe field expressions (depends_on, mandatory_depends_on,
+ * read_only_depends_on) independently for each document column, enabling
+ * per-cell hidden/required/readonly states in the comparison table.
+ *
+ * Uses frappe.utils.custom_eval (same evaluator as SVADatatable) with a
+ * fallback to direct eval for resilience.
+ *
+ * Also owns the sticky dismissible error banner shown above the table.
+ */
+const ValidationMixin = {
+	/**
+	 * Evaluate a Frappe depends_on expression against a document.
+	 * Handles "eval:" prefix. Returns false on any error.
+	 *
+	 * @param {string} expr — e.g. "eval:doc.status=='Active'" or "status"
+	 * @param {object} doc  — document data object
+	 * @returns {boolean}
+	 */
+	_evaluateDepends(expr, doc) {
+		if (!expr) return false;
+		try {
+			if (typeof frappe.utils.custom_eval === "function") {
+				return !!frappe.utils.custom_eval(expr, doc);
+			}
+			// Fallback: strip "eval:" prefix and evaluate with doc bound
+			const code = expr.replace(/^eval:/, "");
+			// eslint-disable-next-line no-new-func
+			const fn = new Function("doc", `try { return !!(${code}); } catch(e) { return false; }`);
+			return fn(doc);
+		} catch (_) {
+			return false;
+		}
+	},
+
+	/**
+	 * Returns true when the field should be hidden for the given document.
+	 * Hidden when: df.hidden is set, OR depends_on evaluates to false.
+	 *
+	 * @param {object} df  — field descriptor from meta
+	 * @param {object} doc — document data object
+	 * @returns {boolean}
+	 */
+	isFieldHidden(df, doc) {
+		if (df.hidden) return true;
+		if (df.depends_on) return !this._evaluateDepends(df.depends_on, doc);
+		return false;
+	},
+
+	/**
+	 * Returns true when the field should be read-only for the given document.
+	 *
+	 * @param {object} df  — field descriptor from meta
+	 * @param {object} doc — document data object
+	 * @returns {boolean}
+	 */
+	isFieldReadOnly(df, doc) {
+		if (df.read_only) return true;
+		if (df.read_only_depends_on) return this._evaluateDepends(df.read_only_depends_on, doc);
+		return false;
+	},
+
+	/**
+	 * Returns true when the field is required for the given document.
+	 *
+	 * @param {object} df  — field descriptor from meta
+	 * @param {object} doc — document data object
+	 * @returns {boolean}
+	 */
+	isFieldRequired(df, doc) {
+		if (df.reqd) return true;
+		if (df.mandatory_depends_on) return this._evaluateDepends(df.mandatory_depends_on, doc);
+		return false;
+	},
+
+	/**
+	 * Validate a value before saving.
+	 * Returns an array of error message strings (empty = valid).
+	 *
+	 * @param {object} df       — field descriptor
+	 * @param {object} doc      — document data object
+	 * @param {*}      newValue — the value being saved
+	 * @returns {string[]}
+	 */
+	validateBeforeSave(df, doc, newValue) {
+		const errors = [];
+		if (this.isFieldRequired(df, doc)) {
+			const isEmpty =
+				newValue === null ||
+				newValue === undefined ||
+				newValue === "" ||
+				newValue === 0;
+			if (isEmpty) {
+				const label = __(df.label || df.fieldname);
+				errors.push(__("'{0}' is required for {1}", [label, doc.name]));
+			}
+		}
+		return errors;
+	},
+
+	/**
+	 * Show a dismissible red error banner above the table.
+	 * Replaces any existing banner. Does nothing when errors is empty.
+	 *
+	 * @param {string[]} errors — list of error messages
+	 */
+	showErrorBanner(errors) {
+		this.clearErrorBanner();
+		if (!errors || !errors.length) return;
+
+		const banner = document.createElement("div");
+		banner.className = "sva-vdr-error-banner";
+		banner.style.cssText = `
+			background: #fce8e8;
+			border: 1px solid #f5c6cb;
+			border-radius: 4px;
+			padding: 8px 36px 8px 12px;
+			margin-bottom: 6px;
+			position: relative;
+			color: #721c24;
+			font-size: 12px;
+			line-height: 1.6;
+		`;
+
+		const closeBtn = document.createElement("button");
+		closeBtn.innerHTML = "&times;";
+		closeBtn.title = __("Dismiss");
+		closeBtn.style.cssText = `
+			position: absolute;
+			top: 4px;
+			right: 8px;
+			border: none;
+			background: none;
+			cursor: pointer;
+			font-size: 18px;
+			line-height: 1;
+			color: inherit;
+			padding: 0 4px;
+		`;
+		closeBtn.addEventListener("click", () => this.clearErrorBanner());
+		banner.appendChild(closeBtn);
+
+		errors.forEach((msg) => {
+			const row = document.createElement("div");
+			row.textContent = "\u26a0 " + msg;
+			banner.appendChild(row);
+		});
+
+		this._errorBanner = banner;
+		// Insert before the scroll box (below title if any)
+		this.container.insertBefore(banner, this.scrollBox);
+	},
+
+	/**
+	 * Remove the error banner from the DOM if it exists.
+	 */
+	clearErrorBanner() {
+		if (this._errorBanner) {
+			this._errorBanner.remove();
+			this._errorBanner = null;
+		}
+	},
+};
+
+export default ValidationMixin;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/validation.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/validation.js
@@ -28,7 +28,10 @@ const ValidationMixin = {
 			// Fallback: strip "eval:" prefix and evaluate with doc bound
 			const code = expr.replace(/^eval:/, "");
 			// eslint-disable-next-line no-new-func
-			const fn = new Function("doc", `try { return !!(${code}); } catch(e) { return false; }`);
+			const fn = new Function(
+				"doc",
+				`try { return !!(${code}); } catch(e) { return false; }`
+			);
 			return fn(doc);
 		} catch (_) {
 			return false;
@@ -88,10 +91,7 @@ const ValidationMixin = {
 		const errors = [];
 		if (this.isFieldRequired(df, doc)) {
 			const isEmpty =
-				newValue === null ||
-				newValue === undefined ||
-				newValue === "" ||
-				newValue === 0;
+				newValue === null || newValue === undefined || newValue === "" || newValue === 0;
 			if (isEmpty) {
 				const label = __(df.label || df.fieldname);
 				errors.push(__("'{0}' is required for {1}", [label, doc.name]));

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
@@ -1,0 +1,226 @@
+/**
+ * ViewportMixin — lazy column loading via IntersectionObserver
+ *
+ * After the first batch of columns is rendered by render(), this mixin
+ * places an invisible sentinel <th> at the far-right edge of the header row.
+ * When the sentinel scrolls into view, the next batch of columns is fetched
+ * and appended — no more than `column_batch_size` records per API call.
+ *
+ * Works with all three docs shapes:
+ *   object[]  → slices from in-memory _all_inputs (zero API calls)
+ *   string[]  → frappe.db.get_list filtered by the next slice of names
+ *   null      → frappe.db.get_list with start offset (strict server-side pagination)
+ */
+const ViewportMixin = {
+	/**
+	 * Called once after the initial render() completes.
+	 * Auto-calculates batch_size from viewport width if column_batch_size = 0.
+	 * Places the first IntersectionObserver sentinel.
+	 */
+	setupViewportLoader() {
+		// Auto-calculate batch size when caller did not specify one
+		if (!this.column_batch_size) {
+			const viewportWidth = this.scrollBox.clientWidth || 600;
+			const colWidth = this.column_width || 150;
+			this.column_batch_size = Math.max(3, Math.floor(viewportWidth / colWidth));
+		}
+
+		this._rendered_count = this.data.length; // already rendered by render()
+		this._sentinel = null;
+		this._observer = null;
+		this._loading_batch = false;
+
+		this._placeSentinel();
+	},
+
+	/**
+	 * Total number of columns that will ever be shown.
+	 * Returns Infinity when docs:null (server decides when to stop).
+	 */
+	_total_col_count() {
+		if (this._all_inputs === null) return Infinity;
+		return this._all_inputs.length;
+	},
+
+	/**
+	 * Place an invisible sentinel <th> at the far-right of the header row.
+	 * When it enters the viewport, _loadNextBatch() fires.
+	 * If all columns are already rendered, no sentinel is placed.
+	 */
+	_placeSentinel() {
+		// Clean up any previous sentinel + observer
+		if (this._sentinel) {
+			this._sentinel.remove();
+			this._sentinel = null;
+		}
+		if (this._observer) {
+			this._observer.disconnect();
+			this._observer = null;
+		}
+
+		// All columns have been rendered — nothing left to load
+		if (this._rendered_count >= this._total_col_count()) return;
+
+		const sentinel = document.createElement("th");
+		sentinel.className = "sva-vdr-sentinel";
+		sentinel.style.cssText =
+			"width:1px;min-width:1px;padding:0;border:none;background:transparent;";
+		this._theadRow.appendChild(sentinel);
+		this._sentinel = sentinel;
+
+		this._observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0].isIntersecting && !this._loading_batch) {
+					this._loadNextBatch();
+				}
+			},
+			{ root: this.scrollBox, threshold: 0.01 }
+		);
+		this._observer.observe(sentinel);
+	},
+
+	/**
+	 * Fetch and render the next batch of columns.
+	 * Disconnects the observer first so it doesn't fire again mid-load.
+	 * Re-places the sentinel after appending, ready for the batch after that.
+	 */
+	async _loadNextBatch() {
+		this._loading_batch = true;
+		this._observer?.disconnect();
+
+		const from = this._rendered_count;
+		const batchSize = this.column_batch_size || 10;
+
+		let batchData;
+		try {
+			batchData = await this._fetchBatchData(from, from + batchSize);
+		} catch (e) {
+			console.error("SVAVerticalDocRenderer: _loadNextBatch failed", e);
+			this._loading_batch = false;
+			return;
+		}
+
+		if (!batchData || !batchData.length) {
+			// Server returned nothing — we have exhausted all records
+			this._loading_batch = false;
+			return;
+		}
+
+		batchData.forEach((doc, i) => this._appendDocColumn(doc, from + i));
+		this._rendered_count += batchData.length;
+
+		this._loading_batch = false;
+		this._placeSentinel(); // watch for the batch after this one
+	},
+
+	/**
+	 * Fetch data for one batch of columns.
+	 *
+	 * object[]  → slice from in-memory _all_inputs (no API call)
+	 * string[]  → frappe.db.get_list filtered by names[from..to]
+	 * null      → frappe.db.get_list with start offset (paginated)
+	 *
+	 * @param {number} from — first column index (inclusive, 0-based absolute)
+	 * @param {number} to   — last column index  (exclusive)
+	 * @returns {Promise<object[]>}
+	 */
+	async _fetchBatchData(from, to) {
+		const input = this._all_inputs;
+		const batchSize = to - from;
+		const fields = this._getDataFields();
+
+		// object[] — data already in memory; no API call
+		if (
+			input !== null &&
+			Array.isArray(input) &&
+			input.length > 0 &&
+			typeof input[0] === "object"
+		) {
+			return input.slice(from, to);
+		}
+
+		// string[] — fetch the next slice of doc names from the server
+		if (input !== null && Array.isArray(input)) {
+			const names = input.slice(from, to);
+			if (!names.length) return [];
+			let data = [];
+			try {
+				data = await frappe.db.get_list(this.doctype, {
+					filters: [["name", "in", names]],
+					fields,
+					limit: names.length + 1,
+				});
+			} catch (e) {
+				console.error("SVAVerticalDocRenderer: _fetchBatchData failed", e);
+				return [];
+			}
+			// Re-sort to match the caller-specified order
+			const nameMap = {};
+			data.forEach((d) => (nameMap[d.name] = d));
+			return names.map((name) => nameMap[name] || { name });
+		}
+
+		// null — paginate by server-side offset
+		try {
+			return await frappe.db.get_list(this.doctype, {
+				filters: this.filters || [],
+				fields,
+				limit: batchSize,
+				start: from,
+				...(this.order_by ? { order_by: this.order_by } : {}),
+			});
+		} catch (e) {
+			console.error("SVAVerticalDocRenderer: _fetchBatchData failed", e);
+			return [];
+		}
+	},
+
+	/**
+	 * Append one document's column to the already-rendered table.
+	 * Called for each doc in a lazy-loaded batch.
+	 *
+	 * Steps:
+	 *   1. Insert <th> before the sentinel in the header row
+	 *   2. Append <td> to each tr.sva-vdr-field-row
+	 *   3. Increment colSpan on every tr.sva-vdr-section-row td
+	 *   4. Sync this.data / this.docs (needed by edit operations)
+	 *
+	 * @param {object} doc      — document data object
+	 * @param {number} absIndex — absolute 0-based column index across all batches
+	 */
+	_appendDocColumn(doc, absIndex) {
+		const conf = (this.column_configs || [])[absIndex] || {};
+
+		// 1. Header cell — insert before the sentinel so sentinel stays at far right
+		const th = this._buildDocHeaderCell(doc, absIndex, conf);
+		if (this._sentinel) {
+			this._theadRow.insertBefore(th, this._sentinel);
+		} else {
+			this._theadRow.appendChild(th);
+		}
+
+		// 2. Value cell in each field data row
+		const fieldRows = this._table.querySelectorAll("tr.sva-vdr-field-row");
+		fieldRows.forEach((tr) => {
+			const fieldname = tr.dataset.fieldname;
+			const df = (this.meta.fields || []).find((f) => f.fieldname === fieldname);
+			if (!df) return;
+			tr.appendChild(this._buildValueCell(df, doc, absIndex));
+		});
+
+		// 3. Extend colspan on every section header row by 1
+		this._table.querySelectorAll("tr.sva-vdr-section-row td").forEach((td) => {
+			td.colSpan = (td.colSpan || 1) + 1;
+		});
+
+		// 4. Keep this.data and this.docs in sync for inline editing
+		if (!this.data.find((d) => d.name === doc.name)) {
+			this.data.push(doc);
+		}
+		if (!this.docs.includes(doc.name)) {
+			this.docs.push(doc.name);
+		}
+	},
+};
+
+export default ViewportMixin;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
@@ -10,6 +10,10 @@
  *   object[]  → slices from in-memory _all_inputs (zero API calls)
  *   string[]  → frappe.db.get_list filtered by the next slice of names
  *   null      → frappe.db.get_list with start offset (strict server-side pagination)
+ *
+ * After each batch is appended:
+ *   - resolveLinkTitles() is called to batch-fetch titles for newly added cells.
+ *   - _appendDeleteCell() is called for each new doc (if delete is enabled).
  */
 const ViewportMixin = {
 	/**
@@ -81,8 +85,8 @@ const ViewportMixin = {
 
 	/**
 	 * Fetch and render the next batch of columns.
-	 * Disconnects the observer first so it doesn't fire again mid-load.
-	 * Re-places the sentinel after appending, ready for the batch after that.
+	 * After appending, calls resolveLinkTitles() and _appendDeleteCell()
+	 * for each new doc.
 	 */
 	async _loadNextBatch() {
 		this._loading_batch = true;
@@ -101,13 +105,26 @@ const ViewportMixin = {
 		}
 
 		if (!batchData || !batchData.length) {
-			// Server returned nothing — we have exhausted all records
+			// Server returned nothing — all records exhausted
 			this._loading_batch = false;
 			return;
 		}
 
-		batchData.forEach((doc, i) => this._appendDocColumn(doc, from + i));
+		batchData.forEach((doc, i) => {
+			const absIndex = from + i;
+			this._appendDocColumn(doc, absIndex);
+
+			// Append delete cell for new column (guard: method may not exist)
+			if (this._appendDeleteCell) {
+				this._appendDeleteCell(doc);
+			}
+		});
 		this._rendered_count += batchData.length;
+
+		// Batch-fetch link titles for newly added columns (non-blocking)
+		if (typeof this.resolveLinkTitles === "function") {
+			this.resolveLinkTitles();
+		}
 
 		this._loading_batch = false;
 		this._placeSentinel(); // watch for the batch after this one

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
@@ -191,10 +191,12 @@ const ViewportMixin = {
 	_appendDocColumn(doc, absIndex) {
 		const conf = (this.column_configs || [])[absIndex] || {};
 
-		// 1. Header cell — insert before the sentinel so sentinel stays at far right
+		// 1. Header cell — insert before _createTh ("+") or sentinel, whichever comes first.
+		//    Order in thead: [...doc cols] [+create?] [sentinel?]
 		const th = this._buildDocHeaderCell(doc, absIndex, conf);
-		if (this._sentinel) {
-			this._theadRow.insertBefore(th, this._sentinel);
+		const headerInsertBefore = this._createTh || this._sentinel;
+		if (headerInsertBefore) {
+			this._theadRow.insertBefore(th, headerInsertBefore);
 		} else {
 			this._theadRow.appendChild(th);
 		}

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
@@ -327,6 +327,11 @@ const ViewportMixin = {
 		if (!this.docs.includes(doc.name)) {
 			this.docs.push(doc.name);
 		}
+
+		// 5. Grow table min-width so narrow viewports scroll rather than squish
+		if (this._table && typeof this._calcTableMinWidth === "function") {
+			this._table.style.minWidth = `${this._calcTableMinWidth(this.data.length)}px`;
+		}
 	},
 };
 

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
@@ -199,54 +199,67 @@ const ViewportMixin = {
 	 * when set (used by the filter ribbon reset/apply flow).
 	 */
 	async reloadTable() {
-		// ── Batched mode: rebuild all batch sections from scratch ─────────────
-		if (this._isBatchGrouped && this._isBatchGrouped()) {
-			this.container.querySelectorAll(".sva-vdr-batch-section").forEach((el) => el.remove());
-			this._batchInstances = {};
-			this.showLoading();
-			await this._renderBatchGroups();
-			this.hideLoading();
-			return;
-		}
+		// Spin the reload button while reloading
+		const _icon = this._reloadBtn?.querySelector(".sva-vdr-reload-icon");
+		if (this._reloadBtn) this._reloadBtn.disabled = true;
+		if (_icon) _icon.style.animation = "sva-vdr-spin 0.6s linear infinite";
 
-		// ── Standard mode ────────────────────────────────────────────────────
-		// Stop in-progress observation
-		if (this._observer) {
-			this._observer.disconnect();
-			this._observer = null;
-		}
-		this._sentinel = null;
-		this._loading_batch = false;
-
-		// Restore filters: only touch them when setFilters() was previously called
-		// (signalled by _base_filters being set). Otherwise keep this.filters as-is
-		// so the original constructor filters are never wiped on a plain reload.
-		if (this._base_filters !== undefined) {
-			if (this.additional_list_filters && this.additional_list_filters.length) {
-				this.filters = [...this._base_filters, ...this.additional_list_filters];
-			} else {
-				this.filters = [...this._base_filters];
+		try {
+			// ── Batched mode: rebuild all batch sections from scratch ─────────────
+			if (this._isBatchGrouped && this._isBatchGrouped()) {
+				this.container.querySelectorAll(".sva-vdr-batch-section").forEach((el) => el.remove());
+				this._batchInstances = {};
+				this.showLoading();
+				await this._renderBatchGroups();
+				this.hideLoading();
+				return;
 			}
-		}
 
-		// Reset data state
-		this.data = [];
-		this.docs = [];
-		this._rendered_count = 0;
+			// ── Standard mode ────────────────────────────────────────────────────
+			// Stop in-progress observation
+			if (this._observer) {
+				this._observer.disconnect();
+				this._observer = null;
+			}
+			this._sentinel = null;
+			this._loading_batch = false;
 
-		// Clear rendered table
-		if (this.scrollBox) {
-			this.scrollBox.innerHTML = "";
-		}
+			// Restore filters: only touch them when setFilters() was previously called
+			// (signalled by _base_filters being set). Otherwise keep this.filters as-is
+			// so the original constructor filters are never wiped on a plain reload.
+			if (this._base_filters !== undefined) {
+				if (this.additional_list_filters && this.additional_list_filters.length) {
+					this.filters = [...this._base_filters, ...this.additional_list_filters];
+				} else {
+					this.filters = [...this._base_filters];
+				}
+			}
 
-		// Re-fetch and re-render first batch
-		await this.fetchDocs();
-		this._sortDataByOrderRules && this._sortDataByOrderRules();
-		this.render();
-		if (typeof this.resolveLinkTitles === "function") {
-			this.resolveLinkTitles();
+			// Reset data state
+			this.data = [];
+			this.docs = [];
+			this._rendered_count = 0;
+
+			// Clear rendered table and show skeleton while fetching
+			if (this.scrollBox) {
+				this.scrollBox.innerHTML = "";
+			}
+			this.showLoading();
+
+			// Re-fetch and re-render first batch
+			await this.fetchDocs();
+			this.hideLoading();
+			this._sortDataByOrderRules && this._sortDataByOrderRules();
+			this.render();
+			if (typeof this.resolveLinkTitles === "function") {
+				this.resolveLinkTitles();
+			}
+			this.setupViewportLoader();
+		} finally {
+			// Restore button regardless of success or error
+			if (this._reloadBtn) this._reloadBtn.disabled = false;
+			if (_icon) _icon.style.animation = "";
 		}
-		this.setupViewportLoader();
 	},
 
 	/**

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
@@ -121,6 +121,11 @@ const ViewportMixin = {
 		});
 		this._rendered_count += batchData.length;
 
+		// Re-sort all rendered columns by order rules (fixes cross-batch ordering)
+		if (typeof this._reorderColumnsByRules === "function") {
+			this._reorderColumnsByRules();
+		}
+
 		// Batch-fetch link titles for newly added columns (non-blocking)
 		if (typeof this.resolveLinkTitles === "function") {
 			this.resolveLinkTitles();

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
@@ -212,7 +212,9 @@ const ViewportMixin = {
 		try {
 			// ── Batched mode: rebuild all batch sections from scratch ─────────────
 			if (this._isBatchGrouped && this._isBatchGrouped()) {
-				this.container.querySelectorAll(".sva-vdr-batch-section").forEach((el) => el.remove());
+				this.container
+					.querySelectorAll(".sva-vdr-batch-section")
+					.forEach((el) => el.remove());
 				this._batchInstances = {};
 				this.showLoading();
 				await this._renderBatchGroups();

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
@@ -199,6 +199,17 @@ const ViewportMixin = {
 	 * when set (used by the filter ribbon reset/apply flow).
 	 */
 	async reloadTable() {
+		// ── Batched mode: rebuild all batch sections from scratch ─────────────
+		if (this._isBatchGrouped && this._isBatchGrouped()) {
+			this.container.querySelectorAll(".sva-vdr-batch-section").forEach((el) => el.remove());
+			this._batchInstances = {};
+			this.showLoading();
+			await this._renderBatchGroups();
+			this.hideLoading();
+			return;
+		}
+
+		// ── Standard mode ────────────────────────────────────────────────────
 		// Stop in-progress observation
 		if (this._observer) {
 			this._observer.disconnect();
@@ -207,11 +218,15 @@ const ViewportMixin = {
 		this._sentinel = null;
 		this._loading_batch = false;
 
-		// Merge base filters with additional (applied by filter ribbon)
-		if (this.additional_list_filters && this.additional_list_filters.length) {
-			this.filters = [...(this._base_filters || []), ...this.additional_list_filters];
-		} else {
-			this.filters = [...(this._base_filters || [])];
+		// Restore filters: only touch them when setFilters() was previously called
+		// (signalled by _base_filters being set). Otherwise keep this.filters as-is
+		// so the original constructor filters are never wiped on a plain reload.
+		if (this._base_filters !== undefined) {
+			if (this.additional_list_filters && this.additional_list_filters.length) {
+				this.filters = [...this._base_filters, ...this.additional_list_filters];
+			} else {
+				this.filters = [...this._base_filters];
+			}
 		}
 
 		// Reset data state
@@ -226,6 +241,7 @@ const ViewportMixin = {
 
 		// Re-fetch and re-render first batch
 		await this.fetchDocs();
+		this._sortDataByOrderRules && this._sortDataByOrderRules();
 		this.render();
 		if (typeof this.resolveLinkTitles === "function") {
 			this.resolveLinkTitles();

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
@@ -204,6 +204,12 @@ const ViewportMixin = {
 	 * when set (used by the filter ribbon reset/apply flow).
 	 */
 	async reloadTable() {
+		// Sub-VDRs (batch children) hold stale inline docs — delegate to the parent
+		// so all batches are rebuilt with fresh server data.
+		if (this._is_sub_vdr && this._parent_vdr) {
+			return this._parent_vdr.reloadTable();
+		}
+
 		// Spin the reload button while reloading
 		const _icon = this._reloadBtn?.querySelector(".sva-vdr-reload-icon");
 		if (this._reloadBtn) this._reloadBtn.disabled = true;

--- a/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/mixins/viewport.js
@@ -193,6 +193,65 @@ const ViewportMixin = {
 	},
 
 	/**
+	 * Reload the entire table from scratch.
+	 * Called by the dashboard refresh button (frm.sva_ft_instances loop) or
+	 * after a filter change. Merges this.additional_list_filters into filters
+	 * when set (used by the filter ribbon reset/apply flow).
+	 */
+	async reloadTable() {
+		// Stop in-progress observation
+		if (this._observer) {
+			this._observer.disconnect();
+			this._observer = null;
+		}
+		this._sentinel = null;
+		this._loading_batch = false;
+
+		// Merge base filters with additional (applied by filter ribbon)
+		if (this.additional_list_filters && this.additional_list_filters.length) {
+			this.filters = [...(this._base_filters || []), ...this.additional_list_filters];
+		} else {
+			this.filters = [...(this._base_filters || [])];
+		}
+
+		// Reset data state
+		this.data = [];
+		this.docs = [];
+		this._rendered_count = 0;
+
+		// Clear rendered table
+		if (this.scrollBox) {
+			this.scrollBox.innerHTML = "";
+		}
+
+		// Re-fetch and re-render first batch
+		await this.fetchDocs();
+		this.render();
+		if (typeof this.resolveLinkTitles === "function") {
+			this.resolveLinkTitles();
+		}
+		this.setupViewportLoader();
+	},
+
+	/**
+	 * Apply a filter dict {fieldname: value} from the dashboard filter ribbon.
+	 * Stores additional filters and reloads the table.
+	 * Only meaningful when docs: null (paginated server-side mode).
+	 *
+	 * @param {Object} filters — {fieldname: value} dict
+	 */
+	setFilters(filters) {
+		if (!this._base_filters) {
+			// Snapshot the original filters on first call so resets work correctly
+			this._base_filters = [...(this.filters || [])];
+		}
+		this.additional_list_filters = Object.entries(filters || {})
+			.filter(([, val]) => val !== "" && val !== null && val !== undefined)
+			.map(([fn, val]) => [fn, "=", val]);
+		this.reloadTable();
+	},
+
+	/**
 	 * Append one document's column to the already-rendered table.
 	 * Called for each doc in a lazy-loaded batch.
 	 *

--- a/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
@@ -1,0 +1,143 @@
+import UISetupMixin from "./mixins/ui_setup.js";
+import DataMixin from "./mixins/data.js";
+import FieldsMixin from "./mixins/fields.js";
+import RenderingMixin from "./mixins/rendering.js";
+import EditMixin from "./mixins/edit.js";
+import HelpersMixin from "./mixins/helpers.js";
+
+/**
+ * SVAVerticalDocRenderer
+ * ──────────────────────────────────────────────────────────────────────────
+ * Renders multiple documents of a given DocType side-by-side as a comparison
+ * table — fields as rows, documents as columns, section breaks as styled
+ * header rows.
+ *
+ * Usage
+ * ─────
+ *   new SVAVerticalDocRenderer({
+ *     wrapper,              // HTMLElement — container
+ *     frm,                  // Frappe form object (optional, used for vdr_events)
+ *
+ *     doctype,              // string | object
+ *                           //   string  → DocType name; meta is fetched automatically
+ *                           //   object  → pre-built Frappe meta (e.g. frm.meta or frappe.get_meta result)
+ *                           //             doctype name is derived from meta.name
+ *
+ *     docs,                 // string[] — doc names to display as columns (left-to-right)
+ *
+ *     column_configs,       // [{label, bg_color, text_color}] — per-column header styling
+ *                           //   index-aligned to docs array
+ *
+ *     fields_to_show,       // string[] | null — explicit allowlist; null = show all
+ *     fields_to_hide,       // string[]        — fieldnames to exclude
+ *
+ *     show_section_headers, // boolean (default true)  — render Section/Tab Break labels
+ *     show_unit,            // boolean (default false) — show a "Unit" column parsed from field.description
+ *     hide_empty_rows,      // boolean (default false) — skip rows where all doc values are empty
+ *
+ *     title,                // string | null — heading shown above the table
+ *     show_legend,          // boolean (default false)
+ *     legend_items,         // [{label, bg_color, text_color, description}]
+ *
+ *     crud_permissions,     // string[] (default ["read"]) — include "write" to enable inline editing
+ *     signal,               // AbortSignal — clears the wrapper when aborted
+ *   });
+ *
+ * Events (vdr_events)
+ * ───────────────────
+ * Set frm.vdr_events to override rendering at any granularity:
+ *
+ *   frm.vdr_events = {
+ *     // Return non-null/undefined to replace default frappe.format() output
+ *     formatCell(value, df, doc, colIndex) {},
+ *
+ *     // Return true to signal that the tr was fully built (skip default cells)
+ *     renderRow(df, allDocsData, tr) {},
+ *
+ *     // Return true to signal the tr was built (skip default td)
+ *     renderSectionHeader(label, colCount, tr) {},
+ *
+ *     // Mutate the th element (no return value needed)
+ *     renderColumnHeader(doc, colIndex, th) {},
+ *
+ *     // Return false to cancel a save operation
+ *     beforeSave(df, docName, newValue) {},
+ *
+ *     afterSave(df, docName, newValue) {},
+ *
+ *     afterRender(instance) {},
+ *   };
+ */
+class SVAVerticalDocRenderer {
+	constructor({
+		wrapper,
+		frm,
+		doctype,
+		docs = [],
+		column_configs = [],
+		fields_to_show = null,
+		fields_to_hide = [],
+		show_section_headers = true,
+		show_unit = false,
+		hide_empty_rows = false,
+		title = null,
+		show_legend = false,
+		legend_items = [],
+		crud_permissions = ["read"],
+		signal = null,
+	}) {
+		// Branch on doctype type: string = name to fetch, object = pre-built meta
+		const isMetaObj = doctype && typeof doctype === "object";
+
+		Object.assign(this, {
+			wrapper,
+			frm,
+			doctype: isMetaObj ? doctype.name : doctype,
+			_meta_override: isMetaObj ? doctype : null,
+			docs,
+			column_configs,
+			fields_to_show,
+			fields_to_hide,
+			show_section_headers,
+			show_unit,
+			hide_empty_rows,
+			title,
+			show_legend,
+			legend_items,
+			crud_permissions,
+			signal,
+		});
+
+		// Pull vdr_events from the form if set; otherwise empty object
+		this.events = (frm && frm.vdr_events) || {};
+
+		this.meta = null;
+		this.data = [];
+
+		this._initialize();
+	}
+
+	async _initialize() {
+		this.setupWrapper();
+		this.setupAbortHandler();
+		this.showLoading();
+
+		await this.fetchMeta();
+		await this.fetchDocs();
+
+		this.hideLoading();
+		this.render();
+	}
+}
+
+Object.assign(
+	SVAVerticalDocRenderer.prototype,
+	UISetupMixin,
+	DataMixin,
+	FieldsMixin,
+	RenderingMixin,
+	EditMixin,
+	HelpersMixin
+);
+
+export default SVAVerticalDocRenderer;

--- a/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
@@ -4,6 +4,7 @@ import FieldsMixin from "./mixins/fields.js";
 import RenderingMixin from "./mixins/rendering.js";
 import EditMixin from "./mixins/edit.js";
 import HelpersMixin from "./mixins/helpers.js";
+import ViewportMixin from "./mixins/viewport.js";
 
 /**
  * SVAVerticalDocRenderer

--- a/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
@@ -6,6 +6,9 @@ import EditMixin from "./mixins/edit.js";
 import HelpersMixin from "./mixins/helpers.js";
 import ViewportMixin from "./mixins/viewport.js";
 import CreateMixin from "./mixins/create.js";
+import ValidationMixin from "./mixins/validation.js";
+import LinkTitlesMixin from "./mixins/link_titles.js";
+import DeleteMixin from "./mixins/delete.js";
 
 /**
  * SVAVerticalDocRenderer
@@ -45,13 +48,16 @@ import CreateMixin from "./mixins/create.js";
  *     legend_items,         // [{label, bg_color, text_color, description}]
  *
  *     crud_permissions,     // string[] (default ["read"])
- *                           //   "write"  → inline cell editing
+ *                           //   "write"  → inline cell auto-sync editing
  *                           //   "create" → "+" column header to create new docs
+ *                           //   "delete" → 🗑 icon row to delete doc columns
  *
  *     filters,              // frappe.db.get_list filter array — used when docs: null
  *     order_by,             // string — e.g. "creation desc" — used when docs: null
  *     column_batch_size,    // number (default 0 = auto from viewport width)
  *     column_width,         // number px (default 150) — used for auto batch-size calculation
+ *     max_height,           // number px (default 600) — scrollBox max-height for vertical sticky
+ *                           //   0 = no limit (header sticks to browser viewport via window scroll)
  *
  *     signal,               // AbortSignal — clears the wrapper when aborted
  *   });
@@ -92,6 +98,7 @@ class SVAVerticalDocRenderer {
 		order_by = null,
 		column_batch_size = 0,
 		column_width = 150,
+		max_height = 600,
 		signal = null,
 	}) {
 		// Branch on doctype type: string = name to fetch, object = pre-built/mimicked meta
@@ -115,10 +122,12 @@ class SVAVerticalDocRenderer {
 			legend_items,
 			crud_permissions,
 			allow_create: crud_permissions.includes("create"),
+			allow_delete: crud_permissions.includes("delete"),
 			filters,
 			order_by,
 			column_batch_size,
 			column_width,
+			max_height,
 			signal,
 		});
 
@@ -141,6 +150,10 @@ class SVAVerticalDocRenderer {
 
 		this.hideLoading();
 		this.render();              // renders first-batch columns
+
+		// Batch-fetch link display titles (non-blocking — updates cells asynchronously)
+		this.resolveLinkTitles();
+
 		this.setupViewportLoader(); // IntersectionObserver watches for scroll-right
 	}
 }
@@ -154,7 +167,10 @@ Object.assign(
 	EditMixin,
 	HelpersMixin,
 	ViewportMixin,
-	CreateMixin
+	CreateMixin,
+	ValidationMixin,
+	LinkTitlesMixin,
+	DeleteMixin
 );
 
 export default SVAVerticalDocRenderer;

--- a/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
@@ -5,6 +5,7 @@ import RenderingMixin from "./mixins/rendering.js";
 import EditMixin from "./mixins/edit.js";
 import HelpersMixin from "./mixins/helpers.js";
 import ViewportMixin from "./mixins/viewport.js";
+import CreateMixin from "./mixins/create.js";
 
 /**
  * SVAVerticalDocRenderer
@@ -21,10 +22,13 @@ import ViewportMixin from "./mixins/viewport.js";
  *
  *     doctype,              // string | object
  *                           //   string  → DocType name; meta is fetched automatically
- *                           //   object  → pre-built Frappe meta (e.g. frm.meta or frappe.get_meta result)
+ *                           //   object  → pre-built/mimicked meta {name, fields[]}
  *                           //             doctype name is derived from meta.name
  *
- *     docs,                 // string[] — doc names to display as columns (left-to-right)
+ *     docs,                 // string[] | object[] | null
+ *                           //   string[]  → doc names; data fetched in batches as user scrolls
+ *                           //   object[]  → inline data; zero API calls; lazy-loaded from memory
+ *                           //   null      → frappe.db.get_list with start+limit pagination
  *
  *     column_configs,       // [{label, bg_color, text_color}] — per-column header styling
  *                           //   index-aligned to docs array
@@ -40,7 +44,15 @@ import ViewportMixin from "./mixins/viewport.js";
  *     show_legend,          // boolean (default false)
  *     legend_items,         // [{label, bg_color, text_color, description}]
  *
- *     crud_permissions,     // string[] (default ["read"]) — include "write" to enable inline editing
+ *     crud_permissions,     // string[] (default ["read"])
+ *                           //   "write"  → inline cell editing
+ *                           //   "create" → "+" column header to create new docs
+ *
+ *     filters,              // frappe.db.get_list filter array — used when docs: null
+ *     order_by,             // string — e.g. "creation desc" — used when docs: null
+ *     column_batch_size,    // number (default 0 = auto from viewport width)
+ *     column_width,         // number px (default 150) — used for auto batch-size calculation
+ *
  *     signal,               // AbortSignal — clears the wrapper when aborted
  *   });
  *
@@ -49,23 +61,14 @@ import ViewportMixin from "./mixins/viewport.js";
  * Set frm.vdr_events to override rendering at any granularity:
  *
  *   frm.vdr_events = {
- *     // Return non-null/undefined to replace default frappe.format() output
- *     formatCell(value, df, doc, colIndex) {},
- *
- *     // Return true to signal that the tr was fully built (skip default cells)
- *     renderRow(df, allDocsData, tr) {},
- *
- *     // Return true to signal the tr was built (skip default td)
- *     renderSectionHeader(label, colCount, tr) {},
- *
- *     // Mutate the th element (no return value needed)
- *     renderColumnHeader(doc, colIndex, th) {},
- *
- *     // Return false to cancel a save operation
- *     beforeSave(df, docName, newValue) {},
- *
+ *     formatCell(value, df, doc, colIndex) {},      // return non-null to replace frappe.format() output
+ *     renderRow(df, allDocsData, tr) {},            // return true = custom row fully built
+ *     renderSectionHeader(label, colCount, tr) {},  // return true = custom header fully built
+ *     renderColumnHeader(doc, colIndex, th) {},     // mutate th directly
+ *     beforeSave(df, docName, newValue) {},         // return false to cancel save
  *     afterSave(df, docName, newValue) {},
- *
+ *     beforeCreate(values, dialog) {},              // return false to cancel create
+ *     afterCreate(newDoc) {},
  *     afterRender(instance) {},
  *   };
  */
@@ -74,7 +77,7 @@ class SVAVerticalDocRenderer {
 		wrapper,
 		frm,
 		doctype,
-		docs = [],
+		docs = null,
 		column_configs = [],
 		fields_to_show = null,
 		fields_to_hide = [],
@@ -85,9 +88,13 @@ class SVAVerticalDocRenderer {
 		show_legend = false,
 		legend_items = [],
 		crud_permissions = ["read"],
+		filters = [],
+		order_by = null,
+		column_batch_size = 0,
+		column_width = 150,
 		signal = null,
 	}) {
-		// Branch on doctype type: string = name to fetch, object = pre-built meta
+		// Branch on doctype type: string = name to fetch, object = pre-built/mimicked meta
 		const isMetaObj = doctype && typeof doctype === "object";
 
 		Object.assign(this, {
@@ -95,7 +102,8 @@ class SVAVerticalDocRenderer {
 			frm,
 			doctype: isMetaObj ? doctype.name : doctype,
 			_meta_override: isMetaObj ? doctype : null,
-			docs,
+			_docs_input: docs,   // raw input — data.js and viewport.js branch on this
+			docs: [],            // names of currently rendered columns (grows as batches load)
 			column_configs,
 			fields_to_show,
 			fields_to_hide,
@@ -106,6 +114,11 @@ class SVAVerticalDocRenderer {
 			show_legend,
 			legend_items,
 			crud_permissions,
+			allow_create: crud_permissions.includes("create"),
+			filters,
+			order_by,
+			column_batch_size,
+			column_width,
 			signal,
 		});
 
@@ -124,10 +137,11 @@ class SVAVerticalDocRenderer {
 		this.showLoading();
 
 		await this.fetchMeta();
-		await this.fetchDocs();
+		await this.fetchDocs();     // loads first batch only
 
 		this.hideLoading();
-		this.render();
+		this.render();              // renders first-batch columns
+		this.setupViewportLoader(); // IntersectionObserver watches for scroll-right
 	}
 }
 
@@ -138,7 +152,9 @@ Object.assign(
 	FieldsMixin,
 	RenderingMixin,
 	EditMixin,
-	HelpersMixin
+	HelpersMixin,
+	ViewportMixin,
+	CreateMixin
 );
 
 export default SVAVerticalDocRenderer;

--- a/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
@@ -107,6 +107,9 @@ class SVAVerticalDocRenderer {
 		//   { [fieldname|label]: { label, bg_color, text_color, collapsed, hidden } }
 		//   collapsed: true  → section starts collapsed; click header to toggle
 		//   hidden:    true  → entire section (header + fields) is not rendered
+		link_title_fields = {}, // { [LinkedDocType]: fieldname } — explicit display-field override
+		//   e.g. { "Block": "block_name", "District": "district_name" }
+		//   Takes priority over frappe.boot.link_title_doctypes and title_field meta
 	}) {
 		// Branch on doctype type: string = name to fetch, object = pre-built/mimicked meta
 		const isMetaObj = doctype && typeof doctype === "object";
@@ -139,6 +142,7 @@ class SVAVerticalDocRenderer {
 			vdr_field_name,
 			fields_config,
 			section_configs,
+			link_title_fields,
 			_initial_fields_config: fields_config ? [...fields_config] : null,
 			_has_user_settings: false,
 		});

--- a/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
@@ -102,6 +102,7 @@ class SVAVerticalDocRenderer {
 		order_by = null,
 		column_batch_size = 0,
 		column_width = 150,
+		label_width = 160,
 		max_height = 600,
 		signal = null,
 		vdr_field_name = null, // HTML field name hosting this VDR — enables server-side settings save
@@ -113,6 +114,9 @@ class SVAVerticalDocRenderer {
 		link_title_fields = {}, // { [LinkedDocType]: fieldname } — explicit display-field override
 		//   e.g. { "Block": "block_name", "District": "district_name" }
 		//   Takes priority over frappe.boot.link_title_doctypes and title_field meta
+		add_more_config = null, // batch config from vdr_batch_config property setter field
+		//   { allow_add_more_table, add_more_button_label, add_more_doctype,
+		//     grouping_field, plot_link_field, default_collapsed_new_table, batch_title_prefix }
 	}) {
 		// Branch on doctype type: string = name to fetch, object = pre-built/mimicked meta
 		const isMetaObj = doctype && typeof doctype === "object";
@@ -143,12 +147,14 @@ class SVAVerticalDocRenderer {
 			order_by,
 			column_batch_size,
 			column_width,
+			label_width,
 			max_height,
 			signal,
 			vdr_field_name,
 			fields_config,
 			section_configs,
 			link_title_fields,
+			add_more_config,
 			_initial_fields_config: fields_config ? [...fields_config] : null,
 			_has_user_settings: false,
 		});
@@ -173,6 +179,7 @@ class SVAVerticalDocRenderer {
 
 		this.hideLoading();
 		this.render(); // renders first-batch columns
+		this._renderAddMoreButton(); // append Add More button if batch config is present
 
 		// Batch-fetch link display titles (non-blocking — updates cells asynchronously)
 		this.resolveLinkTitles();

--- a/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
@@ -86,6 +86,9 @@ class SVAVerticalDocRenderer {
 		doctype,
 		docs = null,
 		column_configs = [],
+		column_label_field = null, // fieldname on source DocType to use as column header label
+		column_default_bg = null, // default bg_color for all columns (overridden by column_configs[i].bg_color)
+		column_default_text = null, // default text_color for all columns (overridden by column_configs[i].text_color)
 		fields_to_show = null,
 		fields_to_hide = [],
 		show_section_headers = true,
@@ -122,6 +125,9 @@ class SVAVerticalDocRenderer {
 			_docs_input: docs, // raw input — data.js and viewport.js branch on this
 			docs: [], // names of currently rendered columns (grows as batches load)
 			column_configs,
+			column_label_field,
+			column_default_bg,
+			column_default_text,
 			fields_to_show,
 			fields_to_hide,
 			show_section_headers,

--- a/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
@@ -9,6 +9,7 @@ import CreateMixin from "./mixins/create.js";
 import ValidationMixin from "./mixins/validation.js";
 import LinkTitlesMixin from "./mixins/link_titles.js";
 import DeleteMixin from "./mixins/delete.js";
+import RowSettingsMixin from "./mixins/row_settings.js";
 
 /**
  * SVAVerticalDocRenderer
@@ -100,6 +101,8 @@ class SVAVerticalDocRenderer {
 		column_width = 150,
 		max_height = 600,
 		signal = null,
+		vdr_field_name = null, // HTML field name hosting this VDR — enables server-side settings save
+		fields_config = null, // string[] of fieldnames in display order, or null for default
 	}) {
 		// Branch on doctype type: string = name to fetch, object = pre-built/mimicked meta
 		const isMetaObj = doctype && typeof doctype === "object";
@@ -109,8 +112,8 @@ class SVAVerticalDocRenderer {
 			frm,
 			doctype: isMetaObj ? doctype.name : doctype,
 			_meta_override: isMetaObj ? doctype : null,
-			_docs_input: docs,   // raw input — data.js and viewport.js branch on this
-			docs: [],            // names of currently rendered columns (grows as batches load)
+			_docs_input: docs, // raw input — data.js and viewport.js branch on this
+			docs: [], // names of currently rendered columns (grows as batches load)
 			column_configs,
 			fields_to_show,
 			fields_to_hide,
@@ -129,6 +132,10 @@ class SVAVerticalDocRenderer {
 			column_width,
 			max_height,
 			signal,
+			vdr_field_name,
+			fields_config,
+			_initial_fields_config: fields_config ? [...fields_config] : null,
+			_has_user_settings: false,
 		});
 
 		// Pull vdr_events from the form if set; otherwise empty object
@@ -146,10 +153,11 @@ class SVAVerticalDocRenderer {
 		this.showLoading();
 
 		await this.fetchMeta();
-		await this.fetchDocs();     // loads first batch only
+		await this._loadUserRowSettings(); // apply non-admin row settings override (if any)
+		await this.fetchDocs(); // loads first batch only
 
 		this.hideLoading();
-		this.render();              // renders first-batch columns
+		this.render(); // renders first-batch columns
 
 		// Batch-fetch link display titles (non-blocking — updates cells asynchronously)
 		this.resolveLinkTitles();
@@ -170,7 +178,9 @@ Object.assign(
 	CreateMixin,
 	ValidationMixin,
 	LinkTitlesMixin,
-	DeleteMixin
+	DeleteMixin,
+	RowSettingsMixin
 );
 
 export default SVAVerticalDocRenderer;
+frappe.ui.SVAVerticalDocRenderer = SVAVerticalDocRenderer;

--- a/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
@@ -10,6 +10,8 @@ import ValidationMixin from "./mixins/validation.js";
 import LinkTitlesMixin from "./mixins/link_titles.js";
 import DeleteMixin from "./mixins/delete.js";
 import RowSettingsMixin from "./mixins/row_settings.js";
+import AddMoreMixin from "./mixins/add_more.js";
+import BatchGroupMixin from "./mixins/batch_group.js";
 
 /**
  * SVAVerticalDocRenderer
@@ -89,6 +91,12 @@ class SVAVerticalDocRenderer {
 		column_label_field = null, // fieldname on source DocType to use as column header label
 		column_default_bg = null, // default bg_color for all columns (overridden by column_configs[i].bg_color)
 		column_default_text = null, // default text_color for all columns (overridden by column_configs[i].text_color)
+		column_color_rules = [], // [{key, bg_color, text_color, priority}] — key-based color matching
+		// key is matched (case-insensitive substring) against column header label
+		// highest priority wins when multiple keys match
+		column_order_rules = [], // [{key, order, priority}] — key-based column ordering
+		// order: numeric sort position (lower = rendered first)
+		// priority: higher wins when multiple keys match (default 0)
 		fields_to_show = null,
 		fields_to_hide = [],
 		show_section_headers = true,
@@ -103,6 +111,7 @@ class SVAVerticalDocRenderer {
 		column_batch_size = 0,
 		column_width = 150,
 		label_width = 160,
+		vdr_label_width = null, // alias for label_width (matches Custom Property Setter field name)
 		max_height = 600,
 		signal = null,
 		vdr_field_name = null, // HTML field name hosting this VDR — enables server-side settings save
@@ -114,6 +123,8 @@ class SVAVerticalDocRenderer {
 		link_title_fields = {}, // { [LinkedDocType]: fieldname } — explicit display-field override
 		//   e.g. { "Block": "block_name", "District": "district_name" }
 		//   Takes priority over frappe.boot.link_title_doctypes and title_field meta
+		table_max_rows = null, // null = unlimited rows per Table field; 1 = single-row mode (no listing dialog)
+		vdr_table_max_rows = null, // alias for table_max_rows (matches Custom Property Setter field name)
 		add_more_config = null, // batch config from vdr_batch_config property setter field
 		//   { allow_add_more_table, add_more_button_label, add_more_doctype,
 		//     grouping_field, plot_link_field, default_collapsed_new_table, batch_title_prefix }
@@ -132,6 +143,8 @@ class SVAVerticalDocRenderer {
 			column_label_field,
 			column_default_bg,
 			column_default_text,
+			column_color_rules,
+			column_order_rules,
 			fields_to_show,
 			fields_to_hide,
 			show_section_headers,
@@ -147,13 +160,14 @@ class SVAVerticalDocRenderer {
 			order_by,
 			column_batch_size,
 			column_width,
-			label_width,
+			label_width: vdr_label_width ? Number(vdr_label_width) : label_width,
 			max_height,
 			signal,
 			vdr_field_name,
 			fields_config,
 			section_configs,
 			link_title_fields,
+			table_max_rows: vdr_table_max_rows ? Number(vdr_table_max_rows) : table_max_rows,
 			add_more_config,
 			_initial_fields_config: fields_config ? [...fields_config] : null,
 			_has_user_settings: false,
@@ -165,7 +179,9 @@ class SVAVerticalDocRenderer {
 		this.meta = null;
 		this.data = [];
 
-		this._initialize();
+		// _ready resolves when _initialize() fully completes.
+		// Used by batch_group.js to await sub-VDR render before starting the next.
+		this._ready = this._initialize();
 	}
 
 	async _initialize() {
@@ -174,17 +190,23 @@ class SVAVerticalDocRenderer {
 		this.showLoading();
 
 		await this.fetchMeta();
-		await this._loadUserRowSettings(); // apply non-admin row settings override (if any)
-		await this.fetchDocs(); // loads first batch only
+		await this._loadUserRowSettings();
 
-		this.hideLoading();
-		this.render(); // renders first-batch columns
-		this._renderAddMoreButton(); // append Add More button if batch config is present
-
-		// Batch-fetch link display titles (non-blocking — updates cells asynchronously)
-		this.resolveLinkTitles();
-
-		this.setupViewportLoader(); // IntersectionObserver watches for scroll-right
+		if (this._isBatchGrouped && this._isBatchGrouped()) {
+			// ── Batched mode: one collapsible table per batch_no ──────────────
+			await this._renderBatchGroups();
+			this.hideLoading();
+			this._renderAddMoreButton();
+		} else {
+			// ── Standard mode ─────────────────────────────────────────────────
+			await this.fetchDocs();
+			this._sortDataByOrderRules();
+			this.hideLoading();
+			this.render();
+			this._renderAddMoreButton();
+			this.resolveLinkTitles();
+			this.setupViewportLoader();
+		}
 	}
 }
 
@@ -201,7 +223,9 @@ Object.assign(
 	ValidationMixin,
 	LinkTitlesMixin,
 	DeleteMixin,
-	RowSettingsMixin
+	RowSettingsMixin,
+	AddMoreMixin,
+	BatchGroupMixin
 );
 
 export default SVAVerticalDocRenderer;

--- a/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
@@ -128,6 +128,7 @@ class SVAVerticalDocRenderer {
 		add_more_config = null, // batch config from vdr_batch_config property setter field
 		//   { allow_add_more_table, add_more_button_label, add_more_doctype,
 		//     grouping_field, plot_link_field, default_collapsed_new_table, batch_title_prefix }
+		child_add_row_labels = null, // { [fieldname]: "Custom Label" } — per child-table "Add Row" label
 		_is_sub_vdr = false, // true when instantiated as a batch child — suppresses reload button
 	}) {
 		// Branch on doctype type: string = name to fetch, object = pre-built/mimicked meta
@@ -170,6 +171,7 @@ class SVAVerticalDocRenderer {
 			link_title_fields,
 			table_max_rows: vdr_table_max_rows ? Number(vdr_table_max_rows) : table_max_rows,
 			add_more_config,
+			child_add_row_labels,
 			_is_sub_vdr,
 			_initial_fields_config: fields_config ? [...fields_config] : null,
 			_has_user_settings: false,

--- a/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
@@ -103,6 +103,10 @@ class SVAVerticalDocRenderer {
 		signal = null,
 		vdr_field_name = null, // HTML field name hosting this VDR — enables server-side settings save
 		fields_config = null, // string[] of fieldnames in display order, or null for default
+		section_configs = {}, // object keyed by section fieldname or label:
+		//   { [fieldname|label]: { label, bg_color, text_color, collapsed, hidden } }
+		//   collapsed: true  → section starts collapsed; click header to toggle
+		//   hidden:    true  → entire section (header + fields) is not rendered
 	}) {
 		// Branch on doctype type: string = name to fetch, object = pre-built/mimicked meta
 		const isMetaObj = doctype && typeof doctype === "object";
@@ -134,6 +138,7 @@ class SVAVerticalDocRenderer {
 			signal,
 			vdr_field_name,
 			fields_config,
+			section_configs,
 			_initial_fields_config: fields_config ? [...fields_config] : null,
 			_has_user_settings: false,
 		});

--- a/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
@@ -130,6 +130,7 @@ class SVAVerticalDocRenderer {
 		//     grouping_field, plot_link_field, default_collapsed_new_table, batch_title_prefix }
 		child_add_row_labels = null, // { [fieldname]: "Custom Label" } — per child-table "Add Row" label
 		_is_sub_vdr = false, // true when instantiated as a batch child — suppresses reload button
+		_parent_vdr = null, // parent SVAVerticalDocRenderer instance (set by _addBatchSection)
 	}) {
 		// Branch on doctype type: string = name to fetch, object = pre-built/mimicked meta
 		const isMetaObj = doctype && typeof doctype === "object";
@@ -173,6 +174,7 @@ class SVAVerticalDocRenderer {
 			add_more_config,
 			child_add_row_labels,
 			_is_sub_vdr,
+			_parent_vdr,
 			_initial_fields_config: fields_config ? [...fields_config] : null,
 			_has_user_settings: false,
 		});

--- a/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
+++ b/frappe_theme/public/js/vertical_doc_renderer/sva_vertical_doc_renderer.bundle.js
@@ -128,6 +128,7 @@ class SVAVerticalDocRenderer {
 		add_more_config = null, // batch config from vdr_batch_config property setter field
 		//   { allow_add_more_table, add_more_button_label, add_more_doctype,
 		//     grouping_field, plot_link_field, default_collapsed_new_table, batch_title_prefix }
+		_is_sub_vdr = false, // true when instantiated as a batch child — suppresses reload button
 	}) {
 		// Branch on doctype type: string = name to fetch, object = pre-built/mimicked meta
 		const isMetaObj = doctype && typeof doctype === "object";
@@ -169,6 +170,7 @@ class SVAVerticalDocRenderer {
 			link_title_fields,
 			table_max_rows: vdr_table_max_rows ? Number(vdr_table_max_rows) : table_max_rows,
 			add_more_config,
+			_is_sub_vdr,
 			_initial_fields_config: fields_config ? [...fields_config] : null,
 			_has_user_settings: false,
 		});

--- a/frappe_theme/utils/data_protection.py
+++ b/frappe_theme/utils/data_protection.py
@@ -203,7 +203,10 @@ def mask_query_report(*args, **kwargs):
 		if not report_name:
 			return result
 
-		report = frappe.get_doc("Report", report_name)
+		# frappe.get_cached_doc avoids a fresh DB fetch on every single report
+		# run just to read ref_doctype — cache is invalidated automatically
+		# when the Report doc is saved.
+		report = frappe.get_cached_doc("Report", report_name)
 		doctype = report.ref_doctype
 		if not doctype:
 			return result
@@ -289,7 +292,7 @@ def mask_query_report_export_query():
 
 	# Step 3: Apply masking here
 	try:
-		report = frappe.get_doc("Report", report_name)
+		report = frappe.get_cached_doc("Report", report_name)
 		doctype = report.ref_doctype
 		if doctype:
 			meta = frappe.get_meta(doctype)

--- a/frappe_theme/utils/global_sanitizer.py
+++ b/frappe_theme/utils/global_sanitizer.py
@@ -43,10 +43,15 @@ def sanitize_all_fields(doc, method=None):
 	# doctype (this app's single doctype). Per-document flags are not used.
 	site_flag = bool(conf.get("sanitize_all_fields"))
 
-	# Read the single theme doctype `My Theme` if available (issingle = 1)
+	# Read the single theme doctype `My Theme` if available (issingle = 1).
+	# Uses the Redis-backed document cache (frappe.get_cached_doc) instead of a
+	# fresh DB query — this hook runs on every validate() of every doctype
+	# site-wide, so a plain frappe.db.get_single_value() here means one extra
+	# SQL query per document save, every time, even when the feature is off.
+	# get_cached_doc is invalidated automatically whenever "My Theme" is saved.
 	theme_flag = False
 	try:
-		theme = frappe.db.get_single_value("My Theme", "sanitize_all_fields")
+		theme = frappe.get_cached_doc("My Theme").get("sanitize_all_fields")
 		if theme:
 			theme_flag = bool(theme)
 	except Exception:

--- a/frappe_theme/utils/test_data_protection.py
+++ b/frappe_theme/utils/test_data_protection.py
@@ -1,0 +1,222 @@
+"""
+Unit tests for data_protection.py's caching fix.
+
+Covers: mask_query_report and mask_query_report_export_query must fetch the
+Report document via frappe.get_cached_doc() (Redis-backed, invalidated on
+save) instead of a fresh frappe.get_doc() on every single report run/export.
+
+To run in Frappe:
+    bench run-tests --module frappe_theme.utils.test_data_protection
+
+Or standalone (frappe/cryptography deps are the only real ones needed;
+this repo's own package __init__ chain is bypassed):
+    python -m unittest test_data_protection -v
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from cryptography.fernet import Fernet
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+MODULE_PATH = os.path.join(THIS_DIR, "data_protection.py")
+
+
+class _dict(dict):
+	"""Mirrors frappe._dict: a plain dict with attribute-style access."""
+
+	__getattr__ = dict.get
+	__setattr__ = dict.__setitem__
+
+
+def _field(fieldname, data_protection=None):
+	return SimpleNamespace(fieldname=fieldname, data_protection=data_protection)
+
+
+def _make_mock_frappe(encryption_key):
+	frappe = MagicMock()
+	# @frappe.whitelist() must be an identity decorator here — otherwise every
+	# decorated function in data_protection.py (nearly all of them) gets
+	# replaced by a MagicMock instead of the real implementation under test.
+	frappe.whitelist = lambda *a, **kw: (lambda fn: fn)
+	frappe._dict = _dict
+	frappe._ = lambda s: s
+	frappe.session = SimpleNamespace(user="tester@example.com")
+	frappe.get_roles.return_value = ["Some Role"]
+	frappe.conf = MagicMock()
+	frappe.conf.get = lambda k: encryption_key if k == "encryption_key" else None
+	frappe.log_error = MagicMock()
+
+	# frappe.desk.query_report / reportview submodules, for
+	# `from frappe.desk import query_report, reportview` at module top.
+	frappe.desk = MagicMock()
+	frappe.desk.query_report = MagicMock()
+	frappe.desk.reportview = MagicMock()
+
+	sys.modules["frappe.desk"] = frappe.desk
+	sys.modules["frappe.desk.query_report"] = frappe.desk.query_report
+	sys.modules["frappe.desk.reportview"] = frappe.desk.reportview
+
+	return frappe
+
+
+def _load_module(mock_frappe):
+	spec = importlib.util.spec_from_file_location("data_protection_under_test", MODULE_PATH)
+	module = importlib.util.module_from_spec(spec)
+	with patch.dict(sys.modules, {"frappe": mock_frappe}):
+		spec.loader.exec_module(module)
+	return module
+
+
+class TestMaskQueryReportCachingRegression(unittest.TestCase):
+	"""The actual bug: no fresh frappe.get_doc() fetch on every report run."""
+
+	def setUp(self):
+		self.key = Fernet.generate_key().decode()
+		self.mock_frappe = _make_mock_frappe(self.key)
+		self.module = _load_module(self.mock_frappe)
+
+		report_doc = SimpleNamespace(ref_doctype="Some Doctype")
+		self.mock_frappe.get_cached_doc.return_value = report_doc
+
+		meta = MagicMock()
+		meta.get_field = lambda fieldname: {
+			"secret": _field("secret", {"encrypt": True}),
+			"public": _field("public", None),
+		}.get(fieldname)
+		self.mock_frappe.get_meta.return_value = meta
+
+	def test_uses_get_cached_doc_not_get_doc(self):
+		self.mock_frappe.desk.query_report.run.return_value = {
+			"result": [],
+			"columns": [{"fieldname": "public"}],
+		}
+
+		self.module.mask_query_report("My Report")
+
+		self.mock_frappe.get_cached_doc.assert_called_once_with("Report", "My Report")
+		self.mock_frappe.get_doc.assert_not_called()
+
+	def test_decrypts_encrypted_field_in_result(self):
+		encrypted = self.module.encrypt_value("plain-secret")
+		self.assertTrue(self.module.is_encrypted(encrypted))
+
+		self.mock_frappe.desk.query_report.run.return_value = {
+			"result": [{"secret": encrypted, "public": "hello"}],
+			"columns": [{"fieldname": "secret"}, {"fieldname": "public"}],
+		}
+
+		result = self.module.mask_query_report("My Report")
+
+		self.assertEqual(result["result"][0]["secret"], "plain-secret")
+		self.assertEqual(result["result"][0]["public"], "hello")
+
+	def test_no_report_name_short_circuits_without_lookup(self):
+		self.mock_frappe.desk.query_report.run.return_value = {"result": [], "columns": []}
+
+		self.module.mask_query_report(report_name=None)
+
+		self.mock_frappe.get_cached_doc.assert_not_called()
+
+	def test_lookup_failure_is_caught_and_logged(self):
+		self.mock_frappe.get_cached_doc.side_effect = Exception("cache miss / DB down")
+		self.mock_frappe.desk.query_report.run.return_value = {
+			"result": [{"public": "hello"}],
+			"columns": [{"fieldname": "public"}],
+		}
+
+		result = self.module.mask_query_report("My Report")  # must not raise
+
+		self.mock_frappe.log_error.assert_called_once()
+		self.assertEqual(result["result"][0]["public"], "hello")
+
+
+class TestMaskQueryReportExportCachingRegression(unittest.TestCase):
+	"""Same fix, applied in the export path (mask_query_report_export_query)."""
+
+	def setUp(self):
+		self.key = Fernet.generate_key().decode()
+		self.mock_frappe = _make_mock_frappe(self.key)
+
+		# Dynamic imports inside mask_query_report_export_query:
+		#   from frappe.desk.query_report import build_xlsx_data, format_fields,
+		#       valid_report_name, clean_params, parse_json
+		#   from frappe.desk.utils import get_csv_bytes, pop_csv_params, provide_binary_file
+		#   from frappe.utils.xlsxutils import handle_html
+		qr = self.mock_frappe.desk.query_report
+		qr.build_xlsx_data = MagicMock(return_value=([], {}))
+		qr.format_fields = MagicMock()
+		qr.valid_report_name = MagicMock(return_value=True)
+		qr.clean_params = MagicMock()
+		qr.parse_json = MagicMock()
+
+		desk_utils = MagicMock()
+		desk_utils.get_csv_bytes = MagicMock(return_value=b"csv-bytes")
+		desk_utils.pop_csv_params = MagicMock(return_value={})
+		desk_utils.provide_binary_file = MagicMock()
+		sys.modules["frappe.desk.utils"] = desk_utils
+
+		xlsxutils = MagicMock()
+		xlsxutils.handle_html = lambda s: s
+		xlsxutils.make_xlsx = MagicMock()
+		sys.modules["frappe.utils.xlsxutils"] = xlsxutils
+
+		self.mock_frappe.permissions = MagicMock()
+		self.mock_frappe.get_cached_value.return_value = "Some Doctype"
+		self.mock_frappe.parse_json = lambda s: json.loads(s) if s else []
+
+		self.module = _load_module(self.mock_frappe)
+
+		report_doc = SimpleNamespace(ref_doctype="Some Doctype")
+		self.mock_frappe.get_cached_doc.return_value = report_doc
+
+		meta = MagicMock()
+		meta.get_field = lambda fieldname: {
+			"secret": _field("secret", {"encrypt": True}),
+		}.get(fieldname)
+		self.mock_frappe.get_meta.return_value = meta
+
+	def _form_params(self, result_rows, columns):
+		self.mock_frappe.local = SimpleNamespace(
+			form_dict={
+				"report_name": "My Report",
+				"file_format_type": "CSV",
+				"custom_columns": "[]",
+				"include_indentation": False,
+				"include_filters": False,
+				"visible_idx": [0],
+				"include_hidden_columns": False,
+				"filters": {},
+				"applied_filters": {},
+			}
+		)
+		self.mock_frappe.desk.query_report.run.return_value = {
+			"result": result_rows,
+			"columns": columns,
+		}
+
+	def test_uses_get_cached_doc_not_get_doc(self):
+		self._form_params(result_rows=[], columns=[{"fieldname": "secret"}])
+
+		self.module.mask_query_report_export_query()
+
+		self.mock_frappe.get_cached_doc.assert_called_once_with("Report", "My Report")
+		self.mock_frappe.get_doc.assert_not_called()
+
+	def test_decrypts_before_export(self):
+		encrypted = self.module.encrypt_value("plain-secret")
+		row = {"secret": encrypted}
+		self._form_params(result_rows=[row], columns=[{"fieldname": "secret"}])
+
+		self.module.mask_query_report_export_query()
+
+		self.assertEqual(row["secret"], "plain-secret")
+
+
+if __name__ == "__main__":
+	unittest.main(verbosity=2)

--- a/frappe_theme/utils/test_global_sanitizer.py
+++ b/frappe_theme/utils/test_global_sanitizer.py
@@ -1,0 +1,187 @@
+"""
+Unit tests for global_sanitizer.sanitize_all_fields.
+
+Covers the caching fix: the "My Theme" enabled/disabled flag must be read via
+frappe.get_cached_doc() (Redis-backed, invalidated on save) instead of a
+fresh frappe.db.get_single_value() query on every single document validate().
+
+To run in Frappe:
+    bench run-tests --module frappe_theme.utils.test_global_sanitizer
+
+Or standalone (frappe is mocked, no bench/site required):
+    python -m unittest test_global_sanitizer -v
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+MODULE_PATH = os.path.join(THIS_DIR, "global_sanitizer.py")
+
+
+class ValidationError(Exception):
+	pass
+
+
+def _make_mock_frappe(site_conf=None, theme_flag=False, meta_fields=None):
+	"""Build a mock `frappe` module.
+
+	theme_flag simulates the value stored on the "My Theme" singleton — this
+	is what frappe.get_cached_doc("My Theme").get("sanitize_all_fields")
+	should return. frappe.db.get_single_value is left as a bare MagicMock so
+	tests can assert it was never called (the whole point of the fix).
+	"""
+	frappe = MagicMock()
+	frappe.utils = None  # forces fallback to the deterministic html.escape path
+	frappe._ = lambda s: s
+	frappe.ValidationError = ValidationError
+
+	def _throw(msg, exc=Exception, **kwargs):
+		raise exc(msg)
+
+	frappe.throw = _throw
+	frappe.get_conf.return_value = site_conf or {}
+
+	theme_doc = MagicMock()
+	theme_doc.get = lambda key, default=None: (
+		theme_flag if key == "sanitize_all_fields" else default
+	)
+	frappe.get_cached_doc.return_value = theme_doc
+
+	meta = MagicMock()
+	meta.fields = meta_fields or []
+	frappe.get_meta.return_value = meta
+
+	frappe.log_error = MagicMock()
+	return frappe
+
+
+def _load_module(mock_frappe):
+	"""Load global_sanitizer.py directly by file path with `frappe` mocked in
+	sys.modules — bypasses frappe_theme/utils/__init__.py (and its real,
+	unrelated dependency chain) entirely, so this runs without a Frappe bench.
+	"""
+	spec = importlib.util.spec_from_file_location("global_sanitizer_under_test", MODULE_PATH)
+	module = importlib.util.module_from_spec(spec)
+	with patch.dict(sys.modules, {"frappe": mock_frappe}):
+		spec.loader.exec_module(module)
+	return module
+
+
+def _field(fieldname, fieldtype, label=None):
+	return SimpleNamespace(fieldname=fieldname, fieldtype=fieldtype, label=label)
+
+
+class TestCachingRegression(unittest.TestCase):
+	"""The actual bug this fix addresses: no direct DB query on every call."""
+
+	def test_uses_get_cached_doc_not_db_get_single_value(self):
+		mock_frappe = _make_mock_frappe(theme_flag=False)
+		module = _load_module(mock_frappe)
+
+		doc = SimpleNamespace(doctype="Some Doctype")
+		module.sanitize_all_fields(doc)
+
+		mock_frappe.get_cached_doc.assert_called_once_with("My Theme")
+		mock_frappe.db.get_single_value.assert_not_called()
+
+	def test_get_cached_doc_called_even_when_site_flag_already_enables_it(self):
+		# Regression guard: even if the site-config flag alone would enable
+		# sanitization, the function must still resolve theme_flag the same
+		# (cached) way rather than reintroducing a raw DB read anywhere.
+		mock_frappe = _make_mock_frappe(site_conf={"sanitize_all_fields": True}, theme_flag=False)
+		module = _load_module(mock_frappe)
+
+		doc = SimpleNamespace(doctype="Some Doctype", get=lambda f: None)
+		module.sanitize_all_fields(doc)
+
+		mock_frappe.db.get_single_value.assert_not_called()
+
+	def test_exception_reading_theme_falls_back_safely(self):
+		# get_cached_doc raising must not propagate — matches the original
+		# try/except-and-log behavior around the single-value read.
+		mock_frappe = _make_mock_frappe()
+		mock_frappe.get_cached_doc.side_effect = Exception("cache backend unavailable")
+		module = _load_module(mock_frappe)
+
+		doc = SimpleNamespace(doctype="Some Doctype")
+		module.sanitize_all_fields(doc)  # must not raise
+
+		mock_frappe.log_error.assert_called_once()
+
+
+class TestSanitizeBehavior(unittest.TestCase):
+	"""Functional behavior must be unchanged by the caching fix."""
+
+	def test_email_queue_is_always_skipped(self):
+		mock_frappe = _make_mock_frappe(theme_flag=True)
+		module = _load_module(mock_frappe)
+
+		doc = SimpleNamespace(doctype="Email Queue")
+		module.sanitize_all_fields(doc)
+
+		mock_frappe.get_cached_doc.assert_not_called()
+
+	def test_disabled_does_nothing(self):
+		mock_frappe = _make_mock_frappe(site_conf={}, theme_flag=False)
+		module = _load_module(mock_frappe)
+
+		doc = SimpleNamespace(
+			doctype="Some Doctype",
+			get=lambda f: "<script>alert(1)</script>",
+		)
+		module.sanitize_all_fields(doc)  # must not raise even with HTML present
+
+	def test_enabled_raises_on_html_in_plain_field(self):
+		mock_frappe = _make_mock_frappe(theme_flag=True)
+		module = _load_module(
+			_patch_meta(mock_frappe, [_field("title", "Data", "Title")])
+		)
+
+		doc = SimpleNamespace(
+			doctype="Some Doctype",
+			get=lambda f: "<b>bold</b>" if f == "title" else None,
+		)
+
+		with self.assertRaises(ValidationError):
+			module.sanitize_all_fields(doc)
+
+	def test_enabled_allows_clean_value(self):
+		mock_frappe = _make_mock_frappe(theme_flag=True)
+		mock_frappe = _patch_meta(mock_frappe, [_field("title", "Data", "Title")])
+		module = _load_module(mock_frappe)
+
+		doc = SimpleNamespace(
+			doctype="Some Doctype",
+			get=lambda f: "Plain text" if f == "title" else None,
+		)
+		module.sanitize_all_fields(doc)  # must not raise
+
+	def test_excluded_fieldtypes_are_never_checked(self):
+		mock_frappe = _make_mock_frappe(theme_flag=True)
+		mock_frappe = _patch_meta(
+			mock_frappe,
+			[_field("body", "Text Editor", "Body"), _field("attachment", "Attach", "File")],
+		)
+		module = _load_module(mock_frappe)
+
+		doc = SimpleNamespace(
+			doctype="Some Doctype",
+			get=lambda f: "<script>alert(1)</script>",
+		)
+		module.sanitize_all_fields(doc)  # excluded fieldtypes -> must not raise
+
+
+def _patch_meta(mock_frappe, fields):
+	meta = MagicMock()
+	meta.fields = fields
+	mock_frappe.get_meta.return_value = meta
+	return mock_frappe
+
+
+if __name__ == "__main__":
+	unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

This branch's accumulated work (SVAVerticalDocRenderer component, VDR table
fixes: responsiveness, filters, ordering, geolocation zoom, link dropdowns,
mobile view, batch config, etc. — see individual commits for detail).

Latest addition (this session): `sanitize_all_fields`, `mask_query_report`,
and `mask_query_report_export_query` were making an unconditional DB query
(`frappe.db.get_single_value` / `frappe.get_doc`) on every single document
validate and every report run/export, site-wide across all doctypes —
switched to `frappe.get_cached_doc()` (Redis-backed, invalidated on save)
to remove that per-call query. Added standalone unit tests
(`test_global_sanitizer.py`, `test_data_protection.py`) covering the fix
and existing sanitize/encrypt/decrypt/mask behavior — no bench/site
required to run them.

## Test plan
- [x] `python -m unittest test_global_sanitizer test_data_protection` — 14/14 passing
- [x] Verified both regression tests fail against the pre-fix code (reverted locally, confirmed 6 failures, restored)
- [ ] Review/test the rest of this branch's changes (VDR table, dashboard, etc.) — prior work, not covered by the above